### PR TITLE
Fix webhook metrics port parameter typo in helm chart

### DIFF
--- a/charts/kafka-operator/templates/operator-deployment-with-webhook.yaml
+++ b/charts/kafka-operator/templates/operator-deployment-with-webhook.yaml
@@ -173,7 +173,7 @@ spec:
             - --development
           {{- end }}
           {{- if (.Values.metricEndpoint).port }}
-            - --mettics-addr=":{{ .Values.metricEndpoint.port }}"
+            - --metrics-addr=":{{ .Values.metricEndpoint.port }}"
           {{- end }}
           image: "{{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.operator.image.pullPolicy }}


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| Related tickets | fixes #X |
| License         | Apache 2.0 |


### What's in this PR?

Fix a typo in webhook metrics address


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
