### PR TITLE
docs: autogenerate type reference

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,11 @@ all: test manager
 .PHONY: check
 check: test lint ## Run tests and linters
 
+# Generate docs
+.PHONY: docs
+docs:
+	go run cmd/docs.go
+
 bin/golangci-lint: bin/golangci-lint-${GOLANGCI_VERSION}
 	@ln -sf golangci-lint-${GOLANGCI_VERSION} bin/golangci-lint
 bin/golangci-lint-${GOLANGCI_VERSION}:

--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -37,10 +37,6 @@ func crds() {
 		},
 		logger.WithName("lister"))
 
-	lister.IncludeSources = []string{
-		".*types",
-	}
-
 	lister.IgnoredSources = []string{
 		"null",
 		".*.deepcopy",
@@ -57,6 +53,7 @@ func crds() {
 		---
 		title: CRDs
 		weight: 1000
+		generated_file: true
 		---
 		
 		The following types are available. For details, click on the name of a type. 
@@ -73,7 +70,7 @@ func crds() {
 			return errors.WrapIff(err, "failed to determine relpath for %s", document.Item.DestPath)
 		}
 		lister.Index.Append(fmt.Sprintf("- **[%s](%s)** %s",
-			document.DisplayName,
+			document.Item.Name,
 			filepath.Join(relPath, document.Item.Name+".md"),
 			document.Desc))
 		return nil

--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -1,0 +1,85 @@
+// Copyright 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"emperror.dev/errors"
+	"github.com/MakeNowJust/heredoc"
+	"github.com/banzaicloud/operator-tools/pkg/docgen"
+	"github.com/banzaicloud/operator-tools/pkg/utils"
+)
+
+var logger = utils.Log
+
+func main() {
+	crds()
+}
+
+func crds() {
+	lister := docgen.NewSourceLister(
+		map[string]docgen.SourceDir{
+			"kafka": {Path: "pkg/sdk/v1beta1", DestPath: "docs/types"},
+		},
+		logger.WithName("lister"))
+
+	lister.IncludeSources = []string{
+		".*types",
+	}
+
+	lister.IgnoredSources = []string{
+		"null",
+		".*.deepcopy",
+		".*_test",
+		".*_info",
+	}
+
+	lister.Index = docgen.NewDoc(docgen.DocItem{
+		Name:     "_index",
+		DestPath: "docs/types",
+	}, logger.WithName("typedoc"))
+
+	lister.Header = heredoc.Doc(`
+		---
+		title: CRDs
+		weight: 1000
+		---
+		
+		The following types are available. For details, click on the name of a type. 
+		`,
+	)
+
+	lister.Footer = heredoc.Doc(`
+
+	`)
+
+	lister.DocGeneratedHook = func(document *docgen.Doc) error {
+		relPath, err := filepath.Rel(lister.Index.Item.DestPath, document.Item.DestPath)
+		if err != nil {
+			return errors.WrapIff(err, "failed to determine relpath for %s", document.Item.DestPath)
+		}
+		lister.Index.Append(fmt.Sprintf("- **[%s](%s)** %s",
+			document.DisplayName,
+			filepath.Join(relPath, document.Item.Name+".md"),
+			document.Desc))
+		return nil
+	}
+
+	if err := lister.Generate(); err != nil {
+		panic(err)
+	}
+}

--- a/config/samples/banzaicloud_v1beta1_kafkacluster.yaml
+++ b/config/samples/banzaicloud_v1beta1_kafkacluster.yaml
@@ -182,82 +182,82 @@ spec:
           # defaultIngressConfig describes which ingress configuration to use
           # when non set on the brokerIngressMapping field inside BrokerConfig
           defaultIngressConfig: "az2"
-            # ingressConfig bundles the two available ingress configuration envoy and istio ingress
-            ingressConfig:
-              # Ingress config name should be unique per external listener
-              ingress-az1:
-                # In case of external listeners using LoadBalancer access method the value of this field is used to advertise the
-                # Kafka broker external listener instead of the public IP of the provisioned LoadBalancer service (e.g. can be used to
-                # advertise the listener using a URL recorded in DNS instead of public IP).
-                # In case of external listeners using NodePort access method the broker instead of node public IP (see "brokerConfig.nodePortExternalIP")
-                # is advertised on the address having the following format: <kafka-cluster-name>-<broker-id>.<namespace><value-specified-in-hostnameOverride-field>
-                # hostnameOverride:
-                # ServiceAnnotations defines annotations which will
-                # be placed to the service or services created for the external listener
-                # serviceAnnotations:
-                # externalTrafficPolicy denotes if this Service desires to route external
-                # traffic to node-local or cluster-wide endpoints. "Local" preserves the
-                # client source IP and avoids a second hop for LoadBalancer and Nodeport
-                # type services, but risks potentially imbalanced traffic spreading.
-                # "Cluster" obscures the client source IP and may cause a second hop to
-                # another node, but should have good overall load-spreading.
-                # externalTrafficPolicy:
-                # Service Type string describes ingress methods for a service
-                # Only "NodePort" and "LoadBalancer" is supported.
-                # Default value is LoadBalancer
-                # serviceType:
-                # envoyConfig defines the envoy specific config used for ingress-az1 external listener
-                envoyConfig:
-                  #  replicas describes how many pods will be used for the created envoy proxy
-                  #  replicas: 1
-                  # image describes the Envoy docker image
-                  #  image: "banzaicloud/envoy:0.1.0"
-                  # resourceRequirements works exactly like Container resources, the user can specify the limit and the requests
-                  # through this property
-                  # resourceRequirements:
-                  #  limits:
-                  #    memory: "300Mi"
-                  #    cpu: "200m"
-                  #  requests:
-                  #    memory: "300Mi"
-                  #    cpu: "200m"
-                  # serviceAccountName specifies the serviceAccount used for envoy
-                  # serviceAccountName: "envoy"
-                  # imagePullSecrets specifies the secret to use when using private registry
-                  # imagePullSecrets: "k8ssecret"
-                  # nodeSelector can be specified, which set the pod to fit on a node
-                  # nodeSelector:
-                  # tolerations can be specified, which set the pod's tolerations
-                  # tolerations:
-                  # annotations can be used to place annotation to the envoy created loadbalancer
-                   annotations:
-                     az1
-                  # loadBalancerSourceRanges refers to the k8s resource used in loadbalancer type services
-                  # loadBalancerSourceRanges:
-              ingress-az1-istio:
-                istioIngressConfig:
-                  # annotations can be used to place annotation to the envoy created loadbalancer
-                  annotations:
-                    istio-az1
-                  # resourceRequirements works exactly like Container resources, the user can specify the limit and the requests
-                  # through this property
-                  # resourceRequirements:
-                  #  limits:
-                  #    memory: "300Mi"
-                  #    cpu: "200m"
-                  #  requests:
-                  #    memory: "300Mi"
-                  #    cpu: "200m"
-                  #  replicas describes how many pods will be used for the created envoy proxy
-                  #  replicas: 1
-                  # nodeSelector can be specified, which set the pod to fit on a node
-                  # nodeSelector:
-                  # tolerations can be specified, which set the pod's tolerations
-                  # tolerations:
-                  # allows to set the created gateway configuration
-                  # gatewayConfig:
-                  # annotations will be placed on the created virtual service
-                  # virtualServiceAnnotations:
+          # ingressConfig bundles the two available ingress configuration envoy and istio ingress
+          ingressConfig:
+            # Ingress config name should be unique per external listener
+            ingress-az1:
+              # In case of external listeners using LoadBalancer access method the value of this field is used to advertise the
+              # Kafka broker external listener instead of the public IP of the provisioned LoadBalancer service (e.g. can be used to
+              # advertise the listener using a URL recorded in DNS instead of public IP).
+              # In case of external listeners using NodePort access method the broker instead of node public IP (see "brokerConfig.nodePortExternalIP")
+              # is advertised on the address having the following format: <kafka-cluster-name>-<broker-id>.<namespace><value-specified-in-hostnameOverride-field>
+              # hostnameOverride:
+              # ServiceAnnotations defines annotations which will
+              # be placed to the service or services created for the external listener
+              # serviceAnnotations:
+              # externalTrafficPolicy denotes if this Service desires to route external
+              # traffic to node-local or cluster-wide endpoints. "Local" preserves the
+              # client source IP and avoids a second hop for LoadBalancer and Nodeport
+              # type services, but risks potentially imbalanced traffic spreading.
+              # "Cluster" obscures the client source IP and may cause a second hop to
+              # another node, but should have good overall load-spreading.
+              # externalTrafficPolicy:
+              # Service Type string describes ingress methods for a service
+              # Only "NodePort" and "LoadBalancer" is supported.
+              # Default value is LoadBalancer
+              # serviceType:
+              # envoyConfig defines the envoy specific config used for ingress-az1 external listener
+              envoyConfig:
+                #  replicas describes how many pods will be used for the created envoy proxy
+                #  replicas: 1
+                # image describes the Envoy docker image
+                #  image: "banzaicloud/envoy:0.1.0"
+                # resourceRequirements works exactly like Container resources, the user can specify the limit and the requests
+                # through this property
+                # resourceRequirements:
+                #  limits:
+                #    memory: "300Mi"
+                #    cpu: "200m"
+                #  requests:
+                #    memory: "300Mi"
+                #    cpu: "200m"
+                # serviceAccountName specifies the serviceAccount used for envoy
+                # serviceAccountName: "envoy"
+                # imagePullSecrets specifies the secret to use when using private registry
+                # imagePullSecrets: "k8ssecret"
+                # nodeSelector can be specified, which set the pod to fit on a node
+                # nodeSelector:
+                # tolerations can be specified, which set the pod's tolerations
+                # tolerations:
+                # annotations can be used to place annotation to the envoy created loadbalancer
+                 annotations:
+                   az1
+                # loadBalancerSourceRanges refers to the k8s resource used in loadbalancer type services
+                # loadBalancerSourceRanges:
+            ingress-az1-istio:
+              istioIngressConfig:
+                # annotations can be used to place annotation to the envoy created loadbalancer
+                annotations:
+                  istio-az1
+                # resourceRequirements works exactly like Container resources, the user can specify the limit and the requests
+                # through this property
+                # resourceRequirements:
+                #  limits:
+                #    memory: "300Mi"
+                #    cpu: "200m"
+                #  requests:
+                #    memory: "300Mi"
+                #    cpu: "200m"
+                #  replicas describes how many pods will be used for the created envoy proxy
+                #  replicas: 1
+                # nodeSelector can be specified, which set the pod to fit on a node
+                # nodeSelector:
+                # tolerations can be specified, which set the pod's tolerations
+                # tolerations:
+                # allows to set the created gateway configuration
+                # gatewayConfig:
+                # annotations will be placed on the created virtual service
+                # virtualServiceAnnotations:
     # internalListeners specifies settings required to access kafka externally
     internalListeners:
       # type defines the used security type ssl, plaintext, sasl_plaintext, sasl_ssl

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	emperror.dev/errors v0.8.0
+	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/Shopify/sarama v1.28.0
 	github.com/banzaicloud/bank-vaults/pkg/sdk v0.3.1
 	github.com/banzaicloud/istio-client-go v0.0.9
@@ -11,6 +12,7 @@ require (
 	github.com/banzaicloud/k8s-objectmatcher v1.4.1
 	github.com/banzaicloud/kafka-operator/api v0.0.0
 	github.com/banzaicloud/kafka-operator/properties v0.0.0
+	github.com/banzaicloud/operator-tools v0.21.2-0.20210507080305-7345f6176c6c
 	github.com/envoyproxy/go-control-plane v0.9.7
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-logr/logr v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/DataDog/zstd v1.4.4/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t
 github.com/Jeffail/gabs v1.1.1 h1:V0uzR08Hj22EX8+8QMhyI9sX2hwRu+/RJhJUmnwda/E=
 github.com/Jeffail/gabs v1.1.1/go.mod h1:6xMvQMK4k33lb7GUUpaAPh6nKMmemQeg5d4gn7/bOXc=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
+github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
+github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/semver v1.4.2 h1:WBLTQ37jOCzSLtXNdoo8bNM8876KhNqOKvrlGITgsTc=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
@@ -150,6 +152,10 @@ github.com/banzaicloud/istio-operator v0.0.0-20210302164221-8883bb9ed9bf/go.mod 
 github.com/banzaicloud/k8s-objectmatcher v1.4.0/go.mod h1:j+N22VwgVfa0ajVtNxOz2G72aSOL21lpB7qV2GDrr/I=
 github.com/banzaicloud/k8s-objectmatcher v1.4.1 h1:/HaUqQzTa5E+pLqG9qelRKUdrzU1Nl2BYPHDut7e1oU=
 github.com/banzaicloud/k8s-objectmatcher v1.4.1/go.mod h1:j+N22VwgVfa0ajVtNxOz2G72aSOL21lpB7qV2GDrr/I=
+github.com/banzaicloud/operator-tools v0.21.1 h1:EHgUFmrrXr2g4+LSS6Zeo82KBdOxiUzH68fFbR7pRHE=
+github.com/banzaicloud/operator-tools v0.21.1/go.mod h1:rbGr9Ud1uQs9KDWDWe6r/gLQdrr1wtBtTP9uo9Aw5Ss=
+github.com/banzaicloud/operator-tools v0.21.2-0.20210507080305-7345f6176c6c h1:kKdsRenHLWst6Ol4u+b1g9Xck/SEibtRLcpPopINRv4=
+github.com/banzaicloud/operator-tools v0.21.2-0.20210507080305-7345f6176c6c/go.mod h1:PHM11b9i4wNIpzLLDyI/dgzdfGEIRiKdUL7ltD+LkBs=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/pkg/sdk/v1beta1/common_types.go
+++ b/pkg/sdk/v1beta1/common_types.go
@@ -16,6 +16,10 @@ package v1beta1
 
 import "strings"
 
+// +name:"Common types"
+// +weight:"200"
+type _hugoCommonTypes interface{}
+
 // RackAwarenessState stores info about rack awareness status
 type RackAwarenessState string
 

--- a/pkg/sdk/v1beta1/kafkacluster_types.go
+++ b/pkg/sdk/v1beta1/kafkacluster_types.go
@@ -140,16 +140,18 @@ type BrokerConfig struct {
 	BrokerAnnotations map[string]string `json:"brokerAnnotations,omitempty"`
 	// Network throughput information in kB/s used by Cruise Control to determine broker network capacity.
 	// By default it is set to `125000` which means 1Gbit/s in network throughput.
+	// (default: 125000)
 	NetworkConfig *NetworkConfig `json:"networkConfig,omitempty"`
 	// External listeners that use NodePort type service to expose the broker outside the Kubernetes clusterT and their
 	// external IP to advertise Kafka broker external listener. The external IP value is ignored in case of external listeners that use LoadBalancer
 	// type service to expose the broker outside the Kubernetes cluster. Also, when "hostnameOverride" field of the external listener is set
 	// it will override the broker's external listener advertise address according to the description of the "hostnameOverride" field.
 	NodePortExternalIP map[string]string `json:"nodePortExternalIP,omitempty"`
-	// Any definition received through this field will override the default behaviour of OneBrokerPerNode flag
+	// Any definition received through this field will override the default behavior of OneBrokerPerNode flag
 	// and the operator supposes that the user is aware of how scheduling is done by kubernetes
 	// Affinity could be set through brokerConfigGroups definitions and can be set for individual brokers as well
 	// where letter setting will override the group setting
+	// (default: OneBrokerPerNode)
 	Affinity           *corev1.Affinity           `json:"affinity,omitempty"`
 	PodSecurityContext *corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
 	// SecurityContext allows to set security context for the kafka container
@@ -374,7 +376,7 @@ type IngressServiceSettings struct {
 	ExternalTrafficPolicy corev1.ServiceExternalTrafficPolicyType `json:"externalTrafficPolicy,omitempty"`
 	// Service Type string describes ingress methods for a service
 	// Only "NodePort" and "LoadBalancer" is supported.
-	// Default value is LoadBalancer
+	// (default: LoadBalancer)
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 }
 
@@ -390,6 +392,7 @@ type ExternalListenerConfig struct {
 	// Two types are supported LoadBalancer and NodePort.
 	// The recommended and default is the LoadBalancer.
 	// NodePort should be used in Kubernetes environments with no support for provisioning Load Balancers.
+	// (default: LoadBalancer)
 	// +optional
 	AccessMethod corev1.ServiceType `json:"accessMethod,omitempty"`
 	// Config allows to specify ingress controller configuration per external listener

--- a/pkg/sdk/v1beta1/kafkacluster_types.go
+++ b/pkg/sdk/v1beta1/kafkacluster_types.go
@@ -40,6 +40,10 @@ const (
 	DefaultEnvoyAdminPort = 9901
 )
 
+// +name:"KafkaClusterSpec"
+// +weight:"200"
+type _hugoKafkaClusterSpec interface{}
+
 // KafkaClusterSpec defines the desired state of KafkaCluster
 type KafkaClusterSpec struct {
 	HeadlessServiceEnabled bool            `json:"headlessServiceEnabled"`


### PR DESCRIPTION
Adds operator-tools to generate reference docs automatically from pkg/sdk/v1beta1/kafkacluster_types.go
Also adds some additional code comments that will be rendered into the docs to pkg/sdk/v1beta1/kafkacluster_types.go 
Loosely depends on https://github.com/banzaicloud/kafka-operator-docs/pull/34