### PR TITLE
fix: controller-gen install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,15 +142,12 @@ docker-push:
 
 # find or download controller-gen
 # download controller-gen if necessary
-bin/controller-gen:
-	@ if ! test -x bin/controller-gen; then \
-		set -ex ;\
-		CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
-		cd $$CONTROLLER_GEN_TMP_DIR ;\
-		go mod init tmp ;\
-		GOBIN=$(PWD)/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@${CONTROLLER_GEN_VERSION} ;\
-		rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
-	fi
+bin/controller-gen: bin/controller-gen-$(CONTROLLER_GEN_VERSION)
+	@ln -sf controller-gen-$(CONTROLLER_GEN_VERSION) bin/controller-gen
+
+bin/controller-gen-$(CONTROLLER_GEN_VERSION):
+	GOBIN=$(PWD)/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_GEN_VERSION)
+	mv bin/controller-gen bin/controller-gen-$(CONTROLLER_GEN_VERSION)
 
 # find or download setup-envtest
 bin/setup-envtest:


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | - |
| License         | Apache 2.0 |


### What's in this PR?
Make sure that the right version of controller-gen is used for generating manifests.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
