### PR TITLE
Remove code that fixed deprecated status

### DIFF
--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -134,21 +134,6 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 
 	log.V(1).Info("Reconciling")
 
-	//TODO remove this in a future release (baluchicken)
-	// this is only required to keep backward compatibility
-	var brokerIdWithDeprecatedStatus []string
-	for bId, bStatus := range r.KafkaCluster.Status.BrokersState {
-		if bStatus.GracefulActionState.CruiseControlState == "GracefulUpdateNotRequired" {
-			brokerIdWithDeprecatedStatus = append(brokerIdWithDeprecatedStatus, bId)
-		}
-	}
-	statusErr := k8sutil.UpdateBrokerStatus(r.Client, brokerIdWithDeprecatedStatus, r.KafkaCluster,
-		v1beta1.GracefulActionState{CruiseControlState: v1beta1.GracefulUpscaleSucceeded}, log)
-
-	if statusErr != nil {
-		return errorfactory.New(errorfactory.StatusUpdateError{}, statusErr, "updating deprecated status failed")
-	}
-
 	if r.KafkaCluster.Spec.HeadlessServiceEnabled {
 		o := r.headlessService()
 		err := k8sutil.Reconcile(log, r.Client, o, r.KafkaCluster)


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | yes |
| Related tickets | - |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Removed code that fixed a deprecation.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
In the `<0.10` version of the koperator the CC state `GracefulUpdateNotRequired` was being used. It was removed, and to fix upgrading to newer operator, the Kafka reconciler starts with a check to update that state. Since this was introduced in `v0.10 ` and the likelihood of a user upgrading from that old version to the newer one is negligible, I propose to remove this unnecessary block.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
-

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline