### PR TITLE
Fix wrong JKS password has been generated for KafkaUser

### DIFF
--- a/pkg/util/cert/certutil.go
+++ b/pkg/util/cert/certutil.go
@@ -206,13 +206,6 @@ func GenerateJKS(certs []*x509.Certificate, privateKey []byte) (out, passw []byt
 	}
 
 	password := GeneratePass(16)
-	//Zeroing password after this function for safety
-	defer func(s []byte) {
-		for i := 0; i < len(s); i++ {
-			s[i] = 0
-		}
-	}(password)
-
 	if err = jksKeyStore.SetPrivateKeyEntry("certs", pkeIn, password); err != nil {
 		return nil, nil, err
 	}

--- a/pkg/util/cert/certutil_test.go
+++ b/pkg/util/cert/certutil_test.go
@@ -22,6 +22,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/pavel-v-chernykh/keystore-go/v4"
+
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/banzaicloud/koperator/api/v1alpha1"
@@ -100,10 +102,16 @@ func TestGenerateJKS(t *testing.T) {
 	if err != nil {
 		t.Error("Failed to generate test certificate")
 	}
-	caCert := cert
 
-	if _, _, err = GenerateJKSFromByte(cert, key, caCert); err != nil {
+	caCert := cert
+	keyStoreBytes, password, err := GenerateJKSFromByte(cert, key, caCert)
+	if err != nil {
 		t.Error("Expected to generate JKS, got error:", err)
+	}
+	jksKeyStore := keystore.New()
+	keyStoreBytesReader := bytes.NewReader(keyStoreBytes)
+	if err = jksKeyStore.Load(keyStoreBytesReader, password); err != nil {
+		t.Error("Failed to generate keyStore from keyStore representation in bytes, probably due wrong pssword. Error: ", err)
 	}
 
 	badCACert := cert[:len(cert)-10]


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |

### What's in this PR?
Removes password override, because it clears the password too soon and the function returns with a wrong password.

### Why?
When KafkaUser custom resource has been created, koperator can create certs in JKS format into a secret. The koperator generates wrong password for that JKS.