### PR TITLE
Handle Shutdown pods. Update alertmanager port name

### DIFF
--- a/charts/kafka-operator/templates/alertmanager-service.yaml
+++ b/charts/kafka-operator/templates/alertmanager-service.yaml
@@ -24,6 +24,6 @@ spec:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: operator
   ports:
-  - name: alerts
+  - name: http-alerts
     port: 9001
 {{- end -}}

--- a/pkg/k8sutil/resource.go
+++ b/pkg/k8sutil/resource.go
@@ -204,6 +204,14 @@ func IsPodContainsEvictedContainer(pod *corev1.Pod) bool {
 	return false
 }
 
+// IsPodContainsShutdownContainer returns true if pod status has an shutdown reason false otherwise
+func IsPodContainsShutdownContainer(pod *corev1.Pod) bool {
+	if pod.Status.Phase == corev1.PodFailed && strings.Contains(pod.Status.Reason, "Shutdown") {
+		return true
+	}
+	return false
+}
+
 func IsPodContainsPendingContainer(pod *corev1.Pod) bool {
 	for _, containerState := range pod.Status.ContainerStatuses {
 		if containerState.State.Waiting != nil {

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -607,7 +607,8 @@ func (r *Reconciler) handleRollingUpgrade(log logr.Logger, desiredPod, currentPo
 	case patchResult.IsEmpty():
 		if !k8sutil.IsPodContainsTerminatedContainer(currentPod) &&
 			r.KafkaCluster.Status.BrokersState[currentPod.Labels["brokerId"]].ConfigurationState == v1beta1.ConfigInSync &&
-			!k8sutil.IsPodContainsEvictedContainer(currentPod) {
+			!k8sutil.IsPodContainsEvictedContainer(currentPod) &&
+			!k8sutil.IsPodContainsShutdownContainer(currentPod) {
 			log.V(1).Info("resource is in sync")
 			return nil
 		}


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no |
| New feature?    | yes |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?

* Handle pods with `Shutdown` status
* Update alertmanager port name `alerts` -> `http-alerts` so Istio can handle connections correctly

### Why?

* With a new [Graceful node shutdown](https://kubernetes.io/docs/concepts/architecture/nodes/#graceful-node-shutdown) feature `Shutdown` pod status was added. Non GC-ed pod in that status needs to be removed in order to create a new one. 

* Istio handles alertmanager connections as `TCP` having `alerts` as a port name. Renamed to `http-alerts` to help Istio recognize connection type correctly.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
