### PR TITLE
Revert "Use local broker as bootstrap for cruisecontrol metrics repor…

### DIFF
--- a/controllers/tests/kafkacluster_controller_kafka_test.go
+++ b/controllers/tests/kafkacluster_controller_kafka_test.go
@@ -165,7 +165,7 @@ func expectKafkaBrokerConfigmap(kafkaCluster *v1beta1.KafkaCluster, broker v1bet
 	Expect(configMap.Data).To(HaveKeyWithValue("broker-config", fmt.Sprintf(`advertised.listeners=CONTROLLER://kafkacluster-%d-%d.kafka-%d.svc.cluster.local:29093,INTERNAL://kafkacluster-%d-%d.kafka-%d.svc.cluster.local:29092,TEST://test.host.com:%d
 broker.id=%d
 control.plane.listener.name=CONTROLLER
-cruise.control.metrics.reporter.bootstrap.servers=localhost:29092
+cruise.control.metrics.reporter.bootstrap.servers=kafkacluster-1-all-broker.kafka-1.svc.cluster.local:29092
 cruise.control.metrics.reporter.kubernetes.mode=true
 inter.broker.listener.name=INTERNAL
 listener.security.protocol.map=INTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT,TEST:PLAINTEXT

--- a/pkg/resources/kafka/configmap.go
+++ b/pkg/resources/kafka/configmap.go
@@ -102,11 +102,11 @@ func (r *Reconciler) getConfigProperties(bConfig *v1beta1.BrokerConfig, id int32
 	if err := config.Set("metric.reporters", "com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter"); err != nil {
 		log.Error(err, "setting metric.reporters in broker configuration resulted an error")
 	}
-	brokerPort, err := kafkautils.GetBrokerContainerPort(r.KafkaCluster)
+	bootstrapServers, err := kafkautils.GetBootstrapServersService(r.KafkaCluster)
 	if err != nil {
-		log.Error(err, "getting Kafka broker port for Cruise Control failed")
+		log.Error(err, "getting Kafka bootstrap servers for Cruise Control failed")
 	}
-	if err := config.Set("cruise.control.metrics.reporter.bootstrap.servers", fmt.Sprintf("localhost:%d", brokerPort)); err != nil {
+	if err := config.Set("cruise.control.metrics.reporter.bootstrap.servers", bootstrapServers); err != nil {
 		log.Error(err, "setting cruise.control.metrics.reporter.bootstrap.servers in broker configuration resulted an error")
 	}
 	if err := config.Set("cruise.control.metrics.reporter.kubernetes.mode", true); err != nil {

--- a/pkg/resources/kafka/configmap_test.go
+++ b/pkg/resources/kafka/configmap_test.go
@@ -54,7 +54,7 @@ func TestGenerateBrokerConfig(t *testing.T) {
 			listenerType:              "plaintext",
 			expectedConfig: `advertised.listeners=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
 broker.id=0
-cruise.control.metrics.reporter.bootstrap.servers=localhost:9092
+cruise.control.metrics.reporter.bootstrap.servers=kafka-all-broker.kafka.svc.cluster.local:9092
 cruise.control.metrics.reporter.kubernetes.mode=true
 inter.broker.listener.name=INTERNAL
 listener.security.protocol.map=INTERNAL:PLAINTEXT
@@ -75,7 +75,7 @@ zookeeper.connect=example.zk:2181/`,
 			listenerType:              "plaintext",
 			expectedConfig: `advertised.listeners=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
 broker.id=0
-cruise.control.metrics.reporter.bootstrap.servers=localhost:9092
+cruise.control.metrics.reporter.bootstrap.servers=kafka-all-broker.kafka.svc.cluster.local:9092
 cruise.control.metrics.reporter.kubernetes.mode=true
 inter.broker.listener.name=INTERNAL
 listener.security.protocol.map=INTERNAL:PLAINTEXT
@@ -96,7 +96,7 @@ zookeeper.connect=example.zk:2181/kafka`,
 			listenerType:              "plaintext",
 			expectedConfig: `advertised.listeners=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
 broker.id=0
-cruise.control.metrics.reporter.bootstrap.servers=localhost:9092
+cruise.control.metrics.reporter.bootstrap.servers=kafka-all-broker.kafka.svc.cluster.local:9092
 cruise.control.metrics.reporter.kubernetes.mode=true
 inter.broker.listener.name=INTERNAL
 listener.security.protocol.map=INTERNAL:PLAINTEXT
@@ -117,7 +117,7 @@ zookeeper.connect=example.zk:2181/`,
 			listenerType:              "plaintext",
 			expectedConfig: `advertised.listeners=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
 broker.id=0
-cruise.control.metrics.reporter.bootstrap.servers=localhost:9092
+cruise.control.metrics.reporter.bootstrap.servers=kafka-all-broker.kafka.svc.cluster.local:9092
 cruise.control.metrics.reporter.kubernetes.mode=true
 inter.broker.listener.name=INTERNAL
 listener.security.protocol.map=INTERNAL:PLAINTEXT
@@ -143,7 +143,7 @@ zookeeper.connect=example.zk:2181,example.zk-1:2181/kafka`,
 			listenerType:              "plaintext",
 			expectedConfig: `advertised.listeners=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
 broker.id=0
-cruise.control.metrics.reporter.bootstrap.servers=localhost:9092
+cruise.control.metrics.reporter.bootstrap.servers=kafka-all-broker.kafka.svc.cluster.local:9092
 cruise.control.metrics.reporter.kubernetes.mode=true
 inter.broker.listener.name=INTERNAL
 listener.security.protocol.map=INTERNAL:PLAINTEXT
@@ -165,7 +165,7 @@ zookeeper.connect=example.zk:2181/`,
 			listenerType:              "plaintext",
 			expectedConfig: `advertised.listeners=INTERNAL://kafka-0.kafka.svc.foo.bar:9092
 broker.id=0
-cruise.control.metrics.reporter.bootstrap.servers=localhost:9092
+cruise.control.metrics.reporter.bootstrap.servers=kafka-all-broker.kafka.svc.foo.bar:9092
 cruise.control.metrics.reporter.kubernetes.mode=true
 inter.broker.listener.name=INTERNAL
 listener.security.protocol.map=INTERNAL:PLAINTEXT
@@ -196,7 +196,7 @@ auto.create.topics.enable=true
 auto.create.topics.enable=true
 broker.id=0
 control.plane.listener.name=thisisatest
-cruise.control.metrics.reporter.bootstrap.servers=localhost:9092
+cruise.control.metrics.reporter.bootstrap.servers=kafka-all-broker.kafka.svc.cluster.local:9092
 cruise.control.metrics.reporter.kubernetes.mode=true
 inter.broker.listener.name=INTERNAL
 listener.security.protocol.map=INTERNAL:PLAINTEXT
@@ -217,7 +217,7 @@ zookeeper.connect=example.zk:2181/`,
 			listenerType:              "sasl_plaintext",
 			expectedConfig: `advertised.listeners=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
 broker.id=0
-cruise.control.metrics.reporter.bootstrap.servers=localhost:9092
+cruise.control.metrics.reporter.bootstrap.servers=kafka-all-broker.kafka.svc.cluster.local:9092
 cruise.control.metrics.reporter.kubernetes.mode=true
 inter.broker.listener.name=INTERNAL
 listener.security.protocol.map=INTERNAL:SASL_PLAINTEXT


### PR DESCRIPTION
This PR reverts https://github.com/banzaicloud/koperator/pull/677 since it breaks the ability to turn in ssl on the internal broker communication