### PR TITLE
Pvcglobaluniqeid

### DIFF
--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -57,7 +57,8 @@ type brokerReconcilePriority int
 const (
 	componentName         = "kafka"
 	brokerConfigTemplate  = "%s-config"
-	brokerStorageTemplate = "%s-%d-storage-%d-"
+	brokerStorageTemplate = "%s-%d-storage-%d"
+
 
 	brokerConfigMapVolumeMount = "broker-config"
 	kafkaDataVolumeMount       = "kafka-data"

--- a/pkg/resources/kafka/pvc.go
+++ b/pkg/resources/kafka/pvc.go
@@ -29,7 +29,7 @@ import (
 
 func (r *Reconciler) pvc(brokerId int32, storageIndex int, storage v1beta1.StorageConfig, _ logr.Logger) runtime.Object {
 	return &corev1.PersistentVolumeClaim{
-		ObjectMeta: templates.ObjectMetaWithGeneratedNameAndAnnotations(
+		ObjectMeta: templates.ObjectMetaWithNameAndAnnotations(
 			fmt.Sprintf(brokerStorageTemplate, r.KafkaCluster.Name, brokerId, storageIndex),
 			util.MergeLabels(
 				kafka.LabelsForKafka(r.KafkaCluster.Name),

--- a/pkg/resources/templates/templates.go
+++ b/pkg/resources/templates/templates.go
@@ -87,6 +87,25 @@ func ObjectMetaWithGeneratedName(namePrefix string, labels map[string]string, cl
 	}
 }
 
+// ObjectMetaWithName returns a metav1.ObjectMeta object with labels, ownerReference and name
+func ObjectMetaWithName(name string, labels map[string]string, cluster *v1beta1.KafkaCluster) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name: name,
+		Namespace:    cluster.Namespace,
+		Labels:       ObjectMetaLabels(cluster, labels),
+		OwnerReferences: []metav1.OwnerReference{
+			{
+				APIVersion:         cluster.APIVersion,
+				Kind:               cluster.Kind,
+				Name:               cluster.Name,
+				UID:                cluster.UID,
+				Controller:         util.BoolPointer(true),
+				BlockOwnerDeletion: util.BoolPointer(true),
+			},
+		},
+	}
+}
+
 func ObjectMetaLabels(cluster *v1beta1.KafkaCluster, l map[string]string) map[string]string {
 	if cluster.Spec.PropagateLabels {
 		return util.MergeLabels(cluster.Labels, l)
@@ -104,6 +123,13 @@ func ObjectMetaWithAnnotations(name string, labels map[string]string, annotation
 // ObjectMetaWithGeneratedNameAndAnnotations returns a metav1.ObjectMeta object with labels, ownerReference, generatedName and annotations
 func ObjectMetaWithGeneratedNameAndAnnotations(namePrefix string, labels map[string]string, annotations map[string]string, cluster *v1beta1.KafkaCluster) metav1.ObjectMeta {
 	o := ObjectMetaWithGeneratedName(namePrefix, labels, cluster)
+	o.Annotations = annotations
+	return o
+}
+
+// ObjectMetaWithNameAndAnnotations returns a metav1.ObjectMeta object with labels, ownerReference, name and annotations
+func ObjectMetaWithNameAndAnnotations(name string, labels map[string]string, annotations map[string]string, cluster *v1beta1.KafkaCluster) metav1.ObjectMeta {
+	o := ObjectMetaWithName(name, labels, cluster)
 	o.Annotations = annotations
 	return o
 }


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no |
| New feature?    | yes |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | fixes #744 |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Created ObjectMetaWithNameAndAnnotations and ObjectMetaWithName to allow creation of objects with a deterministic name.
Use ObjectMetaWithNameAndAnnotations instead of ObjectMetaWithGeneratedNameAndAnnotations When creating a PVC.
Removed the hyphen at the end of brokerStorageTemplate since there isn't going to be a generated suffix.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
When using storage classes that span multiple Kubernetes clusters which use the PVC name to identify the volume that is referenced by the PersistentVolumeClaim or VolumeClaimTemplates, the PVC must have a deterministic name so it could be referenced on all the Kubernetes clusters that will reference it.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] Testing

### Commentary 
Will be testing this code today/tomorrow. Would love your thoughts about it in the meanwhile.
Also, I make this change optional by adding a flag to StorageConfig:
```
type StorageConfig struct {
	MountPath string                                                     `json:"mountPath"`
        IsGlobal      bool                                                       `json:"isGlobal"`
	PvcSpec    *corev1.PersistentVolumeClaimSpec `json:"pvcSpec"`
}
```