### PR TITLE
Handle with priority new brokers and missing broker pods reconciliation

### DIFF
--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -960,12 +960,12 @@ func (r *Reconciler) determineControllerId() (int32, error) {
 	if err != nil {
 		return -1, errors.WrapIf(err, "could not create Kafka client, thus could not determine controller")
 	}
+	defer close()
+	
 	_, controllerID, err := kClient.DescribeCluster()
 	if err != nil {
 		return -1, errors.WrapIf(err, "could not find controller broker")
 	}
-
-	defer close()
 
 	return controllerID, nil
 }


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| Related to | #533 |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Handle with priority the reconciliation of new brokers and missing broker pods in order to ensure that new brokers are added to the cluster and missing broker pods are re-created as soon as possible.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Missing broker pods may result in offline partitions and not all replicas being in sync which in turn may case a rolling upgrade flow to stuck. By re-creating as soon as possible the missing broker pods the offline replicas error may disappear thus allowing the rolling upgrade to escape from the stuck state. In certain scenarios it may be needed to upscale the cluster to get it out from a bad state thus reconciling newly added brokers should have priority over others.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
