### PR TITLE
Add support for TopologySpreadConstraints in envoy ingress deployment

### DIFF
--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -238,12 +238,16 @@ type EnvoyConfig struct {
 	Image     string                       `json:"image,omitempty"`
 	Resources *corev1.ResourceRequirements `json:"resourceRequirements,omitempty"`
 	// +kubebuilder:validation:Minimum=1
-	Replicas           int32                         `json:"replicas,omitempty"`
-	ServiceAccountName string                        `json:"serviceAccountName,omitempty"`
-	ImagePullSecrets   []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
-	Affinity           *corev1.Affinity              `json:"affinity,omitempty"`
-	NodeSelector       map[string]string             `json:"nodeSelector,omitempty"`
-	Tolerations        []corev1.Toleration           `json:"tolerations,omitempty"`
+	Replicas int32 `json:"replicas,omitempty"`
+	// ServiceAccountName is the name of service account
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
+	// ImagePullSecrets for the envoy image pull
+	ImagePullSecrets          []corev1.LocalObjectReference     `json:"imagePullSecrets,omitempty"`
+	Affinity                  *corev1.Affinity                  `json:"affinity,omitempty"`
+	TopologySpreadConstraints []corev1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
+	// NodeSelector is the node selector expression for envoy pods
+	NodeSelector map[string]string   `json:"nodeSelector,omitempty"`
+	Tolerations  []corev1.Toleration `json:"tolerations,omitempty"`
 	// Annotations defines the annotations placed on the envoy ingress controller deployment
 	Annotations              map[string]string `json:"annotations,omitempty"`
 	LoadBalancerSourceRanges []string          `json:"loadBalancerSourceRanges,omitempty"`
@@ -648,6 +652,11 @@ func (eConfig *EnvoyConfig) GetNodeSelector() map[string]string {
 //GetAffinity returns the Affinity config for envoy
 func (eConfig *EnvoyConfig) GetAffinity() *corev1.Affinity {
 	return eConfig.Affinity
+}
+
+//GetTopologySpreadConstaints returns the Affinity config for envoy
+func (eConfig *EnvoyConfig) GetTopologySpreadConstaints() []corev1.TopologySpreadConstraint {
+	return eConfig.TopologySpreadConstraints
 }
 
 //GetNodeSelector returns the node selector for the given broker

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -385,6 +385,13 @@ func (in *EnvoyConfig) DeepCopyInto(out *EnvoyConfig) {
 		*out = new(v1.Affinity)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.TopologySpreadConstraints != nil {
+		in, out := &in.TopologySpreadConstraints, &out.TopologySpreadConstraints
+		*out = make([]v1.TopologySpreadConstraint, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
 		*out = make(map[string]string, len(*in))

--- a/charts/kafka-operator/templates/crds.yaml
+++ b/charts/kafka-operator/templates/crds.yaml
@@ -15805,6 +15805,7 @@ spec:
                   image:
                     type: string
                   imagePullSecrets:
+                    description: ImagePullSecrets image pull secrets
                     items:
                       description: LocalObjectReference contains enough information
                         to let you locate the referenced object inside the same namespace.
@@ -15826,6 +15827,7 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
+                    description: NodeSelector node selector for envoy pods
                     type: object
                   replicas:
                     format: int32
@@ -15859,6 +15861,7 @@ spec:
                         type: object
                     type: object
                   serviceAccountName:
+                    description: ServiceAccountName the name of service account
                     type: string
                   tolerations:
                     items:
@@ -15898,6 +15901,108 @@ spec:
                             to. If the operator is Exists, the value should be empty,
                             otherwise just a regular string.
                           type: string
+                      type: object
+                    type: array
+                  topologySpreadConstraints:
+                    items:
+                      description: TopologySpreadConstraint specifies how to spread
+                        matching pods among the given topology.
+                      properties:
+                        labelSelector:
+                          description: LabelSelector is used to find matching pods.
+                            Pods that match this label selector are counted to determine
+                            the number of pods in their corresponding topology domain.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        maxSkew:
+                          description: 'MaxSkew describes the degree to which pods
+                            may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                            it is the maximum permitted difference between the number
+                            of matching pods in the target topology and the global
+                            minimum. For example, in a 3-zone cluster, MaxSkew is
+                            set to 1, and pods with the same labelSelector spread
+                            as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                            - if MaxSkew is 1, incoming pod can only be scheduled
+                            to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(2-0) on zone1(zone2) violate
+                            MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
+                            onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                            it is used to give higher precedence to topologies that
+                            satisfy it. It''s a required field. Default value is 1
+                            and 0 is not allowed.'
+                          format: int32
+                          type: integer
+                        topologyKey:
+                          description: TopologyKey is the key of node labels. Nodes
+                            that have a label with this key and identical values are
+                            considered to be in the same topology. We consider each
+                            <key, value> as a "bucket", and try to put balanced number
+                            of pods into each bucket. It's a required field.
+                          type: string
+                        whenUnsatisfiable:
+                          description: 'WhenUnsatisfiable indicates how to deal with
+                            a pod if it doesn''t satisfy the spread constraint. -
+                            DoNotSchedule (default) tells the scheduler not to schedule
+                            it. - ScheduleAnyway tells the scheduler to schedule the
+                            pod in any location,   but giving higher precedence to
+                            topologies that would help reduce the   skew. A constraint
+                            is considered "Unsatisfiable" for an incoming pod if and
+                            only if every possible node assigment for that pod would
+                            violate "MaxSkew" on some topology. For example, in a
+                            3-zone cluster, MaxSkew is set to 1, and pods with the
+                            same labelSelector spread as 3/1/1: | zone1 | zone2 |
+                            zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable
+                            is set to DoNotSchedule, incoming pod can only be scheduled
+                            to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1)
+                            on zone2(zone3) satisfies MaxSkew(1). In other words,
+                            the cluster can still be imbalanced, but scheduler won''t
+                            make it *more* imbalanced. It''s a required field.'
+                          type: string
+                      required:
+                      - maxSkew
+                      - topologyKey
+                      - whenUnsatisfiable
                       type: object
                     type: array
                 type: object
@@ -17617,6 +17722,7 @@ spec:
                                       image:
                                         type: string
                                       imagePullSecrets:
+                                        description: ImagePullSecrets image pull secrets
                                         items:
                                           description: LocalObjectReference contains
                                             enough information to let you locate the
@@ -17642,6 +17748,8 @@ spec:
                                       nodeSelector:
                                         additionalProperties:
                                           type: string
+                                        description: NodeSelector node selector for
+                                          envoy pods
                                         type: object
                                       replicas:
                                         format: int32
@@ -17678,6 +17786,8 @@ spec:
                                             type: object
                                         type: object
                                       serviceAccountName:
+                                        description: ServiceAccountName the name of
+                                          service account
                                         type: string
                                       tolerations:
                                         items:
@@ -17728,6 +17838,144 @@ spec:
                                                 be empty, otherwise just a regular
                                                 string.
                                               type: string
+                                          type: object
+                                        type: array
+                                      topologySpreadConstraints:
+                                        items:
+                                          description: TopologySpreadConstraint specifies
+                                            how to spread matching pods among the
+                                            given topology.
+                                          properties:
+                                            labelSelector:
+                                              description: LabelSelector is used to
+                                                find matching pods. Pods that match
+                                                this label selector are counted to
+                                                determine the number of pods in their
+                                                corresponding topology domain.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                            maxSkew:
+                                              description: 'MaxSkew describes the
+                                                degree to which pods may be unevenly
+                                                distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                                                it is the maximum permitted difference
+                                                between the number of matching pods
+                                                in the target topology and the global
+                                                minimum. For example, in a 3-zone
+                                                cluster, MaxSkew is set to 1, and
+                                                pods with the same labelSelector spread
+                                                as 1/1/0: | zone1 | zone2 | zone3
+                                                | |   P   |   P   |       | - if MaxSkew
+                                                is 1, incoming pod can only be scheduled
+                                                to zone3 to become 1/1/1; scheduling
+                                                it onto zone1(zone2) would make the
+                                                ActualSkew(2-0) on zone1(zone2) violate
+                                                MaxSkew(1). - if MaxSkew is 2, incoming
+                                                pod can be scheduled onto any zone.
+                                                When `whenUnsatisfiable=ScheduleAnyway`,
+                                                it is used to give higher precedence
+                                                to topologies that satisfy it. It''s
+                                                a required field. Default value is
+                                                1 and 0 is not allowed.'
+                                              format: int32
+                                              type: integer
+                                            topologyKey:
+                                              description: TopologyKey is the key
+                                                of node labels. Nodes that have a
+                                                label with this key and identical
+                                                values are considered to be in the
+                                                same topology. We consider each <key,
+                                                value> as a "bucket", and try to put
+                                                balanced number of pods into each
+                                                bucket. It's a required field.
+                                              type: string
+                                            whenUnsatisfiable:
+                                              description: 'WhenUnsatisfiable indicates
+                                                how to deal with a pod if it doesn''t
+                                                satisfy the spread constraint. - DoNotSchedule
+                                                (default) tells the scheduler not
+                                                to schedule it. - ScheduleAnyway tells
+                                                the scheduler to schedule the pod
+                                                in any location,   but giving higher
+                                                precedence to topologies that would
+                                                help reduce the   skew. A constraint
+                                                is considered "Unsatisfiable" for
+                                                an incoming pod if and only if every
+                                                possible node assigment for that pod
+                                                would violate "MaxSkew" on some topology.
+                                                For example, in a 3-zone cluster,
+                                                MaxSkew is set to 1, and pods with
+                                                the same labelSelector spread as 3/1/1:
+                                                | zone1 | zone2 | zone3 | | P P P
+                                                |   P   |   P   | If WhenUnsatisfiable
+                                                is set to DoNotSchedule, incoming
+                                                pod can only be scheduled to zone2(zone3)
+                                                to become 3/2/1(3/1/2) as ActualSkew(2-1)
+                                                on zone2(zone3) satisfies MaxSkew(1).
+                                                In other words, the cluster can still
+                                                be imbalanced, but scheduler won''t
+                                                make it *more* imbalanced. It''s a
+                                                required field.'
+                                              type: string
+                                          required:
+                                          - maxSkew
+                                          - topologyKey
+                                          - whenUnsatisfiable
                                           type: object
                                         type: array
                                     type: object

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -15804,6 +15804,7 @@ spec:
                   image:
                     type: string
                   imagePullSecrets:
+                    description: ImagePullSecrets image pull secrets
                     items:
                       description: LocalObjectReference contains enough information
                         to let you locate the referenced object inside the same namespace.
@@ -15825,6 +15826,7 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
+                    description: NodeSelector node selector for envoy pods
                     type: object
                   replicas:
                     format: int32
@@ -15858,6 +15860,7 @@ spec:
                         type: object
                     type: object
                   serviceAccountName:
+                    description: ServiceAccountName the name of service account
                     type: string
                   tolerations:
                     items:
@@ -15897,6 +15900,108 @@ spec:
                             to. If the operator is Exists, the value should be empty,
                             otherwise just a regular string.
                           type: string
+                      type: object
+                    type: array
+                  topologySpreadConstraints:
+                    items:
+                      description: TopologySpreadConstraint specifies how to spread
+                        matching pods among the given topology.
+                      properties:
+                        labelSelector:
+                          description: LabelSelector is used to find matching pods.
+                            Pods that match this label selector are counted to determine
+                            the number of pods in their corresponding topology domain.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        maxSkew:
+                          description: 'MaxSkew describes the degree to which pods
+                            may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                            it is the maximum permitted difference between the number
+                            of matching pods in the target topology and the global
+                            minimum. For example, in a 3-zone cluster, MaxSkew is
+                            set to 1, and pods with the same labelSelector spread
+                            as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                            - if MaxSkew is 1, incoming pod can only be scheduled
+                            to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(2-0) on zone1(zone2) violate
+                            MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
+                            onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                            it is used to give higher precedence to topologies that
+                            satisfy it. It''s a required field. Default value is 1
+                            and 0 is not allowed.'
+                          format: int32
+                          type: integer
+                        topologyKey:
+                          description: TopologyKey is the key of node labels. Nodes
+                            that have a label with this key and identical values are
+                            considered to be in the same topology. We consider each
+                            <key, value> as a "bucket", and try to put balanced number
+                            of pods into each bucket. It's a required field.
+                          type: string
+                        whenUnsatisfiable:
+                          description: 'WhenUnsatisfiable indicates how to deal with
+                            a pod if it doesn''t satisfy the spread constraint. -
+                            DoNotSchedule (default) tells the scheduler not to schedule
+                            it. - ScheduleAnyway tells the scheduler to schedule the
+                            pod in any location,   but giving higher precedence to
+                            topologies that would help reduce the   skew. A constraint
+                            is considered "Unsatisfiable" for an incoming pod if and
+                            only if every possible node assigment for that pod would
+                            violate "MaxSkew" on some topology. For example, in a
+                            3-zone cluster, MaxSkew is set to 1, and pods with the
+                            same labelSelector spread as 3/1/1: | zone1 | zone2 |
+                            zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable
+                            is set to DoNotSchedule, incoming pod can only be scheduled
+                            to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1)
+                            on zone2(zone3) satisfies MaxSkew(1). In other words,
+                            the cluster can still be imbalanced, but scheduler won''t
+                            make it *more* imbalanced. It''s a required field.'
+                          type: string
+                      required:
+                      - maxSkew
+                      - topologyKey
+                      - whenUnsatisfiable
                       type: object
                     type: array
                 type: object
@@ -17616,6 +17721,7 @@ spec:
                                       image:
                                         type: string
                                       imagePullSecrets:
+                                        description: ImagePullSecrets image pull secrets
                                         items:
                                           description: LocalObjectReference contains
                                             enough information to let you locate the
@@ -17641,6 +17747,8 @@ spec:
                                       nodeSelector:
                                         additionalProperties:
                                           type: string
+                                        description: NodeSelector node selector for
+                                          envoy pods
                                         type: object
                                       replicas:
                                         format: int32
@@ -17677,6 +17785,8 @@ spec:
                                             type: object
                                         type: object
                                       serviceAccountName:
+                                        description: ServiceAccountName the name of
+                                          service account
                                         type: string
                                       tolerations:
                                         items:
@@ -17727,6 +17837,144 @@ spec:
                                                 be empty, otherwise just a regular
                                                 string.
                                               type: string
+                                          type: object
+                                        type: array
+                                      topologySpreadConstraints:
+                                        items:
+                                          description: TopologySpreadConstraint specifies
+                                            how to spread matching pods among the
+                                            given topology.
+                                          properties:
+                                            labelSelector:
+                                              description: LabelSelector is used to
+                                                find matching pods. Pods that match
+                                                this label selector are counted to
+                                                determine the number of pods in their
+                                                corresponding topology domain.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                            maxSkew:
+                                              description: 'MaxSkew describes the
+                                                degree to which pods may be unevenly
+                                                distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                                                it is the maximum permitted difference
+                                                between the number of matching pods
+                                                in the target topology and the global
+                                                minimum. For example, in a 3-zone
+                                                cluster, MaxSkew is set to 1, and
+                                                pods with the same labelSelector spread
+                                                as 1/1/0: | zone1 | zone2 | zone3
+                                                | |   P   |   P   |       | - if MaxSkew
+                                                is 1, incoming pod can only be scheduled
+                                                to zone3 to become 1/1/1; scheduling
+                                                it onto zone1(zone2) would make the
+                                                ActualSkew(2-0) on zone1(zone2) violate
+                                                MaxSkew(1). - if MaxSkew is 2, incoming
+                                                pod can be scheduled onto any zone.
+                                                When `whenUnsatisfiable=ScheduleAnyway`,
+                                                it is used to give higher precedence
+                                                to topologies that satisfy it. It''s
+                                                a required field. Default value is
+                                                1 and 0 is not allowed.'
+                                              format: int32
+                                              type: integer
+                                            topologyKey:
+                                              description: TopologyKey is the key
+                                                of node labels. Nodes that have a
+                                                label with this key and identical
+                                                values are considered to be in the
+                                                same topology. We consider each <key,
+                                                value> as a "bucket", and try to put
+                                                balanced number of pods into each
+                                                bucket. It's a required field.
+                                              type: string
+                                            whenUnsatisfiable:
+                                              description: 'WhenUnsatisfiable indicates
+                                                how to deal with a pod if it doesn''t
+                                                satisfy the spread constraint. - DoNotSchedule
+                                                (default) tells the scheduler not
+                                                to schedule it. - ScheduleAnyway tells
+                                                the scheduler to schedule the pod
+                                                in any location,   but giving higher
+                                                precedence to topologies that would
+                                                help reduce the   skew. A constraint
+                                                is considered "Unsatisfiable" for
+                                                an incoming pod if and only if every
+                                                possible node assigment for that pod
+                                                would violate "MaxSkew" on some topology.
+                                                For example, in a 3-zone cluster,
+                                                MaxSkew is set to 1, and pods with
+                                                the same labelSelector spread as 3/1/1:
+                                                | zone1 | zone2 | zone3 | | P P P
+                                                |   P   |   P   | If WhenUnsatisfiable
+                                                is set to DoNotSchedule, incoming
+                                                pod can only be scheduled to zone2(zone3)
+                                                to become 3/2/1(3/1/2) as ActualSkew(2-1)
+                                                on zone2(zone3) satisfies MaxSkew(1).
+                                                In other words, the cluster can still
+                                                be imbalanced, but scheduler won''t
+                                                make it *more* imbalanced. It''s a
+                                                required field.'
+                                              type: string
+                                          required:
+                                          - maxSkew
+                                          - topologyKey
+                                          - whenUnsatisfiable
                                           type: object
                                         type: array
                                     type: object

--- a/pkg/resources/envoy/deployment.go
+++ b/pkg/resources/envoy/deployment.go
@@ -83,11 +83,12 @@ func (r *Reconciler) deployment(log logr.Logger, extListener v1beta1.ExternalLis
 						defaultIngressConfigName, log),
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: ingressConfig.EnvoyConfig.GetServiceAccount(),
-					ImagePullSecrets:   ingressConfig.EnvoyConfig.GetImagePullSecrets(),
-					Tolerations:        ingressConfig.EnvoyConfig.GetTolerations(),
-					NodeSelector:       ingressConfig.EnvoyConfig.GetNodeSelector(),
-					Affinity:           ingressConfig.EnvoyConfig.GetAffinity(),
+					ServiceAccountName:        ingressConfig.EnvoyConfig.GetServiceAccount(),
+					ImagePullSecrets:          ingressConfig.EnvoyConfig.GetImagePullSecrets(),
+					Tolerations:               ingressConfig.EnvoyConfig.GetTolerations(),
+					NodeSelector:              ingressConfig.EnvoyConfig.GetNodeSelector(),
+					Affinity:                  ingressConfig.EnvoyConfig.GetAffinity(),
+					TopologySpreadConstraints: ingressConfig.EnvoyConfig.GetTopologySpreadConstaints(),
 					Containers: []corev1.Container{
 						{
 							Name:  "envoy",


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no|
| New feature?    | yes |
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0 |


### What's in this PR?

Allow setting envoy pods' TopologySpreadConstraints to help spread envoy pods evenly based on topology keys.
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Higher flexibility in the way envoy pods are scheduled. In our environment we've seen much better stablitiy and performance when envoy pods are uniformly distributed on nodes in cluster.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
