### PR TITLE
Set KafkaUser as owner for its corresponding Certificate object

### DIFF
--- a/pkg/pki/certmanagerpki/certmanager_user.go
+++ b/pkg/pki/certmanagerpki/certmanager_user.go
@@ -147,7 +147,7 @@ func (c *certManager) clusterCertificateForUser(
 	user *v1alpha1.KafkaUser, clusterDomain string) *certv1.Certificate {
 	caName, caKind := c.getCA(user)
 	cert := &certv1.Certificate{
-		ObjectMeta: templates.ObjectMetaWithCustomNamespaceAndWithoutLabels(user.GetName(), user.GetNamespace(), c.cluster),
+		ObjectMeta: templates.ObjectMetaWithKafkaUserOwnerAndWithoutLabels(user.GetName(), user),
 		Spec: certv1.CertificateSpec{
 			SecretName: user.Spec.SecretName,
 			PrivateKey: &certv1.CertificatePrivateKey{

--- a/pkg/resources/templates/templates.go
+++ b/pkg/resources/templates/templates.go
@@ -17,6 +17,7 @@ package templates
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/banzaicloud/koperator/api/v1alpha1"
 	"github.com/banzaicloud/koperator/api/v1beta1"
 	"github.com/banzaicloud/koperator/pkg/util"
 )
@@ -40,17 +41,17 @@ func ObjectMeta(name string, labels map[string]string, cluster *v1beta1.KafkaClu
 	}
 }
 
-// ObjectMetaWithCustomNamespaceAndWithoutLabels returns a metav1.ObjectMeta object with custom namespace, ownerReference and name
-func ObjectMetaWithCustomNamespaceAndWithoutLabels(name, namespace string, cluster *v1beta1.KafkaCluster) metav1.ObjectMeta {
+// ObjectMetaWithKafkaUserOwnerAndWithoutLabels returns a metav1.ObjectMeta object with ownerReference and name
+func ObjectMetaWithKafkaUserOwnerAndWithoutLabels(name string, user *v1alpha1.KafkaUser) metav1.ObjectMeta {
 	return metav1.ObjectMeta{
 		Name:      name,
-		Namespace: namespace,
+		Namespace: user.GetNamespace(),
 		OwnerReferences: []metav1.OwnerReference{
 			{
-				APIVersion:         cluster.APIVersion,
-				Kind:               cluster.Kind,
-				Name:               cluster.Name,
-				UID:                cluster.UID,
+				APIVersion:         user.APIVersion,
+				Kind:               user.Kind,
+				Name:               user.Name,
+				UID:                user.UID,
 				Controller:         util.BoolPointer(true),
 				BlockOwnerDeletion: util.BoolPointer(true),
 			},


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Remove `KafkaCluster` owner reference form the cert-manager `Certificate` generated for a KafkaUser and use `KafkaUser` instance as owner reference.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Starting from Kubernetes 1.20+ cross-namespace owner references are disallowed by design. In case of cross-namespace references Kubernetes deletes the dependent resource. This results in the cert-manager `Certificate` resource generated for a KafkaUser to be deleted by Kubernetes thus user certificate provisioning via cert-manager fails.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/#owner-references-in-object-specifications


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline

