### PR TITLE
Use the number of distinct brokers with offline partition or out of sync replicas as error count during rolling upgrade

### DIFF
--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -104,7 +104,7 @@ type RollingUpgradeStatus struct {
 
 // RollingUpgradeConfig defines the desired config of the RollingUpgrade
 type RollingUpgradeConfig struct {
-	// FailureThreshold controls how many failures can the cluster tolerate during a rolling upgrade. Once the number of
+	// FailureThreshold controls how many failures the cluster can tolerate during a rolling upgrade. Once the number of
 	// failures reaches this threshold a rolling upgrade flow stops. The number of failures is computed as the sum of
 	// distinct broker replicas with either offline replicas or out of sync replicas and the number of alerts triggered by
 	// alerts with 'rollingupgrade'

--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -97,11 +97,17 @@ type KafkaClusterStatus struct {
 // RollingUpgradeStatus defines status of rolling upgrade
 type RollingUpgradeStatus struct {
 	LastSuccess string `json:"lastSuccess"`
-	ErrorCount  int    `json:"errorCount"`
+	// ErrorCount keeps track the number of errors reported by alerts labeled with 'rollingupgrade'.
+	// It's reset once these alerts stop firing.
+	ErrorCount int `json:"errorCount"`
 }
 
 // RollingUpgradeConfig defines the desired config of the RollingUpgrade
 type RollingUpgradeConfig struct {
+	// FailureThreshold controls how many failures can the cluster tolerate during a rolling upgrade. Once the number of
+	// failures reaches this threshold a rolling upgrade flow stops. The number of failures is computed as the sum of
+	// distinct broker replicas with either offline replicas or out of sync replicas and the number of alerts triggered by
+	// alerts with 'rollingupgrade'
 	FailureThreshold int `json:"failureThreshold"`
 }
 

--- a/charts/kafka-operator/templates/crds.yaml
+++ b/charts/kafka-operator/templates/crds.yaml
@@ -18553,12 +18553,12 @@ spec:
                   RollingUpgrade
                 properties:
                   failureThreshold:
-                    description: FailureThreshold controls how many failures can the
-                      cluster tolerate during a rolling upgrade. Once the number of
-                      failures reaches this threshold a rolling upgrade flow stops.
-                      The number of failures is computed as the sum of distinct broker
-                      replicas with either offline replicas or out of sync replicas
-                      and the number of alerts triggered by alerts with 'rollingupgrade'
+                    description: FailureThreshold controls how many failures the cluster
+                      can tolerate during a rolling upgrade. Once the number of failures
+                      reaches this threshold a rolling upgrade flow stops. The number
+                      of failures is computed as the sum of distinct broker replicas
+                      with either offline replicas or out of sync replicas and the
+                      number of alerts triggered by alerts with 'rollingupgrade'
                     type: integer
                 required:
                 - failureThreshold

--- a/charts/kafka-operator/templates/crds.yaml
+++ b/charts/kafka-operator/templates/crds.yaml
@@ -18553,6 +18553,12 @@ spec:
                   RollingUpgrade
                 properties:
                   failureThreshold:
+                    description: FailureThreshold controls how many failures can the
+                      cluster tolerate during a rolling upgrade. Once the number of
+                      failures reaches this threshold a rolling upgrade flow stops.
+                      The number of failures is computed as the sum of distinct broker
+                      replicas with either offline replicas or out of sync replicas
+                      and the number of alerts triggered by alerts with 'rollingupgrade'
                     type: integer
                 required:
                 - failureThreshold
@@ -18720,6 +18726,9 @@ spec:
                 description: RollingUpgradeStatus defines status of rolling upgrade
                 properties:
                   errorCount:
+                    description: ErrorCount keeps track the number of errors reported
+                      by alerts labeled with 'rollingupgrade'. It's reset once these
+                      alerts stop firing.
                     type: integer
                   lastSuccess:
                     type: string

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -18552,12 +18552,12 @@ spec:
                   RollingUpgrade
                 properties:
                   failureThreshold:
-                    description: FailureThreshold controls how many failures can the
-                      cluster tolerate during a rolling upgrade. Once the number of
-                      failures reaches this threshold a rolling upgrade flow stops.
-                      The number of failures is computed as the sum of distinct broker
-                      replicas with either offline replicas or out of sync replicas
-                      and the number of alerts triggered by alerts with 'rollingupgrade'
+                    description: FailureThreshold controls how many failures the cluster
+                      can tolerate during a rolling upgrade. Once the number of failures
+                      reaches this threshold a rolling upgrade flow stops. The number
+                      of failures is computed as the sum of distinct broker replicas
+                      with either offline replicas or out of sync replicas and the
+                      number of alerts triggered by alerts with 'rollingupgrade'
                     type: integer
                 required:
                 - failureThreshold

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -18552,6 +18552,12 @@ spec:
                   RollingUpgrade
                 properties:
                   failureThreshold:
+                    description: FailureThreshold controls how many failures can the
+                      cluster tolerate during a rolling upgrade. Once the number of
+                      failures reaches this threshold a rolling upgrade flow stops.
+                      The number of failures is computed as the sum of distinct broker
+                      replicas with either offline replicas or out of sync replicas
+                      and the number of alerts triggered by alerts with 'rollingupgrade'
                     type: integer
                 required:
                 - failureThreshold
@@ -18719,6 +18725,9 @@ spec:
                 description: RollingUpgradeStatus defines status of rolling upgrade
                 properties:
                   errorCount:
+                    description: ErrorCount keeps track the number of errors reported
+                      by alerts labeled with 'rollingupgrade'. It's reset once these
+                      alerts stop firing.
                     type: integer
                   lastSuccess:
                     type: string

--- a/config/samples/banzaicloud_v1beta1_kafkacluster.yaml
+++ b/config/samples/banzaicloud_v1beta1_kafkacluster.yaml
@@ -39,7 +39,10 @@ spec:
   # brokerConfigGroups specifies multiple broker configs with unique name
   #rollingUpgradeConfig specifies the rolling upgrade config for the cluster
   #rollingUpgradeConfig:
-  #failureThreshold states that how many errors can the cluster tolerate during rolling upgrade
+  #failureThreshold controls how many failures can the cluster tolerate during a rolling upgrade. Once the number of
+  # failures reaches this threshold a rolling upgrade flow stops. The number of failures is computed as the sum of
+  #	distinct broker replicas with either offline replicas or out of sync replicas and the number of alerts triggered by
+  #	alerts with 'rollingupgrade'
   #  failureThreshold: 1
   brokerConfigGroups:
     # Specify desired group name (eg., 'default_group')

--- a/config/samples/banzaicloud_v1beta1_kafkacluster.yaml
+++ b/config/samples/banzaicloud_v1beta1_kafkacluster.yaml
@@ -39,7 +39,7 @@ spec:
   # brokerConfigGroups specifies multiple broker configs with unique name
   #rollingUpgradeConfig specifies the rolling upgrade config for the cluster
   #rollingUpgradeConfig:
-  #failureThreshold controls how many failures can the cluster tolerate during a rolling upgrade. Once the number of
+  #failureThreshold controls how many failures the cluster can tolerate during a rolling upgrade. Once the number of
   # failures reaches this threshold a rolling upgrade flow stops. The number of failures is computed as the sum of
   #	distinct broker replicas with either offline replicas or out of sync replicas and the number of alerts triggered by
   #	alerts with 'rollingupgrade'

--- a/internal/alertmanager/currentalert/process.go
+++ b/internal/alertmanager/currentalert/process.go
@@ -97,7 +97,7 @@ func (e *examiner) examineAlert(rollingUpgradeAlertCount int) (bool, error) {
 		return false, errors.New("kafkaCR is nil")
 	}
 
-	if err := k8sutil.UpdateCrWithRollingUpgrade(rollingUpgradeAlertCount, cr, e.Client); err != nil {
+	if err := k8sutil.UpdateCrWithRollingUpgrade(rollingUpgradeAlertCount, cr, e.Client, e.Log); err != nil {
 		return false, err
 	}
 

--- a/pkg/k8sutil/cr.go
+++ b/pkg/k8sutil/cr.go
@@ -22,12 +22,15 @@ import (
 	"strings"
 
 	"emperror.dev/errors"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
-	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-logr/logr"
 
 	"github.com/banzaicloud/koperator/api/v1beta1"
 	"github.com/banzaicloud/koperator/pkg/errorfactory"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // UpdateCrWithRackAwarenessConfig updates the CR with rack awareness config
@@ -145,7 +148,8 @@ func UpdateCr(cr *v1beta1.KafkaCluster, client runtimeClient.Client) error {
 }
 
 // UpdateCrWithRollingUpgrade modifies CR status
-func UpdateCrWithRollingUpgrade(errorCount int, cr *v1beta1.KafkaCluster, client runtimeClient.Client) error {
+func UpdateCrWithRollingUpgrade(errorCount int, cr *v1beta1.KafkaCluster, client runtimeClient.Client, logger logr.Logger) error {
 	cr.Status.RollingUpgrade.ErrorCount = errorCount
-	return UpdateCr(cr, client)
+
+	return UpdateCRStatus(client, cr, nil, logger)
 }

--- a/pkg/kafkaclient/client.go
+++ b/pkg/kafkaclient/client.go
@@ -46,8 +46,11 @@ type KafkaClient interface {
 	Brokers() map[int32]string
 	DescribeCluster() ([]*sarama.Broker, int32, error)
 
-	OfflineReplicaCount() (int, error)
-	AllReplicaInSync() (bool, error)
+	// AllOfflineReplicas returns the list of unique offline replica (broker) ids
+	AllOfflineReplicas() ([]int32, error)
+
+	// OutOfSyncReplicas returns the list of unique out of sync replica (broker) ids
+	OutOfSyncReplicas() ([]int32, error)
 
 	AlterPerBrokerConfig(int32, map[string]*string, bool) error
 	DescribePerBrokerConfig(int32, []string) ([]*sarama.ConfigEntry, error)


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | yes |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | fixes #695 |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
The number of failures during a rolling upgrade is is computed as the sum of distinct broker replicas with either offline replicas or out of sync replicas and the number of alerts triggered by alerts with 'rollingupgrade'

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
The current implementation doesn't honor failureThreshold that is greater than 1, only when there is a 'rollingupgrade' alert firing that increases the error count during rolling upgrade.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] User guide and development docs updated (if needed)

