### PR TITLE
Bump chart version to prepare release v0.20.0

### DIFF
--- a/charts/kafka-operator/Chart.yaml
+++ b/charts/kafka-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kafka-operator
-version: 0.4.14
+version: 0.20.0
 description: kafka-operator manages Kafka deployments on Kubernetes
 sources:
   - https://github.com/banzaicloud/koperator
-appVersion: v0.19.0
+appVersion: v0.20.0


### PR DESCRIPTION
This PR prepares the new bugfix release v0.20.0.
We are ditching the old chart version name and bumping that as well to align with the koperator version.