### PR TITLE
Enabled PDB for Envoy deployments ADDENDUM

### DIFF
--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -115,7 +115,7 @@ type DisruptionBudget struct {
 // DisruptionBudgetWithStrategy defines the configuration for PodDisruptionBudget where the workload is managed by an external controller (eg. Deployments)
 type DisruptionBudgetWithStrategy struct {
 	// PodDisruptionBudget default settings
-	DisruptionBudget DisruptionBudget `json:",inline"`
+	DisruptionBudget `json:",inline"`
 	// The strategy to be used, either minAvailable or maxUnavailable
 	// +kubebuilder:validation:Enum=minAvailable;maxUnavailable
 	Stategy string `json:"strategy,omitempty"`


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?

DisruptionBudget is declared as an inline field
so instead of composing the new struct, inherit it so it can be 
automatically read.

Currently you'd still need to declare:
```
podDisruptionBudget:
  PodDisruptionBudget:
    ...
  stragety:
```

for this to work while the CRD lists all the fields inlined
which is misleading for the user

<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)

