### PR TITLE
Remove unnecessary scheme parameter to be passed in ReconcilePKI

### DIFF
--- a/controllers/kafkacluster_controller.go
+++ b/controllers/kafkacluster_controller.go
@@ -28,7 +28,6 @@ import (
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -62,7 +61,6 @@ type KafkaClusterReconciler struct {
 	client.Client
 	DirectClient        client.Reader
 	Log                 logr.Logger
-	Scheme              *runtime.Scheme
 	Namespaces          []string
 	KafkaClientProvider kafkaclient.Provider
 }
@@ -121,7 +119,7 @@ func (r *KafkaClusterReconciler) Reconcile(ctx context.Context, request ctrl.Req
 		nodeportexternalaccess.New(r.Client, instance),
 		kafkamonitoring.New(r.Client, instance),
 		cruisecontrolmonitoring.New(r.Client, instance),
-		kafka.New(r.Client, r.DirectClient, r.Scheme, instance, r.KafkaClientProvider),
+		kafka.New(r.Client, r.DirectClient, instance, r.KafkaClientProvider),
 		cruisecontrol.New(r.Client, instance),
 	}
 

--- a/controllers/tests/suite_test.go
+++ b/controllers/tests/suite_test.go
@@ -150,7 +150,6 @@ var _ = BeforeSuite(func() {
 		Client:              mgr.GetClient(),
 		DirectClient:        mgr.GetAPIReader(),
 		Log:                 ctrl.Log.WithName("controllers").WithName("KafkaCluster"),
-		Scheme:              mgr.GetScheme(),
 		KafkaClientProvider: kafkaclient.NewMockProvider(),
 	}
 

--- a/main.go
+++ b/main.go
@@ -146,7 +146,6 @@ func main() {
 	kafkaClusterReconciler := &controllers.KafkaClusterReconciler{
 		Client:              mgr.GetClient(),
 		DirectClient:        mgr.GetAPIReader(),
-		Scheme:              mgr.GetScheme(),
 		Namespaces:          namespaceList,
 		Log:                 ctrl.Log.WithName("controllers").WithName("KafkaCluster"),
 		KafkaClientProvider: kafkaclient.NewDefaultProvider(),

--- a/pkg/pki/certmanagerpki/certmanager_pki_test.go
+++ b/pkg/pki/certmanagerpki/certmanager_pki_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/banzaicloud/koperator/api/v1alpha1"
@@ -110,7 +109,7 @@ func TestReconcilePKI(t *testing.T) {
 	if err := manager.client.Create(ctx, newServerSecret()); err != nil {
 		t.Error("error during server secret creation", reflect.TypeOf(err))
 	}
-	if err := manager.ReconcilePKI(ctx, log, scheme.Scheme, make(map[string]v1beta1.ListenerStatusList)); err != nil {
+	if err := manager.ReconcilePKI(ctx, log, make(map[string]v1beta1.ListenerStatusList)); err != nil {
 		if reflect.TypeOf(err) != reflect.TypeOf(errorfactory.ResourceNotReady{}) {
 			t.Error("Expected not ready error, got:", reflect.TypeOf(err))
 		}
@@ -119,7 +118,7 @@ func TestReconcilePKI(t *testing.T) {
 	if err := manager.client.Create(ctx, newControllerSecret()); err != nil {
 		t.Error("error during controller secret creation", reflect.TypeOf(err))
 	}
-	if err := manager.ReconcilePKI(ctx, log, scheme.Scheme, make(map[string]v1beta1.ListenerStatusList)); err != nil {
+	if err := manager.ReconcilePKI(ctx, log, make(map[string]v1beta1.ListenerStatusList)); err != nil {
 		if reflect.TypeOf(err) != reflect.TypeOf(errorfactory.ResourceNotReady{}) {
 			t.Error("Expected not ready error, got:", reflect.TypeOf(err))
 		}
@@ -128,7 +127,7 @@ func TestReconcilePKI(t *testing.T) {
 	if err := manager.client.Create(ctx, newCASecret()); err != nil {
 		t.Error("error during CA secret creation", reflect.TypeOf(err))
 	}
-	if err := manager.ReconcilePKI(ctx, log, scheme.Scheme, make(map[string]v1beta1.ListenerStatusList)); err != nil {
+	if err := manager.ReconcilePKI(ctx, log, make(map[string]v1beta1.ListenerStatusList)); err != nil {
 		t.Error("Expected successful reconcile, got:", err)
 	}
 
@@ -137,7 +136,7 @@ func TestReconcilePKI(t *testing.T) {
 	if err != nil {
 		t.Error("Expected no error during mocking the cluster, got:", err)
 	}
-	if err := manager.ReconcilePKI(ctx, log, scheme.Scheme, make(map[string]v1beta1.ListenerStatusList)); err == nil {
+	if err := manager.ReconcilePKI(ctx, log, make(map[string]v1beta1.ListenerStatusList)); err == nil {
 		t.Error("Expected error got nil")
 	} else if reflect.TypeOf(err) != reflect.TypeOf(errorfactory.ResourceNotReady{}) {
 		t.Error("Expected not ready error, got:", reflect.TypeOf(err))
@@ -145,7 +144,7 @@ func TestReconcilePKI(t *testing.T) {
 	if err := manager.client.Create(ctx, newPreCreatedSecret()); err != nil {
 		t.Error("error during pre created secret creation", reflect.TypeOf(err))
 	}
-	if err := manager.ReconcilePKI(ctx, log, scheme.Scheme, make(map[string]v1beta1.ListenerStatusList)); err != nil {
+	if err := manager.ReconcilePKI(ctx, log, make(map[string]v1beta1.ListenerStatusList)); err != nil {
 		t.Error("Expected successful reconcile, got:", err)
 	}
 }

--- a/pkg/pki/k8scsrpki/k8scsr_pki.go
+++ b/pkg/pki/k8scsrpki/k8scsr_pki.go
@@ -20,16 +20,13 @@ import (
 	"github.com/banzaicloud/koperator/api/v1beta1"
 
 	"github.com/go-logr/logr"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
-func (c *k8sCSR) ReconcilePKI(
-	ctx context.Context, logger logr.Logger, scheme *runtime.Scheme,
-	externalHostnames map[string]v1beta1.ListenerStatusList) error {
+func (c *k8sCSR) ReconcilePKI(_ context.Context, logger logr.Logger, _ map[string]v1beta1.ListenerStatusList) error {
 	logger.Info("k8sCSR PKI reconcile is skipped since it is not supported yet for server certs")
 	return nil
 }
 
-func (c *k8sCSR) FinalizePKI(ctx context.Context, logger logr.Logger) error {
+func (c *k8sCSR) FinalizePKI(_ context.Context, _ logr.Logger) error {
 	return nil
 }

--- a/pkg/pki/pki_manager.go
+++ b/pkg/pki/pki_manager.go
@@ -69,7 +69,7 @@ func newMockPKIManager(client client.Client, cluster *v1beta1.KafkaCluster) pki.
 	return &mockPKIManager{client: client, cluster: cluster}
 }
 
-func (m *mockPKIManager) ReconcilePKI(ctx context.Context, logger logr.Logger, scheme *runtime.Scheme, extListenerStatuses map[string]v1beta1.ListenerStatusList) error {
+func (m *mockPKIManager) ReconcilePKI(ctx context.Context, logger logr.Logger, extListenerStatuses map[string]v1beta1.ListenerStatusList) error {
 	return nil
 }
 

--- a/pkg/pki/pki_manager_test.go
+++ b/pkg/pki/pki_manager_test.go
@@ -60,7 +60,7 @@ func TestGetPKIManager(t *testing.T) {
 
 	// Test mock functions
 	var err error
-	if err = mock.ReconcilePKI(ctx, log, scheme.Scheme, make(map[string]v1beta1.ListenerStatusList)); err != nil {
+	if err = mock.ReconcilePKI(ctx, log, make(map[string]v1beta1.ListenerStatusList)); err != nil {
 		t.Error("Expected nil error got:", err)
 	}
 

--- a/pkg/resources/kafka/configmap_test.go
+++ b/pkg/resources/kafka/configmap_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	properties "github.com/banzaicloud/koperator/properties/pkg"
@@ -235,7 +234,6 @@ zookeeper.connect=example.zk:2181/`,
 
 		t.Run(test.testName, func(t *testing.T) {
 			r := Reconciler{
-				Scheme: scheme.Scheme,
 				Reconciler: resources.Reconciler{
 					KafkaCluster: &v1beta1.KafkaCluster{
 						ObjectMeta: metav1.ObjectMeta{

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -74,14 +74,12 @@ const (
 // Reconciler implements the Component Reconciler
 type Reconciler struct {
 	resources.Reconciler
-	Scheme              *runtime.Scheme
 	kafkaClientProvider kafkaclient.Provider
 }
 
 // New creates a new reconciler for Kafka
-func New(client client.Client, directClient client.Reader, scheme *runtime.Scheme, cluster *v1beta1.KafkaCluster, kafkaClientProvider kafkaclient.Provider) *Reconciler {
+func New(client client.Client, directClient client.Reader, cluster *v1beta1.KafkaCluster, kafkaClientProvider kafkaclient.Provider) *Reconciler {
 	return &Reconciler{
-		Scheme: scheme,
 		Reconciler: resources.Reconciler{
 			Client:       client,
 			DirectClient: directClient,
@@ -179,7 +177,7 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 	// Setup the PKI if using SSL
 	if r.KafkaCluster.Spec.ListenersConfig.SSLSecrets != nil {
 		// reconcile the PKI
-		if err := pki.GetPKIManager(r.Client, r.KafkaCluster, v1beta1.PKIBackendProvided, log).ReconcilePKI(context.TODO(), log, r.Scheme, extListenerStatuses); err != nil {
+		if err := pki.GetPKIManager(r.Client, r.KafkaCluster, v1beta1.PKIBackendProvided, log).ReconcilePKI(context.TODO(), log, extListenerStatuses); err != nil {
 			return err
 		}
 	}

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -27,7 +27,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/util/pki/common.go
+++ b/pkg/util/pki/common.go
@@ -65,7 +65,7 @@ type Manager interface {
 	// ReconcilePKI ensures a PKI for a kafka cluster - should be idempotent.
 	// This method should at least setup any issuer needed for user certificates
 	// as well as broker/cruise-control secrets
-	ReconcilePKI(ctx context.Context, logger logr.Logger, scheme *runtime.Scheme, externalHostnames map[string]v1beta1.ListenerStatusList) error
+	ReconcilePKI(ctx context.Context, logger logr.Logger, externalHostnames map[string]v1beta1.ListenerStatusList) error
 
 	// FinalizePKI performs any cleanup steps necessary for a PKI backend
 	FinalizePKI(ctx context.Context, logger logr.Logger) error


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no |
| New feature?    | no |
| API breaks?     | yes* |
| Deprecations?   | no |
| Related tickets | - |
| License         | Apache 2.0 |

\* breaks `Manager` internal interface in `common.go`

### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Remove the `scheme` argument to be passed along the call chain. It is not used semantically. 

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
To decrease complexity of the code.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
Neither of our PKI implementation is using that, so let's remove to simplify the code.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
