### PR TITLE
Pass DNS fields to the CSR if specified in the KafkaUserSpec

### DIFF
--- a/controllers/tests/kafkauser_controller_test.go
+++ b/controllers/tests/kafkauser_controller_test.go
@@ -239,6 +239,7 @@ var _ = Describe("KafkaTopic", func() {
 					PKIBackend: string(v1beta1.PKIBackendK8sCSR),
 					SignerName: "foo.bar/foobar",
 				},
+				DNSNames: []string{"subdomain.example.com"},
 			},
 		}
 		err := k8sClient.Create(context.Background(), &user)

--- a/controllers/tests/kafkauser_controller_test.go
+++ b/controllers/tests/kafkauser_controller_test.go
@@ -239,7 +239,6 @@ var _ = Describe("KafkaTopic", func() {
 					PKIBackend: string(v1beta1.PKIBackendK8sCSR),
 					SignerName: "foo.bar/foobar",
 				},
-				DNSNames: []string{"subdomain.example.com"},
 			},
 		}
 		err := k8sClient.Create(context.Background(), &user)

--- a/pkg/pki/k8scsrpki/k8scsr_test.go
+++ b/pkg/pki/k8scsrpki/k8scsr_test.go
@@ -29,22 +29,26 @@ type mockClient struct {
 }
 
 func newMockCluster() *v1beta1.KafkaCluster {
-	cluster := &v1beta1.KafkaCluster{}
-	cluster.Name = "test"
-	cluster.Namespace = "test-namespace"
-	cluster.Spec = v1beta1.KafkaClusterSpec{}
-	cluster.Spec.ListenersConfig = v1beta1.ListenersConfig{}
-	cluster.Spec.ListenersConfig.InternalListeners = []v1beta1.InternalListenerConfig{
-		{
-			CommonListenerSpec: v1beta1.CommonListenerSpec{
-				ContainerPort: 9092,
+	return &v1beta1.KafkaCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test-namespace",
+		},
+		Spec: v1beta1.KafkaClusterSpec{
+			ListenersConfig: v1beta1.ListenersConfig{
+				InternalListeners: []v1beta1.InternalListenerConfig{
+					{
+						CommonListenerSpec: v1beta1.CommonListenerSpec{
+							ContainerPort: 9092,
+						},
+					},
+				},
+				SSLSecrets: &v1beta1.SSLSecrets{
+					PKIBackend: v1beta1.PKIBackendK8sCSR,
+				},
 			},
 		},
 	}
-	cluster.Spec.ListenersConfig.SSLSecrets = &v1beta1.SSLSecrets{
-		PKIBackend: v1beta1.PKIBackendK8sCSR,
-	}
-	return cluster
 }
 
 func TestNew(t *testing.T) {

--- a/pkg/pki/k8scsrpki/k8scsr_test.go
+++ b/pkg/pki/k8scsrpki/k8scsr_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 

--- a/pkg/pki/k8scsrpki/k8scsr_test.go
+++ b/pkg/pki/k8scsrpki/k8scsr_test.go
@@ -1,0 +1,55 @@
+// Copyright © 2021 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8scsrpki
+
+import (
+	"reflect"
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/banzaicloud/koperator/api/v1beta1"
+)
+
+type mockClient struct {
+	client.Client
+}
+
+func newMockCluster() *v1beta1.KafkaCluster {
+	cluster := &v1beta1.KafkaCluster{}
+	cluster.Name = "test"
+	cluster.Namespace = "test-namespace"
+	cluster.Spec = v1beta1.KafkaClusterSpec{}
+	cluster.Spec.ListenersConfig = v1beta1.ListenersConfig{}
+	cluster.Spec.ListenersConfig.InternalListeners = []v1beta1.InternalListenerConfig{
+		{
+			CommonListenerSpec: v1beta1.CommonListenerSpec{
+				ContainerPort: 9092,
+			},
+		},
+	}
+	cluster.Spec.ListenersConfig.SSLSecrets = &v1beta1.SSLSecrets{
+		PKIBackend: v1beta1.PKIBackendK8sCSR,
+	}
+	return cluster
+}
+
+func TestNew(t *testing.T) {
+	pkiManager := New(&mockClient{}, newMockCluster(), log.Log)
+	if reflect.TypeOf(pkiManager) != reflect.TypeOf(&k8sCSR{}) {
+		t.Error("Expected new k8sCSR from New, got:", reflect.TypeOf(pkiManager))
+	}
+}

--- a/pkg/pki/k8scsrpki/k8scsr_user.go
+++ b/pkg/pki/k8scsrpki/k8scsr_user.go
@@ -40,6 +40,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+const (
+	notApprovedErrMsg         = "instance is not approved"
+	notFoundApprovedCsrErrMsg = "could not find approved csr"
+)
+
 // ReconcileUserCertificate ensures and returns a user certificate - should be idempotent
 func (c *k8sCSR) ReconcileUserCertificate(
 	ctx context.Context, user *v1alpha1.KafkaUser, scheme *runtime.Scheme, _ string) (*pkicommon.UserCertificate, error) {
@@ -151,8 +156,8 @@ func (c *k8sCSR) ReconcileUserCertificate(
 	}
 
 	if !foundApproved {
-		return nil, errorfactory.New(errorfactory.FatalReconcileError{}, errors.New("instance is not approved"),
-			"could not find approved csr", "csrName", signingReq.GetName())
+		return nil, errorfactory.New(errorfactory.FatalReconcileError{}, errors.New(notApprovedErrMsg),
+			notFoundApprovedCsrErrMsg, "csrName", signingReq.GetName())
 	}
 	if len(signingReq.Status.Certificate) == 0 {
 		return nil, errorfactory.New(errorfactory.ResourceNotReady{},

--- a/pkg/pki/k8scsrpki/k8scsr_user.go
+++ b/pkg/pki/k8scsrpki/k8scsr_user.go
@@ -258,7 +258,7 @@ func (c *k8sCSR) generateAndCreateCSR(ctx context.Context, clientkey []byte, use
 		return nil, parseErr
 	}
 	c.logger.Info("Generating SigningRequest")
-	csr, err := certutil.GenerateSigningRequestInPemFormat(privKey, user.GetName())
+	csr, err := certutil.GenerateSigningRequestInPemFormat(privKey, user.GetName(), user.Spec.DNSNames)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/pki/k8scsrpki/k8scsr_user_test.go
+++ b/pkg/pki/k8scsrpki/k8scsr_user_test.go
@@ -1,0 +1,133 @@
+// Copyright © 2021 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8scsrpki
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"testing"
+
+	certsigningreqv1 "k8s.io/api/certificates/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/banzaicloud/istio-client-go/pkg/networking/v1alpha3"
+	banzaiistiov1beta1 "github.com/banzaicloud/istio-operator/pkg/apis/istio/v1beta1"
+
+	"github.com/banzaicloud/koperator/api/v1alpha1"
+	"github.com/banzaicloud/koperator/api/v1beta1"
+	"github.com/banzaicloud/koperator/pkg/util/cert"
+)
+
+const (
+	testNamespace = "test-namespace-csr"
+	testDns       = "example.com"
+)
+
+func createKafkaUser() *v1alpha1.KafkaUser {
+	return &v1alpha1.KafkaUser{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "KafkaUser", // it is not populated by default and required for the tests
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-user",
+			Namespace: testNamespace,
+		},
+		Spec: v1alpha1.KafkaUserSpec{
+			SecretName: "test-secret",
+			PKIBackendSpec: &v1alpha1.PKIBackendSpec{
+				PKIBackend: string(v1beta1.PKIBackendK8sCSR),
+				SignerName: "foo.bar/foobar",
+			},
+			DNSNames: []string{testDns},
+		},
+	}
+}
+
+func setupSchemeForTests() (*runtime.Scheme, error) {
+	sch := runtime.NewScheme()
+	err := scheme.AddToScheme(sch)
+	if err != nil {
+		return nil, err
+	}
+	err = v1alpha1.AddToScheme(sch)
+	if err != nil {
+		return nil, err
+	}
+	err = v1beta1.AddToScheme(sch)
+	if err != nil {
+		return nil, err
+	}
+	err = banzaiistiov1beta1.AddToScheme(sch)
+	if err != nil {
+		return nil, err
+	}
+	err = v1alpha3.AddToScheme(sch)
+	if err != nil {
+		return nil, err
+	}
+	return sch, nil
+}
+
+func TestReconcileUserCertificate(t *testing.T) {
+	sch, err := setupSchemeForTests()
+	if err != nil {
+		t.Fatal("failed to setup scheme", err)
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(sch).Build()
+	pkiManager := New(fakeClient, newMockCluster(), log.Log)
+	ctx := context.Background()
+	user := createKafkaUser()
+	_, err = pkiManager.ReconcileUserCertificate(ctx, user, sch, "")
+	if err != nil && err.Error() != fmt.Sprintf("%s: %s", notFoundApprovedCsrErrMsg, notApprovedErrMsg) {
+		t.Fatal("failed to reconcile user certificate", err)
+	}
+
+	var requestList certsigningreqv1.CertificateSigningRequestList
+	err = fakeClient.List(ctx, &requestList)
+	if err != nil {
+		t.Fatal("failed to get reconciled CertificateSigningRequest")
+	}
+	if len(requestList.Items) == 0 {
+		t.Fatal("could not find CertificateSigningRequest in cluster")
+	}
+	if len(requestList.Items) > 1 {
+		t.Fatal("multiple CertificateSigningRequests found in cluster")
+	}
+	csr := requestList.Items[0]
+	req := csr.Spec.Request
+	block, _ := pem.Decode(req)
+	if block == nil {
+		t.Fatal("found empty block")
+	}
+	if block.Type != cert.CertRequestType {
+		t.Error("type of block mismatch, found:", block.Type)
+	}
+	certReq, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		t.Fatal("could not parse cert request", err)
+	}
+	if certReq.Subject.CommonName != user.GetName() {
+		t.Error("wrong common name:", certReq.Subject.CommonName)
+	}
+	if len(certReq.DNSNames) != 1 && certReq.DNSNames[0] != testDns {
+		t.Error("wrong DNS names:", certReq.DNSNames)
+	}
+}

--- a/pkg/util/cert/certutil.go
+++ b/pkg/util/cert/certutil.go
@@ -297,12 +297,13 @@ func GeneratePrivateKeyInPemFormat() ([]byte, error) {
 }
 
 // GenerateSigningRequestInPemFormat is used to generate a signing request in a pem format
-func GenerateSigningRequestInPemFormat(priv *rsa.PrivateKey, commonName string) ([]byte, error) {
+func GenerateSigningRequestInPemFormat(priv *rsa.PrivateKey, commonName string, dnsNames []string) ([]byte, error) {
 	template := x509.CertificateRequest{
 		SignatureAlgorithm: x509.SHA256WithRSA,
 		Subject: pkix.Name{
 			CommonName: commonName,
 		},
+		DNSNames: dnsNames,
 	}
 	csr, err := x509.CreateCertificateRequest(rand.Reader, &template, priv)
 	if err != nil {

--- a/pkg/util/cert/certutil.go
+++ b/pkg/util/cert/certutil.go
@@ -39,6 +39,7 @@ const (
 	RSAPrivateKeyType = "RSA PRIVATE KEY"
 	PrivateKeyType    = "PRIVATE KEY"
 	ECPrivateKeyType  = "EC PRIVATE KEY"
+	CertRequestType   = "CERTIFICATE REQUEST"
 )
 
 type CertificateContainer struct {
@@ -310,7 +311,7 @@ func GenerateSigningRequestInPemFormat(priv *rsa.PrivateKey, commonName string, 
 		return nil, err
 	}
 	buf := new(bytes.Buffer)
-	if err = pem.Encode(buf, &pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csr}); err != nil {
+	if err = pem.Encode(buf, &pem.Block{Type: CertRequestType, Bytes: csr}); err != nil {
 		return nil, err
 	}
 	signingReq := buf.Bytes()


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | - |
| License         | Apache 2.0 |

### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
A simple PR to pass DNS fields in the CSR if specified in the `KafkaUserSpec`.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Otherwise the PKI manager would create a certificate that does not contain the DNS names as SAN.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline