### PR TITLE
Fix kafka topic creation failure due to mismatched webhook server port

### DIFF
--- a/charts/kafka-operator/templates/operator-deployment-with-webhook.yaml
+++ b/charts/kafka-operator/templates/operator-deployment-with-webhook.yaml
@@ -172,6 +172,11 @@ spec:
           {{- if .Values.operator.developmentLogging }}
             - --development
           {{- end }}
+          {{- if .Values.metricEndpoint }}
+            {{- if .Values.metricEndpoint.port }}
+            - --mettics-addr=":{{ .Values.metricEndpoint.port }}"
+            {{- end }}
+          {{- end }}
           image: "{{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
           name: manager
@@ -193,11 +198,11 @@ spec:
           {{- end }}
           ports:
           {{- if .Values.webhook.enabled }}
-            - containerPort: 443
+            - containerPort: {{ .Values.webhook.serverPort | default 443 }}
               name: webhook-server
               protocol: TCP
           {{- end }}
-            - containerPort: 8080
+            - containerPort: {{ .Values.webhook.serverPort | default 8080 }}
               name: metrics
               protocol: TCP
             - containerPort: 9001

--- a/charts/kafka-operator/templates/operator-deployment-with-webhook.yaml
+++ b/charts/kafka-operator/templates/operator-deployment-with-webhook.yaml
@@ -153,7 +153,14 @@ spec:
           {{- if not .Values.certSigning.enabled }}
             - --disable-cert-signing-support
           {{- end }}
-          {{- if not .Values.webhook.enabled }}
+          {{- if .Values.webhook.enabled }}
+            {{- if .Values.webhook.tls.certDir }}
+            - --tls-cert-dir={{ .Values.webhook.tls.certDir }}
+            {{- end}}
+            {{- if .Values.webhook.serverPort }}
+            - --webhook-server-port={{ .Values.webhook.serverPort }}
+            {{- end }}
+          {{ else }}
             - --disable-webhooks
           {{- end }}
           {{- if .Values.operator.namespaces }}

--- a/charts/kafka-operator/templates/operator-deployment-with-webhook.yaml
+++ b/charts/kafka-operator/templates/operator-deployment-with-webhook.yaml
@@ -202,7 +202,7 @@ spec:
               name: webhook-server
               protocol: TCP
           {{- end }}
-            - containerPort: {{ .Values.webhook.serverPort | default 8080 }}
+            - containerPort: {{ .Values.metricEndpoint.port | default 8080 }}
               name: metrics
               protocol: TCP
             - containerPort: 9001

--- a/charts/kafka-operator/templates/operator-deployment-with-webhook.yaml
+++ b/charts/kafka-operator/templates/operator-deployment-with-webhook.yaml
@@ -160,7 +160,7 @@ spec:
             {{- if .Values.webhook.serverPort }}
             - --webhook-server-port={{ .Values.webhook.serverPort }}
             {{- end }}
-          {{ else }}
+          {{- else }}
             - --disable-webhooks
           {{- end }}
           {{- if .Values.operator.namespaces }}

--- a/charts/kafka-operator/templates/operator-deployment-with-webhook.yaml
+++ b/charts/kafka-operator/templates/operator-deployment-with-webhook.yaml
@@ -154,7 +154,7 @@ spec:
             - --disable-cert-signing-support
           {{- end }}
           {{- if .Values.webhook.enabled }}
-            {{- if .Values.webhook.tls.certDir }}
+            {{- if (.Values.webhook.tls).certDir }}
             - --tls-cert-dir={{ .Values.webhook.tls.certDir }}
             {{- end}}
             {{- if .Values.webhook.serverPort }}
@@ -172,10 +172,8 @@ spec:
           {{- if .Values.operator.developmentLogging }}
             - --development
           {{- end }}
-          {{- if .Values.metricEndpoint }}
-            {{- if .Values.metricEndpoint.port }}
+          {{- if (.Values.metricEndpoint).port }}
             - --mettics-addr=":{{ .Values.metricEndpoint.port }}"
-            {{- end }}
           {{- end }}
           image: "{{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
@@ -202,7 +200,7 @@ spec:
               name: webhook-server
               protocol: TCP
           {{- end }}
-            - containerPort: {{ .Values.metricEndpoint.port | default 8080 }}
+            - containerPort: {{ (.Values.metricEndpoint).port | default 8080 }}
               name: metrics
               protocol: TCP
             - containerPort: 9001
@@ -210,7 +208,7 @@ spec:
               protocol: TCP
           volumeMounts:
           {{- if .Values.webhook.enabled }}
-            - mountPath: /etc/webhook/certs
+            - mountPath: {{ (.Values.webhook.tls).certDir | default "/etc/webhook/certs" }}
               name: serving-cert
               readOnly: true
           {{- end }}

--- a/charts/kafka-operator/values.yaml
+++ b/charts/kafka-operator/values.yaml
@@ -35,8 +35,8 @@ operator:
 webhook:
   enabled: true
 #  serverPort:
-  tls:
-    certDir: ""
+#  tls:
+#    certDir: ""
   certs:
     generate: true
     secret: "kafka-operator-serving-cert"
@@ -63,6 +63,8 @@ prometheusMetrics:
       create: true
       name: kafka-operator-authproxy
 
