### PR TITLE
Fix: odd number of arguments passed as key-value pairs for logging

### DIFF
--- a/pkg/resources/istioingress/istioingress.go
+++ b/pkg/resources/istioingress/istioingress.go
@@ -66,7 +66,7 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 		for _, eListener := range r.KafkaCluster.Spec.ListenersConfig.ExternalListeners {
 			if eListener.GetAccessMethod() == corev1.ServiceTypeLoadBalancer {
 				if r.KafkaCluster.Spec.IstioControlPlane == nil {
-					log.Error(errors.NewPlain("skip the reconciliation of external listener as reference to Istio Control Plane is missing"), "external listener", eListener.Name)
+					log.Error(errors.NewPlain("reference to Istio Control Plane is missing"), "skip external listener reconciliation", "external listener", eListener.Name)
 					continue
 				}
 				ingressConfigs, defaultControllerName, err := util.GetIngressConfigs(r.KafkaCluster.Spec, eListener)


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Fix: `odd number of arguments passed as key-value pairs for logging` error


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
`log.Error` requires an even number of arguments passed as key-value pairs 

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
