### PR TITLE
Fixing failed to list *v1.CertificateSigningRequest errors

### DIFF
--- a/charts/kafka-operator/templates/operator-rbac.yaml
+++ b/charts/kafka-operator/templates/operator-rbac.yaml
@@ -205,9 +205,9 @@ rules:
   - update
   - watch
 - apiGroups:
-  - certificates
+  - certificates.k8s.io
   resources:
-  - certificatesigningrequest
+  - certificatesigningrequests
   verbs:
   - create
   - delete

--- a/config/base/rbac/role.yaml
+++ b/config/base/rbac/role.yaml
@@ -138,9 +138,9 @@ rules:
   - update
   - watch
 - apiGroups:
-  - certificates
+  - certificates.k8s.io
   resources:
-  - certificatesigningrequest
+  - certificatesigningrequests
   verbs:
   - create
   - delete

--- a/controllers/kafkauser_controller.go
+++ b/controllers/kafkauser_controller.go
@@ -124,7 +124,7 @@ type KafkaUserReconciler struct {
 // +kubebuilder:rbac:groups=cert-manager.io,resources=certificates,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cert-manager.io,resources=issuers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cert-manager.io,resources=clusterissuers,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=certificates,resources=certificatesigningrequest,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=certificates.k8s.io,resources=certificatesigningrequests,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile reads that state of the cluster for a KafkaUser object and makes changes based on the state read
 // and what is in the KafkaUser.Spec


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | fixes #651 |
| License         | Apache 2.0 |

### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Fix the permission entry in the CRBs so that the operator could list `certificatesigningrequests`.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Otherwise the operator won't start due to missing permissions to list them.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
See #651 and #656

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline