### PR TITLE
Update downScale to allow broker ID based auto-scaling

### DIFF
--- a/internal/alertmanager/currentalert/process.go
+++ b/internal/alertmanager/currentalert/process.go
@@ -308,6 +308,7 @@ func downScale(log logr.Logger, labels model.LabelSet, client client.Client) err
 
 		return nil
 	}
+
 	var brokerId string
 	if broker, ok := labels["broker_id"]; ok {
 		brokerId = string(broker)

--- a/internal/alertmanager/currentalert/process_test.go
+++ b/internal/alertmanager/currentalert/process_test.go
@@ -17,6 +17,8 @@ package currentalert
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/onsi/gomega"
 	"github.com/prometheus/common/model"
 	corev1 "k8s.io/api/core/v1"
@@ -25,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"testing"
 
 	//nolint:staticcheck
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -606,7 +607,7 @@ func Test_downScale(t *testing.T) {
 		expectedBrokers []v1beta1.Broker
 	}{
 		{
-			testName: "downscale with config group",
+			testName: "downscale with broker id",
 			kafkaCluster: v1beta1.KafkaCluster{
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "test-cluster",


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no |
| New feature?    | yes |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | https://github.com/banzaicloud/koperator/issues/637 |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Add support to use broker Id from the labels (if available) from the alert to select broker for removal instead of always choosing the broker with the least number of partitions

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
Relevant Cruise Control logs for removing a broker with id `3` (based on my Prometheus rule configuration) through downScale in local testing:
```
kubectl logs kafka-cruisecontrol-5bdbdcd6b-cckbl kafka-cruisecontrol -n kafka | grep "remov
e_broker"
[2021-08-25 18:22:46,108] INFO Create a new UserTask 8127f16d-619c-4742-af26-39b0a386a631 with SessionKey SessionKey{_httpSession=Session@5bca85b2{id=node01xmls7vk056pr5z11m31yp0zd20,x=node01xmls7vk056pr5z11m31yp0zd20.node0,req=1,res=true},_requestUrl=POST /kafkacruisecontrol/remove_broker,_queryParams={brokerid=[3], dryrun=[false], json=[true]}} (com.linkedin.kafka.cruisecontrol.servlet.UserTaskManager)
[2021-08-25 18:22:47,806] INFO Computation is completed for async request: /remove_broker. (com.linkedin.kafka.cruisecontrol.servlet.handler.async.AbstractAsyncRequest)
{"userTasks":[{"Status":"InExecution","UserTaskId":"8127f16d-619c-4742-af26-39b0a386a631","StartMs":"1629915766108","ClientIdentity":"127.0.0.6","RequestURL":"POST /kafkacruisecontrol/remove_broker?json\u003dtrue\u0026brokerid\u003d3\u0026dryrun\u003dfalse"}],"version":1} (operationLogger)
{"userTasks":[{"Status":"InExecution","UserTaskId":"8127f16d-619c-4742-af26-39b0a386a631","StartMs":"1629915766108","ClientIdentity":"127.0.0.6","RequestURL":"POST /kafkacruisecontrol/remove_broker?json\u003dtrue\u0026brokerid\u003d3\u0026dryrun\u003dfalse"}],"version":1} (operationLogger)
{"userTasks":[{"Status":"InExecution","UserTaskId":"8127f16d-619c-4742-af26-39b0a386a631","StartMs":"1629915766108","ClientIdentity":"127.0.0.6","RequestURL":"POST /kafkacruisecontrol/remove_broker?json\u003dtrue\u0026brokerid\u003d3\u0026dryrun\u003dfalse"}],"version":1} (operationLogger)
[2021-08-25 18:23:49,312] INFO Expiring the session associated with SessionKey{_httpSession=Session@5bca85b2{id=node01xmls7vk056pr5z11m31yp0zd20,x=node01xmls7vk056pr5z11m31yp0zd20.node0,req=0,res=true},_requestUrl=POST /kafkacruisecontrol/remove_broker,_queryParams={brokerid=[3], dryrun=[false], json=[true]}}. (com.linkedin.kafka.cruisecontrol.servlet.UserTaskManager)
{"userTasks":[{"Status":"InExecution","UserTaskId":"8127f16d-619c-4742-af26-39b0a386a631","StartMs":"1629915766108","ClientIdentity":"127.0.0.6","RequestURL":"POST /kafkacruisecontrol/remove_broker?json\u003dtrue\u0026brokerid\u003d3\u0026dryrun\u003dfalse"}],"version":1} (operationLogger)
[2021-08-25 18:24:08,612] INFO Task [8127f16d-619c-4742-af26-39b0a386a631] userPOST /kafkacruisecontrol/remove_broker execution is finished. (operationLogger)
{"userTasks":[{"Status":"InExecution","UserTaskId":"8127f16d-619c-4742-af26-39b0a386a631","StartMs":"1629915766108","ClientIdentity":"127.0.0.6","RequestURL":"POST /kafkacruisecontrol/remove_broker?json\u003dtrue\u0026brokerid\u003d3\u0026dryrun\u003dfalse"}],"version":1} (operationLogger)
{"userTasks":[{"Status":"Completed","UserTaskId":"8127f16d-619c-4742-af26-39b0a386a631","StartMs":"1629915766108","ClientIdentity":"127.0.0.6","RequestURL":"POST /kafkacruisecontrol/remove_broker?json\u003dtrue\u0026brokerid\u003d3\u0026dryrun\u003dfalse"}],"version":1} (operationLogger)
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
