### PR TITLE
Disable native cert-signing support for KafkaUser when access is not allowed

### DIFF
--- a/charts/kafka-operator/templates/operator-deployment-with-webhook.yaml
+++ b/charts/kafka-operator/templates/operator-deployment-with-webhook.yaml
@@ -150,6 +150,9 @@ spec:
             - --enable-leader-election
             - --cert-manager-namespace={{ .Values.certManager.namespace }}
             - --cert-manager-enabled={{ .Values.certManager.enabled }}
+          {{- if not .Values.certSigning.enabled }}
+            - --disable-cert-signing-support
+          {{- end }}
           {{- if not .Values.webhook.enabled }}
             - --disable-webhooks
           {{- end }}

--- a/charts/kafka-operator/values.yaml
+++ b/charts/kafka-operator/values.yaml
@@ -42,6 +42,9 @@ certManager:
   namespace: "cert-manager"
   enabled: false
 
+certSigning:
+  enabled: true
+
 alertManager:
   enable: true
 

--- a/controllers/kafkauser_controller.go
+++ b/controllers/kafkauser_controller.go
@@ -55,14 +55,15 @@ import (
 var userFinalizer = "finalizer.kafkausers.kafka.banzaicloud.io"
 
 // SetupKafkaUserWithManager registers KafkaUser controller to the manager
-func SetupKafkaUserWithManager(mgr ctrl.Manager, certManagerNamespace bool, log logr.Logger) *ctrl.Builder {
+func SetupKafkaUserWithManager(mgr ctrl.Manager, certSigningEnabled bool, certManagerNamespace bool, log logr.Logger) *ctrl.Builder {
 	builder := ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.KafkaUser{}).Named("KafkaUser")
-	builder.Watches(
-		&source.Kind{Type: &certsigningreqv1.CertificateSigningRequest{}},
-		handler.EnqueueRequestsFromMapFunc(certificateSigningRequestMapper),
-		ctrlBuilder.WithPredicates(certificateSigningRequestFilter(log)))
-
+	if certSigningEnabled {
+		builder.Watches(
+			&source.Kind{Type: &certsigningreqv1.CertificateSigningRequest{}},
+			handler.EnqueueRequestsFromMapFunc(certificateSigningRequestMapper),
+			ctrlBuilder.WithPredicates(certificateSigningRequestFilter(log)))
+	}
 	if certManagerNamespace {
 		builder.Owns(&certv1.Certificate{})
 	}

--- a/controllers/tests/suite_test.go
+++ b/controllers/tests/suite_test.go
@@ -169,7 +169,7 @@ var _ = BeforeSuite(func() {
 		Log:    ctrl.Log.WithName("controllers").WithName("KafkaUser"),
 	}
 
-	err = controllers.SetupKafkaUserWithManager(mgr, true, kafkaUserReconciler.Log).Complete(&kafkaUserReconciler)
+	err = controllers.SetupKafkaUserWithManager(mgr, true, true, kafkaUserReconciler.Log).Complete(&kafkaUserReconciler)
 	Expect(err).NotTo(HaveOccurred())
 
 	kafkaClusterCCReconciler := controllers.CruiseControlTaskReconciler{

--- a/main.go
+++ b/main.go
@@ -82,6 +82,7 @@ func main() {
 		webhookDisabled                   bool
 		developmentLogging                bool
 		verboseLogging                    bool
+		certSigningDisabled               bool
 		certManagerEnabled                bool
 		maxKafkaTopicConcurrentReconciles int
 	)
@@ -95,6 +96,7 @@ func main() {
 	flag.BoolVar(&developmentLogging, "development", false, "Enable development logging")
 	flag.BoolVar(&verboseLogging, "verbose", false, "Enable verbose logging")
 	flag.BoolVar(&certManagerEnabled, "cert-manager-enabled", false, "Enable cert-manager integration")
+	flag.BoolVar(&certSigningDisabled, "disable-cert-signing-support", false, "Disable native certificate signing integration")
 	flag.IntVar(&maxKafkaTopicConcurrentReconciles, "max-kafka-topic-concurrent-reconciles", 10, "Define max amount of concurrent KafkaTopic reconciles")
 	flag.Parse()
 
@@ -164,7 +166,7 @@ func main() {
 		Log:    ctrl.Log.WithName("controllers").WithName("KafkaUser"),
 	}
 
-	if err = controllers.SetupKafkaUserWithManager(mgr, certManagerEnabled, kafkaUserReconciler.Log).Complete(kafkaUserReconciler); err != nil {
+	if err = controllers.SetupKafkaUserWithManager(mgr, !certSigningDisabled, certManagerEnabled, kafkaUserReconciler.Log).Complete(kafkaUserReconciler); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KafkaUser")
 		os.Exit(1)
 	}


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no |
| New feature?    | yes |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | fixes #666 |
| License         | Apache 2.0 |


### What's in this PR?

Probe permissions to CertificateSigningRequest custom resources in cluster and if permission is defined disable KafkaUser CSR support

### Why?

This is useful in environments where certsigningrequests resources
cannot be watched due to RBAC restrictions


### Additional context
N/A

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)

