### PR TITLE
Fix creation of multiple KafkaTopics

### DIFF
--- a/pkg/resources/istioingress/istioingress.go
+++ b/pkg/resources/istioingress/istioingress.go
@@ -66,7 +66,7 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 		for _, eListener := range r.KafkaCluster.Spec.ListenersConfig.ExternalListeners {
 			if eListener.GetAccessMethod() == corev1.ServiceTypeLoadBalancer {
 				if r.KafkaCluster.Spec.IstioControlPlane == nil {
-					log.Error(errors.NewPlain("skip the reconciliation of external listener as reference to Istio Control Plane is missing"), "external listener", eListener.Name)
+					log.Error(errors.NewPlain("reference to Istio Control Plane is missing"), "skip external listener reconciliation", "external listener", eListener.Name)
 					continue
 				}
 				ingressConfigs, defaultControllerName, err := util.GetIngressConfigs(r.KafkaCluster.Spec, eListener)

--- a/pkg/webhook/topic_validator.go
+++ b/pkg/webhook/topic_validator.go
@@ -155,7 +155,7 @@ func (s *webhookServer) checkExistingKafkaTopicCRs(ctx context.Context,
 	kafkaTopicList := banzaicloudv1alpha1.KafkaTopicList{}
 	err := s.client.List(ctx, &kafkaTopicList, client.MatchingFields{"spec.name": topic.Spec.Name})
 	if err != nil {
-		log.Info(fmt.Sprintf("Failed to list KafkaTopics. Error message: %s", err))
+		log.Error(err, "couldn't list KafkaTopic custom resources")
 		return notAllowed("API failure while retrieving KafkaTopic list, please try again", metav1.StatusReasonServiceUnavailable)
 	}
 

--- a/pkg/webhook/topic_validator.go
+++ b/pkg/webhook/topic_validator.go
@@ -21,7 +21,6 @@ import (
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -154,16 +153,9 @@ func (s *webhookServer) checkExistingKafkaTopicCRs(ctx context.Context,
 	clusterNamespace string, topic *banzaicloudv1alpha1.KafkaTopic) *admissionv1beta1.AdmissionResponse {
 	// check KafkaTopic in the referred KafkaCluster's namespace
 	kafkaTopicList := banzaicloudv1alpha1.KafkaTopicList{}
-	err := s.client.List(ctx, &kafkaTopicList,
-		client.MatchingFieldsSelector{
-			Selector: fields.OneTermEqualSelector("spec.name", topic.Spec.Name),
-		},
-		client.MatchingFieldsSelector{
-			Selector: fields.OneTermEqualSelector("spec.clusterRef.name", topic.Spec.ClusterRef.Name),
-		},
-	)
+	err := s.client.List(ctx, &kafkaTopicList, client.MatchingFields{"spec.name": topic.Spec.Name})
 	if err != nil {
-		log.Info("failed to list KafkaTopics")
+		log.Info(fmt.Sprintf("Failed to list KafkaTopics. Error message: %s", err))
 		return notAllowed("API failure while retrieving KafkaTopic list, please try again", metav1.StatusReasonServiceUnavailable)
 	}
 
@@ -175,9 +167,12 @@ func (s *webhookServer) checkExistingKafkaTopicCRs(ctx context.Context,
 		}
 
 		referredNamespace := kafkaTopic.Spec.ClusterRef.Namespace
-		if (kafkaTopic.GetNamespace() == clusterNamespace && referredNamespace == "") || referredNamespace == clusterNamespace {
-			foundKafkaTopic = &kafkaTopicList.Items[i]
-			break
+		referredName := kafkaTopic.Spec.ClusterRef.Name
+		if referredName == topic.Spec.ClusterRef.Name {
+			if (kafkaTopic.GetNamespace() == clusterNamespace && referredNamespace == "") || referredNamespace == clusterNamespace {
+				foundKafkaTopic = &kafkaTopicList.Items[i]
+				break
+			}
 		}
 	}
 	if foundKafkaTopic != nil {


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | #747  |
| License         | Apache 2.0 |


### What's in this PR?
It fixes a bug that happens when trying to add multiple KafkaTopic into the kafka cluster.

### Why?
Validating webhook rejects proper KafkaTopic resource.

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)