### PR TITLE
Fixing brokerid label used in autoscaling

### DIFF
--- a/internal/alertmanager/currentalert/process.go
+++ b/internal/alertmanager/currentalert/process.go
@@ -310,7 +310,7 @@ func downScale(log logr.Logger, labels model.LabelSet, client client.Client) err
 	}
 
 	var brokerId string
-	if broker, ok := labels["broker_id"]; ok {
+	if broker, ok := labels["brokerId"]; ok {
 		brokerId = string(broker)
 	} else {
 		cc := scale.NewCruiseControlScaler(string(labels["namespace"]), cr.Spec.GetKubernetesClusterDomain(), cr.Spec.CruiseControlConfig.CruiseControlEndpoint, cr.Name)

--- a/internal/alertmanager/currentalert/process_test.go
+++ b/internal/alertmanager/currentalert/process_test.go
@@ -641,7 +641,7 @@ func Test_downScale(t *testing.T) {
 					"namespace":  "test-namespace",
 					"severity":   "critical",
 					"alertGroup": "test",
-					"broker_id":  "1",
+					"brokerId":   "1",
 				},
 				Annotations: map[model.LabelName]model.LabelValue{
 					"command":           "downscale",


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | fixes #628, caused by #637  |
| License         | Apache 2.0 |

### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Changed the label used by triggering autoscaler from `broker_id` to `brokerId` as the Prometheus metrics has the latter.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Without this, the operator will always use the id the broker of which has the least number of partitions.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
See #628 for discussion, and #637 for the original implementation which introduced this label.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline