### PR TITLE
Add an optional field in KafkaCluster resource to specify cruise control reporter image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ bin/golangci-lint: bin/golangci-lint-${GOLANGCI_VERSION}
 	@ln -sf golangci-lint-${GOLANGCI_VERSION} bin/golangci-lint
 bin/golangci-lint-${GOLANGCI_VERSION}:
 	@mkdir -p bin
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b ./bin v${GOLANGCI_VERSION}
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b ./bin v${GOLANGCI_VERSION}
 	@mv bin/golangci-lint $@
 
 .PHONY: lint

--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -54,15 +54,16 @@ type KafkaClusterSpec struct {
 	ZKAddresses []string `json:"zkAddresses"`
 	// ZKPath specifies the ZooKeeper chroot path as part
 	// of its ZooKeeper connection string which puts its data under some path in the global ZooKeeper namespace.
-	ZKPath               string                  `json:"zkPath,omitempty"`
-	RackAwareness        *RackAwareness          `json:"rackAwareness,omitempty"`
-	ClusterImage         string                  `json:"clusterImage,omitempty"`
-	ReadOnlyConfig       string                  `json:"readOnlyConfig,omitempty"`
-	ClusterWideConfig    string                  `json:"clusterWideConfig,omitempty"`
-	BrokerConfigGroups   map[string]BrokerConfig `json:"brokerConfigGroups,omitempty"`
-	Brokers              []Broker                `json:"brokers"`
-	DisruptionBudget     DisruptionBudget        `json:"disruptionBudget,omitempty"`
-	RollingUpgradeConfig RollingUpgradeConfig    `json:"rollingUpgradeConfig"`
+	ZKPath                      string                  `json:"zkPath,omitempty"`
+	RackAwareness               *RackAwareness          `json:"rackAwareness,omitempty"`
+	ClusterImage                string                  `json:"clusterImage,omitempty"`
+	ClusterMetricsReporterImage string                  `json:"clusterMetricsReporterImage,omitempty"`
+	ReadOnlyConfig              string                  `json:"readOnlyConfig,omitempty"`
+	ClusterWideConfig           string                  `json:"clusterWideConfig,omitempty"`
+	BrokerConfigGroups          map[string]BrokerConfig `json:"brokerConfigGroups,omitempty"`
+	Brokers                     []Broker                `json:"brokers"`
+	DisruptionBudget            DisruptionBudget        `json:"disruptionBudget,omitempty"`
+	RollingUpgradeConfig        RollingUpgradeConfig    `json:"rollingUpgradeConfig"`
 	// +kubebuilder:validation:Enum=envoy;istioingress
 	IngressController string `json:"ingressController,omitempty"`
 	// If true OneBrokerPerNode ensures that each kafka broker will be placed on a different node unless a custom
@@ -131,16 +132,17 @@ type Broker struct {
 
 // BrokerConfig defines the broker configuration
 type BrokerConfig struct {
-	Image              string                        `json:"image,omitempty"`
-	Config             string                        `json:"config,omitempty"`
-	StorageConfigs     []StorageConfig               `json:"storageConfigs,omitempty"`
-	ServiceAccountName string                        `json:"serviceAccountName,omitempty"`
-	Resources          *corev1.ResourceRequirements  `json:"resourceRequirements,omitempty"`
-	ImagePullSecrets   []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
-	NodeSelector       map[string]string             `json:"nodeSelector,omitempty"`
-	Tolerations        []corev1.Toleration           `json:"tolerations,omitempty"`
-	KafkaHeapOpts      string                        `json:"kafkaHeapOpts,omitempty"`
-	KafkaJVMPerfOpts   string                        `json:"kafkaJvmPerfOpts,omitempty"`
+	Image                string                        `json:"image,omitempty"`
+	MetricsReporterImage string                        `json:"metricsReporterImage,omitempty"`
+	Config               string                        `json:"config,omitempty"`
+	StorageConfigs       []StorageConfig               `json:"storageConfigs,omitempty"`
+	ServiceAccountName   string                        `json:"serviceAccountName,omitempty"`
+	Resources            *corev1.ResourceRequirements  `json:"resourceRequirements,omitempty"`
+	ImagePullSecrets     []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
+	NodeSelector         map[string]string             `json:"nodeSelector,omitempty"`
+	Tolerations          []corev1.Toleration           `json:"tolerations,omitempty"`
+	KafkaHeapOpts        string                        `json:"kafkaHeapOpts,omitempty"`
+	KafkaJVMPerfOpts     string                        `json:"kafkaJvmPerfOpts,omitempty"`
 	// Override for the default log4j configuration
 	Log4jConfig string `json:"log4jConfig,omitempty"`
 	// Custom annotations for the broker pods - e.g.: Prometheus scraping annotations:
@@ -565,6 +567,14 @@ func (kSpec *KafkaClusterSpec) GetClusterImage() string {
 		return kSpec.ClusterImage
 	}
 	return "ghcr.io/banzaicloud/kafka:2.13-2.8.1"
+}
+
+// GetClusterMetricsReporterImage returns the default container image for Kafka Cluster
+func (kSpec *KafkaClusterSpec) GetClusterMetricsReporterImage() string {
+	if kSpec.ClusterMetricsReporterImage != "" {
+		return kSpec.ClusterMetricsReporterImage
+	}
+	return kSpec.CruiseControlConfig.GetCCImage()
 }
 
 func (cTaskSpec *CruiseControlTaskSpec) GetDurationMinutes() float64 {

--- a/charts/kafka-operator/templates/crds.yaml
+++ b/charts/kafka-operator/templates/crds.yaml
@@ -3520,6 +3520,8 @@ spec:
                     log4jConfig:
                       description: Override for the default log4j configuration
                       type: string
+                    metricsReporterImage:
+                      type: string
                     networkConfig:
                       description: Network throughput information in kB/s used by
                         Cruise Control to determine broker network capacity. By default
@@ -9353,6 +9355,8 @@ spec:
                         log4jConfig:
                           description: Override for the default log4j configuration
                           type: string
+                        metricsReporterImage:
+                          type: string
                         networkConfig:
                           description: Network throughput information in kB/s used
                             by Cruise Control to determine broker network capacity.
@@ -11677,6 +11681,8 @@ spec:
                   type: object
                 type: array
               clusterImage:
+                type: string
+              clusterMetricsReporterImage:
                 type: string
               clusterWideConfig:
                 type: string
@@ -15805,7 +15811,7 @@ spec:
                   image:
                     type: string
                   imagePullSecrets:
-                    description: ImagePullSecrets image pull secrets
+                    description: ImagePullSecrets for the envoy image pull
                     items:
                       description: LocalObjectReference contains enough information
                         to let you locate the referenced object inside the same namespace.
@@ -15827,7 +15833,8 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector node selector for envoy pods
+                    description: NodeSelector is the node selector expression for
+                      envoy pods
                     type: object
                   replicas:
                     format: int32
@@ -15861,7 +15868,7 @@ spec:
                         type: object
                     type: object
                   serviceAccountName:
-                    description: ServiceAccountName the name of service account
+                    description: ServiceAccountName is the name of service account
                     type: string
                   tolerations:
                     items:
@@ -17722,7 +17729,8 @@ spec:
                                       image:
                                         type: string
                                       imagePullSecrets:
-                                        description: ImagePullSecrets image pull secrets
+                                        description: ImagePullSecrets for the envoy
+                                          image pull
                                         items:
                                           description: LocalObjectReference contains
                                             enough information to let you locate the
@@ -17748,8 +17756,8 @@ spec:
                                       nodeSelector:
                                         additionalProperties:
                                           type: string
-                                        description: NodeSelector node selector for
-                                          envoy pods
+                                        description: NodeSelector is the node selector
+                                          expression for envoy pods
                                         type: object
                                       replicas:
                                         format: int32
@@ -17786,8 +17794,8 @@ spec:
                                             type: object
                                         type: object
                                       serviceAccountName:
-                                        description: ServiceAccountName the name of
-                                          service account
+                                        description: ServiceAccountName is the name
+                                          of service account
                                         type: string
                                       tolerations:
                                         items:

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -3519,6 +3519,8 @@ spec:
                     log4jConfig:
                       description: Override for the default log4j configuration
                       type: string
+                    metricsReporterImage:
+                      type: string
                     networkConfig:
                       description: Network throughput information in kB/s used by
                         Cruise Control to determine broker network capacity. By default
@@ -9352,6 +9354,8 @@ spec:
                         log4jConfig:
                           description: Override for the default log4j configuration
                           type: string
+                        metricsReporterImage:
+                          type: string
                         networkConfig:
                           description: Network throughput information in kB/s used
                             by Cruise Control to determine broker network capacity.
@@ -11676,6 +11680,8 @@ spec:
                   type: object
                 type: array
               clusterImage:
+                type: string
+              clusterMetricsReporterImage:
                 type: string
               clusterWideConfig:
                 type: string
@@ -15804,7 +15810,7 @@ spec:
                   image:
                     type: string
                   imagePullSecrets:
-                    description: ImagePullSecrets image pull secrets
+                    description: ImagePullSecrets for the envoy image pull
                     items:
                       description: LocalObjectReference contains enough information
                         to let you locate the referenced object inside the same namespace.
@@ -15826,7 +15832,8 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector node selector for envoy pods
+                    description: NodeSelector is the node selector expression for
+                      envoy pods
                     type: object
                   replicas:
                     format: int32
@@ -15860,7 +15867,7 @@ spec:
                         type: object
                     type: object
                   serviceAccountName:
-                    description: ServiceAccountName the name of service account
+                    description: ServiceAccountName is the name of service account
                     type: string
                   tolerations:
                     items:
@@ -17721,7 +17728,8 @@ spec:
                                       image:
                                         type: string
                                       imagePullSecrets:
-                                        description: ImagePullSecrets image pull secrets
+                                        description: ImagePullSecrets for the envoy
+                                          image pull
                                         items:
                                           description: LocalObjectReference contains
                                             enough information to let you locate the
@@ -17747,8 +17755,8 @@ spec:
                                       nodeSelector:
                                         additionalProperties:
                                           type: string
-                                        description: NodeSelector node selector for
-                                          envoy pods
+                                        description: NodeSelector is the node selector
+                                          expression for envoy pods
                                         type: object
                                       replicas:
                                         format: int32
@@ -17785,8 +17793,8 @@ spec:
                                             type: object
                                         type: object
                                       serviceAccountName:
-                                        description: ServiceAccountName the name of
-                                          service account
+                                        description: ServiceAccountName is the name
+                                          of service account
                                         type: string
                                       tolerations:
                                         items:

--- a/pkg/resources/cruisecontrol/configmap_test.go
+++ b/pkg/resources/cruisecontrol/configmap_test.go
@@ -473,7 +473,7 @@ func TestGenerateCapacityConfig_JBOD(t *testing.T) {
 	}
 }
 
-//nolint:fulen
+//nolint:funlen
 func TestReturnErrorStorageConfigLessThan1MB(t *testing.T) {
 	//return error when storage config is specified as 500Ki
 

--- a/pkg/resources/kafka/pod.go
+++ b/pkg/resources/kafka/pod.go
@@ -108,7 +108,7 @@ rm /var/run/wait/do-not-exit-yet`}
 		),
 		Spec: corev1.PodSpec{
 			SecurityContext: brokerConfig.PodSecurityContext,
-			InitContainers:  getInitContainers(brokerConfig.InitContainers, r.KafkaCluster.Spec),
+			InitContainers:  getInitContainers(brokerConfig, r.KafkaCluster.Spec),
 			Affinity:        getAffinity(brokerConfig, r.KafkaCluster),
 			Containers: append([]corev1.Container{
 				{
@@ -181,14 +181,14 @@ fi`},
 	return pod
 }
 
-func getInitContainers(brokerConfigInitContainers []corev1.Container, kafkaClusterSpec v1beta1.KafkaClusterSpec) []corev1.Container {
-	initContainers := make([]corev1.Container, 0, len(brokerConfigInitContainers))
-	initContainers = append(initContainers, brokerConfigInitContainers...)
+func getInitContainers(brokerConfig *v1beta1.BrokerConfig, kafkaClusterSpec v1beta1.KafkaClusterSpec) []corev1.Container {
+	initContainers := make([]corev1.Container, 0, len(brokerConfig.InitContainers))
+	initContainers = append(initContainers, brokerConfig.InitContainers...)
 
 	initContainers = append(initContainers, []corev1.Container{
 		{
 			Name:    "cruise-control-reporter",
-			Image:   kafkaClusterSpec.CruiseControlConfig.GetCCImage(),
+			Image:   util.GetBrokerMetricsReporterImage(brokerConfig, kafkaClusterSpec),
 			Command: []string{"/bin/sh", "-cex", "cp -v /opt/cruise-control/cruise-control/build/dependant-libs/cruise-control-metrics-reporter.jar /opt/kafka/libs/extensions/cruise-control-metrics-reporter.jar"},
 			VolumeMounts: []corev1.VolumeMount{{
 				Name:      "extensions",

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -326,6 +326,14 @@ func GetBrokerImage(brokerConfig *v1beta1.BrokerConfig, clusterImage string) str
 	return clusterImage
 }
 
+// GetBrokerMetricsReporterImage returns the image used for cruise-control metrics reporter
+func GetBrokerMetricsReporterImage(brokerConfig *v1beta1.BrokerConfig, kafkaClusterSpec v1beta1.KafkaClusterSpec) string {
+	if brokerConfig.MetricsReporterImage != "" {
+		return brokerConfig.MetricsReporterImage
+	}
+	return kafkaClusterSpec.GetClusterMetricsReporterImage()
+}
+
 // getRandomString returns a random string containing uppercase, lowercase and number characters with the length given
 func GetRandomString(length int) (string, error) {
 	rand.Seed(time.Now().UnixNano())


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no|
| New feature?    | yes |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
Previously the same CruiseControl.Image field was used for both
cruise-control server image version but also kafka pod metrics reporter image



### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
In the case only the cruise-control server version needs to be updated
and avoid a kafka cluster rolling restart, `ClusterMetricsReporterImage` or `BrokerConfig.MetricsReporterImage` can be kept and only the CruiseControl.Image upgraded


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
