### PR TITLE
Prevent creation of multiple KafkaTopics referencing the same Kafka topic

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"os"
 	"strings"
@@ -49,6 +50,7 @@ import (
 	banzaicloudv1alpha1 "github.com/banzaicloud/koperator/api/v1alpha1"
 	banzaicloudv1beta1 "github.com/banzaicloud/koperator/api/v1beta1"
 	"github.com/banzaicloud/koperator/controllers"
+	"github.com/banzaicloud/koperator/pkg/k8sutil"
 	"github.com/banzaicloud/koperator/pkg/kafkaclient"
 	"github.com/banzaicloud/koperator/pkg/util"
 	"github.com/banzaicloud/koperator/pkg/webhook"
@@ -117,6 +119,11 @@ func main() {
 			namespaceList[i] = strings.TrimSpace(namespaceList[i])
 		}
 		managerWatchCache = cache.MultiNamespacedCacheBuilder(namespaceList)
+	}
+	ctx := context.TODO()
+	if !webhookDisabled {
+		// we need to add indexers to KafkaTopics so that the KafkaTopic admission webhooks could work
+		managerWatchCache = k8sutil.AddKafkaTopicIndexers(ctx, managerWatchCache)
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{

--- a/pkg/k8sutil/cache.go
+++ b/pkg/k8sutil/cache.go
@@ -1,0 +1,63 @@
+// Copyright © 2021 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sutil
+
+import (
+	"context"
+
+	"emperror.dev/errors"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/banzaicloud/koperator/api/v1alpha1"
+)
+
+func AddKafkaTopicIndexers(ctx context.Context, cacheFunc cache.NewCacheFunc) cache.NewCacheFunc {
+	if cacheFunc == nil {
+		cacheFunc = cache.New
+	}
+	return func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
+		newCache, err := cacheFunc(config, opts)
+		if err != nil {
+			return nil, err
+		}
+
+		nameIndexFunc := func(obj client.Object) []string {
+			return []string{obj.(*v1alpha1.KafkaTopic).Spec.Name}
+		}
+		err = newCache.IndexField(ctx, &v1alpha1.KafkaTopic{}, "spec.name", nameIndexFunc)
+		if err != nil {
+			return nil, errors.WrapIfWithDetails(err, "could not setup indexer for field", "field", "spec.name")
+		}
+
+		clusterNameIndexFunc := func(obj client.Object) []string {
+			return []string{obj.(*v1alpha1.KafkaTopic).Spec.ClusterRef.Name}
+		}
+		err = newCache.IndexField(ctx, &v1alpha1.KafkaTopic{}, "spec.clusterRef.name", clusterNameIndexFunc)
+		if err != nil {
+			return nil, errors.WrapIfWithDetails(err, "could not setup indexer for field", "field", "spec.clusterRef.name")
+		}
+
+		clusterNamespaceIndexFunc := func(obj client.Object) []string {
+			return []string{obj.(*v1alpha1.KafkaTopic).Spec.ClusterRef.Namespace}
+		}
+		err = newCache.IndexField(ctx, &v1alpha1.KafkaTopic{}, "spec.clusterRef.namespace", clusterNamespaceIndexFunc)
+		if err != nil {
+			return nil, errors.WrapIfWithDetails(err, "could not setup indexer for field", "field", "spec.clusterRef.namespace")
+		}
+		return newCache, nil
+	}
+}

--- a/pkg/k8sutil/cache.go
+++ b/pkg/k8sutil/cache.go
@@ -25,12 +25,9 @@ import (
 	"github.com/banzaicloud/koperator/api/v1alpha1"
 )
 
-func AddKafkaTopicIndexers(ctx context.Context, cacheFunc cache.NewCacheFunc) cache.NewCacheFunc {
-	if cacheFunc == nil {
-		cacheFunc = cache.New
-	}
+func AddKafkaTopicIndexers(ctx context.Context) cache.NewCacheFunc {
 	return func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
-		newCache, err := cacheFunc(config, opts)
+		newCache, err := cache.New(config, opts)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/webhook/topic_validator.go
+++ b/pkg/webhook/topic_validator.go
@@ -39,11 +39,11 @@ func (s *webhookServer) validateKafkaTopic(topic *banzaicloudv1alpha1.KafkaTopic
 	ctx := context.TODO()
 	log.Info(fmt.Sprintf("Doing pre-admission validation of kafka topic %s", topic.Spec.Name))
 
-	// Get the referenced kafkacluster
+	// Get the referenced KafkaCluster
 	clusterName := topic.Spec.ClusterRef.Name
 	clusterNamespace := topic.Spec.ClusterRef.Namespace
 	if clusterNamespace == "" {
-		clusterNamespace = topic.Namespace
+		clusterNamespace = topic.GetNamespace()
 	}
 	var cluster *banzaicloudv1beta1.KafkaCluster
 	var err error
@@ -170,12 +170,12 @@ func (s *webhookServer) checkExistingKafkaTopicCRs(ctx context.Context,
 	var foundKafkaTopic *banzaicloudv1alpha1.KafkaTopic
 	for i, kafkaTopic := range kafkaTopicList.Items {
 		// filter the cr under admission
-		if kafkaTopic.Name == topic.Name && kafkaTopic.Namespace == topic.Namespace {
+		if kafkaTopic.GetName() == topic.GetName() && kafkaTopic.GetNamespace() == topic.GetNamespace() {
 			continue
 		}
 
 		referredNamespace := kafkaTopic.Spec.ClusterRef.Namespace
-		if (kafkaTopic.Namespace == topic.Namespace && referredNamespace == "") || referredNamespace == clusterNamespace {
+		if (kafkaTopic.GetNamespace() == clusterNamespace && referredNamespace == "") || referredNamespace == clusterNamespace {
 			foundKafkaTopic = &kafkaTopicList.Items[i]
 			break
 		}

--- a/pkg/webhook/topic_validator.go
+++ b/pkg/webhook/topic_validator.go
@@ -21,7 +21,9 @@ import (
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	banzaicloudv1alpha1 "github.com/banzaicloud/koperator/api/v1alpha1"
 	banzaicloudv1beta1 "github.com/banzaicloud/koperator/api/v1beta1"
@@ -33,10 +35,12 @@ const (
 	invalidReplicationFactorErrMsg = "Replication factor is larger than the number of nodes in the kafka cluster"
 )
 
-func (s *webhookServer) validateKafkaTopic(topic *banzaicloudv1alpha1.KafkaTopic) (res *admissionv1beta1.AdmissionResponse) {
+func (s *webhookServer) validateKafkaTopic(topic *banzaicloudv1alpha1.KafkaTopic) *admissionv1beta1.AdmissionResponse {
+	ctx := context.TODO()
 	log.Info(fmt.Sprintf("Doing pre-admission validation of kafka topic %s", topic.Spec.Name))
 
 	// Get the referenced kafkacluster
+	clusterName := topic.Spec.ClusterRef.Name
 	clusterNamespace := topic.Spec.ClusterRef.Namespace
 	if clusterNamespace == "" {
 		clusterNamespace = topic.Namespace
@@ -45,7 +49,7 @@ func (s *webhookServer) validateKafkaTopic(topic *banzaicloudv1alpha1.KafkaTopic
 	var err error
 
 	// Check if the cluster being referenced actually exists
-	if cluster, err = k8sutil.LookupKafkaCluster(s.client, topic.Spec.ClusterRef.Name, clusterNamespace); err != nil {
+	if cluster, err = k8sutil.LookupKafkaCluster(s.client, clusterName, clusterNamespace); err != nil {
 		if apierrors.IsNotFound(err) {
 			if k8sutil.IsMarkedForDeletion(topic.ObjectMeta) {
 				log.Info("Deleted as a result of a cluster deletion")
@@ -72,14 +76,34 @@ func (s *webhookServer) validateKafkaTopic(topic *banzaicloudv1alpha1.KafkaTopic
 		}
 	}
 
+	res := s.checkExistingKafkaTopicCRs(ctx, clusterNamespace, topic)
+	if res != nil {
+		return res
+	}
+
+	res = s.checkKafka(ctx, topic, cluster)
+	if res != nil {
+		return res
+	}
+
+	// everything looks a-okay
+	return &admissionv1beta1.AdmissionResponse{
+		Allowed: true,
+	}
+}
+
+// checkKafka creates a Kafka admin client and connects to the Kafka brokers to check
+// whether the referred topic exists, and what are its properties
+func (s *webhookServer) checkKafka(ctx context.Context, topic *banzaicloudv1alpha1.KafkaTopic,
+	cluster *banzaicloudv1beta1.KafkaCluster) *admissionv1beta1.AdmissionResponse {
 	// retrieve an admin client for the cluster
-	broker, close, err := s.newKafkaFromCluster(s.client, cluster)
+	broker, closeClient, err := s.newKafkaFromCluster(s.client, cluster)
 	if err != nil {
 		// Log as info to not cause stack traces when making CC topic
 		log.Info(cantConnectErrorMsg, "error", err.Error())
 		return notAllowed(fmt.Sprintf("%s: %s", cantConnectErrorMsg, topic.Spec.ClusterRef.Name), metav1.StatusReasonServiceUnavailable)
 	}
-	defer close()
+	defer closeClient()
 
 	existing, err := broker.GetTopic(topic.Spec.Name)
 	if err != nil {
@@ -91,7 +115,7 @@ func (s *webhookServer) validateKafkaTopic(topic *banzaicloudv1alpha1.KafkaTopic
 	if existing != nil {
 		// Check if this is the correct CR for this topic
 		topicCR := &banzaicloudv1alpha1.KafkaTopic{}
-		if err := s.client.Get(context.TODO(), types.NamespacedName{Name: topic.Name, Namespace: topic.Namespace}, topicCR); err != nil {
+		if err := s.client.Get(ctx, types.NamespacedName{Name: topic.Name, Namespace: topic.Namespace}, topicCR); err != nil {
 			if apierrors.IsNotFound(err) {
 				// User is trying to overwrite an existing topic - bad user
 				log.Info("User attempted to create topic with name that already exists in the kafka cluster")
@@ -121,9 +145,65 @@ func (s *webhookServer) validateKafkaTopic(topic *banzaicloudv1alpha1.KafkaTopic
 		log.Info(fmt.Sprintf("Spec is requesting replication factor of %v, larger than cluster size of %v", topic.Spec.ReplicationFactor, broker.NumBrokers()))
 		return notAllowed(invalidReplicationFactorErrMsg, metav1.StatusReasonBadRequest)
 	}
+	return nil
+}
 
-	// everything looks a-okay
-	return &admissionv1beta1.AdmissionResponse{
-		Allowed: true,
+// checkExistingKafkaTopicCRs checks whether there's any other duplicate KafkaTopic CR exists
+// that refers to the same KafkaCluster's same topic
+func (s *webhookServer) checkExistingKafkaTopicCRs(ctx context.Context,
+	clusterNamespace string, topic *banzaicloudv1alpha1.KafkaTopic) *admissionv1beta1.AdmissionResponse {
+	// check KafkaTopic in the referred KafkaCluster's namespace
+	kafkaTopicList := banzaicloudv1alpha1.KafkaTopicList{}
+	err := s.client.List(ctx, &kafkaTopicList,
+		client.InNamespace(clusterNamespace),
+		client.MatchingFieldsSelector{
+			Selector: fields.OneTermEqualSelector("spec.name", topic.Spec.Name),
+		},
+		client.MatchingFieldsSelector{
+			Selector: fields.OneTermEqualSelector("spec.clusterRef.name", topic.Spec.ClusterRef.Name),
+		},
+	)
+	if err != nil {
+		log.Info("failed to list KafkaTopics")
+		return notAllowed("API failure while retrieving KafkaTopic list, please try again", metav1.StatusReasonServiceUnavailable)
 	}
+	var foundKafkaTopic *banzaicloudv1alpha1.KafkaTopic
+	for i, kafkaTopic := range kafkaTopicList.Items {
+		referredNamespace := kafkaTopic.Spec.ClusterRef.Namespace
+		if referredNamespace == "" || referredNamespace == clusterNamespace {
+			foundKafkaTopic = &kafkaTopicList.Items[i]
+		}
+	}
+	if foundKafkaTopic != nil {
+		msg := fmt.Sprintf("KafkaTopic CR '%s' in namesapce '%s' is already referencing Kafka topic '%s'",
+			foundKafkaTopic.Name, foundKafkaTopic.Namespace, foundKafkaTopic.Spec.Name)
+		log.Info(msg)
+		return notAllowed(msg, metav1.StatusReasonInvalid)
+	}
+
+	// check KafkaTopic in every namespace
+	kafkaTopicList = banzaicloudv1alpha1.KafkaTopicList{}
+	err = s.client.List(ctx, &kafkaTopicList,
+		client.MatchingFieldsSelector{
+			Selector: fields.OneTermEqualSelector("spec.name", topic.Spec.Name),
+		},
+		client.MatchingFieldsSelector{
+			Selector: fields.OneTermEqualSelector("spec.clusterRef.name", topic.Spec.ClusterRef.Name),
+		},
+		client.MatchingFieldsSelector{
+			Selector: fields.OneTermEqualSelector("spec.clusterRef.namespace", topic.Spec.ClusterRef.Namespace),
+		},
+	)
+	if err != nil {
+		log.Info("failed to list KafkaTopics")
+		return notAllowed("API failure while retrieving KafkaTopic list, please try again", metav1.StatusReasonServiceUnavailable)
+	}
+	if len(kafkaTopicList.Items) > 0 {
+		kafkaTopic := kafkaTopicList.Items[0]
+		msg := fmt.Sprintf("KafkaTopic CR '%s' in namesapce '%s' is already referencing Kafka topic '%s'",
+			kafkaTopic.Name, kafkaTopic.Namespace, kafkaTopic.Spec.Name)
+		return notAllowed(msg, metav1.StatusReasonInvalid)
+	}
+
+	return nil
 }


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | fixes #715 |
| License         | Apache 2.0 |

### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Additional checks in the `KafkaTopic` admission webhook that prevents from multiple `KafkaTopic` CRs from being created referencing the same `KafkaCluster`'s same Kafka topic.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
This could create infinite cycles if two CRs are created with these details but with different configuration.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
Tested by attempting to create topics with the properties above.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline