### PR TITLE
Bump cruise control to version 2.5.78 to avoid CVE-2021-44228

### DIFF
--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -850,7 +850,7 @@ func (cConfig *CruiseControlConfig) GetCCImage() string {
 	if cConfig.Image != "" {
 		return cConfig.Image
 	}
-	return "ghcr.io/banzaicloud/cruise-control:2.5.68"
+	return "ghcr.io/banzaicloud/cruise-control:2.5.78"
 }
 
 // GetCCLog4jConfig returns the used Cruise Control log4j configuration

--- a/controllers/tests/kafkacluster_controller_cruisecontrol_test.go
+++ b/controllers/tests/kafkacluster_controller_cruisecontrol_test.go
@@ -271,7 +271,7 @@ func expectCruiseControlDeployment(kafkaCluster *v1beta1.KafkaCluster) {
 	Expect(container.Lifecycle).NotTo(BeNil())
 	Expect(container.Lifecycle.PreStop).NotTo(BeNil())
 	Expect(container.Lifecycle.PreStop.Exec).NotTo(BeNil())
-	Expect(container.Image).To(Equal("ghcr.io/banzaicloud/cruise-control:2.5.68"))
+	Expect(container.Image).To(Equal("ghcr.io/banzaicloud/cruise-control:2.5.78"))
 	Expect(container.Ports).To(ConsistOf(
 		corev1.ContainerPort{
 			ContainerPort: 8090,


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Bump cruise control to version 2.5.78 to avoid CVE-2021-44228


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