+metricEndpoint:
+#  port:
 
 nameOverride: ""
 fullnameOverride: ""

--- a/charts/kafka-operator/values.yaml
+++ b/charts/kafka-operator/values.yaml
@@ -34,7 +34,7 @@ operator:
 
 webhook:
   enabled: true
-  serverPort:
+#  serverPort:
   tls:
     certDir: ""
   certs:

--- a/charts/kafka-operator/values.yaml
+++ b/charts/kafka-operator/values.yaml
@@ -63,7 +63,7 @@ prometheusMetrics:
       create: true
       name: kafka-operator-authproxy
 
-metricEndpoint:
+#metricEndpoint:
 #  port:
 
 nameOverride: ""

--- a/charts/kafka-operator/values.yaml
+++ b/charts/kafka-operator/values.yaml
@@ -34,6 +34,9 @@ operator:
 
 webhook:
   enabled: true
+  serverPort:
+  tls:
+    certDir: ""
   certs:
     generate: true
     secret: "kafka-operator-serving-cert"

--- a/main.go
+++ b/main.go
@@ -80,6 +80,7 @@ func main() {
 		enableLeaderElection              bool
 		webhookCertDir                    string
 		webhookDisabled                   bool
+		webhookServerPort                 int
 		developmentLogging                bool
 		verboseLogging                    bool
 		certSigningDisabled               bool
@@ -93,6 +94,7 @@ func main() {
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&webhookDisabled, "disable-webhooks", false, "Disable webhooks used to validate custom resources")
 	flag.StringVar(&webhookCertDir, "tls-cert-dir", "/etc/webhook/certs", "The directory with a tls.key and tls.crt for serving HTTPS requests")
+	flag.IntVar(&webhookServerPort, "webhook-server-port", 443, "The port that the webhook server serves at")
 	flag.BoolVar(&developmentLogging, "development", false, "Enable development logging")
 	flag.BoolVar(&verboseLogging, "verbose", false, "Enable verbose logging")
 	flag.BoolVar(&certManagerEnabled, "cert-manager-enabled", false, "Enable cert-manager integration")
@@ -123,6 +125,7 @@ func main() {
 		LeaderElection:     enableLeaderElection,
 		LeaderElectionID:   "controller-leader-election-helper",
 		NewCache:           managerWatchCache,
+		Port:               webhookServerPort,
 	})
 
 	if err != nil {


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR fixes the kafka topic creation failure due to the mismatched webhook server port

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
The `controller-runtime` package changed the default webhook port from 443 to 9443 since [v0.7.0](https://github.com/kubernetes-sigs/controller-runtime/releases/tag/v0.7.0), but we didn't update the webhook server port (it's still listening to 443 in current installation process) when we updated the dependencies, which caused the failure when creating a KafkaTopic:
```
kubectl apply -f -<<EOF
apiVersion: kafka.banzaicloud.io/v1alpha1
kind: KafkaTopic
metadata:
  name: example-topic
  namespace: kafka
spec:
  clusterRef:
    name: kafka
  name: example-topic
  partitions: 12
  replicationFactor: 2
  config:
    "retention.ms": "604800000"
    "cleanup.policy": "delete"
EOF

Error from server (InternalError): error when creating "STDIN": Internal error occurred: failed calling webhook "kafkatopics.kafka.banzaicloud.io": Post "https://kafka-operator-operator.kafka.svc:443/validate?timeout=10s": read tcp 192.168.7.244:43886->10.10.214.140:443: read: connection reset by peer
```

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
After the fix:
```
kubectl apply -f -<<EOF
apiVersion: kafka.banzaicloud.io/v1alpha1
kind: KafkaTopic
metadata:
  name: example-topic
  namespace: kafka
spec:
  clusterRef:
    name: kafka
  name: example-topic
  partitions: 12
  replicationFactor: 2
  config:
    "retention.ms": "604800000"
    "cleanup.policy": "delete"
EOF
kafkatopic.kafka.banzaicloud.io/example-topic created
```

Relevant logs:
```
{"level":"info","ts":"2021-09-20T20:53:39.944Z","logger":"controller-runtime.metrics","msg":"metrics server is starting to listen","addr":":8080"}
{"level":"info","ts":"2021-09-20T20:53:39.945Z","logger":"controller-runtime.webhook","msg":"registering webhook","path":"/validate"}
{"level":"info","ts":"2021-09-20T20:53:39.945Z","logger":"setup","msg":"starting manager"}
I0920 20:53:39.945466       1 leaderelection.go:248] attempting to acquire leader lease kafka/controller-leader-election-helper...
{"level":"info","ts":"2021-09-20T20:53:39.945Z","logger":"controller-runtime.webhook.webhooks","msg":"starting webhook server"}
{"level":"info","ts":"2021-09-20T20:53:39.945Z","logger":"controller-runtime.manager","msg":"starting metrics server","path":"/metrics"}
{"level":"info","ts":"2021-09-20T20:53:39.946Z","logger":"controller-runtime.certwatcher","msg":"Updated current TLS certificate"}
{"level":"info","ts":"2021-09-20T20:53:39.946Z","logger":"controller-runtime.webhook","msg":"serving webhook server","host":"","port":443}
...
```

> Note: This PR has been tested in both k8s v1.19 and v1.21

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
