### PR TITLE
mark upscale alert as processed

### DIFF
--- a/internal/alertmanager/currentalert/process.go
+++ b/internal/alertmanager/currentalert/process.go
@@ -170,7 +170,9 @@ func (e *examiner) processAlert(ds disableScaling) (bool, error) {
 		if err != nil {
 			return false, err
 		}
-		//Used only for testing purposes
+		
+		return true, nil
+	//Used only for testing purposes
 	case "testing":
 		return true, nil
 	}

--- a/internal/alertmanager/currentalert/process.go
+++ b/internal/alertmanager/currentalert/process.go
@@ -170,7 +170,7 @@ func (e *examiner) processAlert(ds disableScaling) (bool, error) {
 		if err != nil {
 			return false, err
 		}
-		
+
 		return true, nil
 	//Used only for testing purposes
 	case "testing":


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
mark upscale alert as `processed` if no errors occurred during handling


### Why?
operator tries to upscale cluster every time even if alert already processed

### Checklist

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
