### PR TITLE
Use local broker as bootstrap for cruisecontrol metrics reporter

### DIFF
--- a/controllers/tests/kafkacluster_controller_kafka_test.go
+++ b/controllers/tests/kafkacluster_controller_kafka_test.go
@@ -165,7 +165,7 @@ func expectKafkaBrokerConfigmap(kafkaCluster *v1beta1.KafkaCluster, broker v1bet
 	Expect(configMap.Data).To(HaveKeyWithValue("broker-config", fmt.Sprintf(`advertised.listeners=CONTROLLER://kafkacluster-%d-%d.kafka-%d.svc.cluster.local:29093,INTERNAL://kafkacluster-%d-%d.kafka-%d.svc.cluster.local:29092,TEST://test.host.com:%d
 broker.id=%d
 control.plane.listener.name=CONTROLLER
-cruise.control.metrics.reporter.bootstrap.servers=kafkacluster-1-all-broker.kafka-1.svc.cluster.local:29092
+cruise.control.metrics.reporter.bootstrap.servers=localhost:29092
 cruise.control.metrics.reporter.kubernetes.mode=true
 inter.broker.listener.name=INTERNAL
 listener.security.protocol.map=INTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT,TEST:PLAINTEXT

--- a/pkg/resources/kafka/configmap.go
+++ b/pkg/resources/kafka/configmap.go
@@ -102,11 +102,11 @@ func (r *Reconciler) getConfigProperties(bConfig *v1beta1.BrokerConfig, id int32
 	if err := config.Set("metric.reporters", "com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter"); err != nil {
 		log.Error(err, "setting metric.reporters in broker configuration resulted an error")
 	}
-	bootstrapServers, err := kafkautils.GetBootstrapServersService(r.KafkaCluster)
+	brokerPort, err := kafkautils.GetBrokerContainerPort(r.KafkaCluster)
 	if err != nil {
-		log.Error(err, "getting Kafka bootstrap servers for Cruise Control failed")
+		log.Error(err, "getting Kafka broker port for Cruise Control failed")
 	}
-	if err := config.Set("cruise.control.metrics.reporter.bootstrap.servers", bootstrapServers); err != nil {
+	if err := config.Set("cruise.control.metrics.reporter.bootstrap.servers", fmt.Sprintf("localhost:%d", brokerPort)); err != nil {
 		log.Error(err, "setting cruise.control.metrics.reporter.bootstrap.servers in broker configuration resulted an error")
 	}
 	if err := config.Set("cruise.control.metrics.reporter.kubernetes.mode", true); err != nil {

--- a/pkg/resources/kafka/configmap_test.go
+++ b/pkg/resources/kafka/configmap_test.go
@@ -55,7 +55,7 @@ func TestGenerateBrokerConfig(t *testing.T) {
 			listenerType:              "plaintext",
 			expectedConfig: `advertised.listeners=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
 broker.id=0
-cruise.control.metrics.reporter.bootstrap.servers=kafka-all-broker.kafka.svc.cluster.local:9092
+cruise.control.metrics.reporter.bootstrap.servers=localhost:9092
 cruise.control.metrics.reporter.kubernetes.mode=true
 inter.broker.listener.name=INTERNAL
 listener.security.protocol.map=INTERNAL:PLAINTEXT
@@ -76,7 +76,7 @@ zookeeper.connect=example.zk:2181/`,
 			listenerType:              "plaintext",
 			expectedConfig: `advertised.listeners=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
 broker.id=0
-cruise.control.metrics.reporter.bootstrap.servers=kafka-all-broker.kafka.svc.cluster.local:9092
+cruise.control.metrics.reporter.bootstrap.servers=localhost:9092
 cruise.control.metrics.reporter.kubernetes.mode=true
 inter.broker.listener.name=INTERNAL
 listener.security.protocol.map=INTERNAL:PLAINTEXT
@@ -97,7 +97,7 @@ zookeeper.connect=example.zk:2181/kafka`,
 			listenerType:              "plaintext",
 			expectedConfig: `advertised.listeners=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
 broker.id=0
-cruise.control.metrics.reporter.bootstrap.servers=kafka-all-broker.kafka.svc.cluster.local:9092
+cruise.control.metrics.reporter.bootstrap.servers=localhost:9092
 cruise.control.metrics.reporter.kubernetes.mode=true
 inter.broker.listener.name=INTERNAL
 listener.security.protocol.map=INTERNAL:PLAINTEXT
@@ -118,7 +118,7 @@ zookeeper.connect=example.zk:2181/`,
 			listenerType:              "plaintext",
 			expectedConfig: `advertised.listeners=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
 broker.id=0
-cruise.control.metrics.reporter.bootstrap.servers=kafka-all-broker.kafka.svc.cluster.local:9092
+cruise.control.metrics.reporter.bootstrap.servers=localhost:9092
 cruise.control.metrics.reporter.kubernetes.mode=true
 inter.broker.listener.name=INTERNAL
 listener.security.protocol.map=INTERNAL:PLAINTEXT
@@ -144,7 +144,7 @@ zookeeper.connect=example.zk:2181,example.zk-1:2181/kafka`,
 			listenerType:              "plaintext",
 			expectedConfig: `advertised.listeners=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
 broker.id=0
-cruise.control.metrics.reporter.bootstrap.servers=kafka-all-broker.kafka.svc.cluster.local:9092
+cruise.control.metrics.reporter.bootstrap.servers=localhost:9092
 cruise.control.metrics.reporter.kubernetes.mode=true
 inter.broker.listener.name=INTERNAL
 listener.security.protocol.map=INTERNAL:PLAINTEXT
@@ -166,7 +166,7 @@ zookeeper.connect=example.zk:2181/`,
 			listenerType:              "plaintext",
 			expectedConfig: `advertised.listeners=INTERNAL://kafka-0.kafka.svc.foo.bar:9092
 broker.id=0
-cruise.control.metrics.reporter.bootstrap.servers=kafka-all-broker.kafka.svc.foo.bar:9092
+cruise.control.metrics.reporter.bootstrap.servers=localhost:9092
 cruise.control.metrics.reporter.kubernetes.mode=true
 inter.broker.listener.name=INTERNAL
 listener.security.protocol.map=INTERNAL:PLAINTEXT
@@ -197,7 +197,7 @@ auto.create.topics.enable=true
 auto.create.topics.enable=true
 broker.id=0
 control.plane.listener.name=thisisatest
-cruise.control.metrics.reporter.bootstrap.servers=kafka-all-broker.kafka.svc.cluster.local:9092
+cruise.control.metrics.reporter.bootstrap.servers=localhost:9092
 cruise.control.metrics.reporter.kubernetes.mode=true
 inter.broker.listener.name=INTERNAL
 listener.security.protocol.map=INTERNAL:PLAINTEXT
@@ -218,7 +218,7 @@ zookeeper.connect=example.zk:2181/`,
 			listenerType:              "sasl_plaintext",
 			expectedConfig: `advertised.listeners=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
 broker.id=0
-cruise.control.metrics.reporter.bootstrap.servers=kafka-all-broker.kafka.svc.cluster.local:9092
+cruise.control.metrics.reporter.bootstrap.servers=localhost:9092
 cruise.control.metrics.reporter.kubernetes.mode=true
 inter.broker.listener.name=INTERNAL
 listener.security.protocol.map=INTERNAL:SASL_PLAINTEXT

--- a/pkg/util/kafka/common.go
+++ b/pkg/util/kafka/common.go
@@ -209,9 +209,9 @@ func GetBootstrapServersService(cluster *v1beta1.KafkaCluster) (string, error) {
 	return getBootstrapServers(cluster, true)
 }
 
-func getBootstrapServers(cluster *v1beta1.KafkaCluster, useService bool) (string, error) {
+// GetBrokerContainerPort return broker container port
+func GetBrokerContainerPort(cluster *v1beta1.KafkaCluster) (int32, error) {
 	var listener v1beta1.InternalListenerConfig
-	var bootstrapServersList []string
 
 	for _, lc := range cluster.Spec.ListenersConfig.InternalListeners {
 		if lc.UsedForInnerBrokerCommunication && !lc.UsedForControllerCommunication {
@@ -219,20 +219,28 @@ func getBootstrapServers(cluster *v1beta1.KafkaCluster, useService bool) (string
 			break
 		}
 	}
-
 	if listener.Name == "" {
-		return "", errors.New("no suitable listener found for using as Kafka bootstrap server configuration")
+		return -1, errors.New("no suitable listener found for using as Kafka bootstrap server configuration")
 	}
+	return listener.ContainerPort, nil
+}
+
+func getBootstrapServers(cluster *v1beta1.KafkaCluster, useService bool) (string, error) {
+	containerPort, err := GetBrokerContainerPort(cluster)
+	if err != nil {
+		return "", err
+	}
+	var bootstrapServersList []string
 
 	if useService {
 		bootstrapServersList = append(bootstrapServersList,
-			fmt.Sprintf("%s:%d", GetClusterServiceFqdn(cluster), listener.ContainerPort))
+			fmt.Sprintf("%s:%d", GetClusterServiceFqdn(cluster), containerPort))
 	} else {
 		for _, broker := range cluster.Spec.Brokers {
 			broker := broker
 			fqdn := GetBrokerServiceFqdn(cluster, &broker)
 			bootstrapServersList = append(bootstrapServersList,
-				fmt.Sprintf("%s:%d", fqdn, listener.ContainerPort))
+				fmt.Sprintf("%s:%d", fqdn, containerPort))
 		}
 	}
 	return strings.Join(bootstrapServersList, ","), nil


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | fixes #X |
| License         | Apache 2.0 |


### What's in this PR?

Configure cruise-control metrics reporter to use local broker as a bootstrap server.


<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->


### Why?

This is needed to avoid a race condition during initial
cluster creation when the first broker is initialised but its dns
entry in internal K8s DNS is not yet available immediately for the cruise-control reporter to use.


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)

