### PR TITLE
Allow to set rc.x to helm chart versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,4 +73,4 @@ workflows:
                       branches:
                           ignore: /.*/
                       tags:
-                          only: /chart\/kafka-operator\/\d+.\d+.\d+/
+                          only: /chart\/kafka-operator\/\d+.\d+.\d+(-rc\.\d+)?/


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no|
| New feature?    |yes |
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR allows to set rc.x versions to helm chart.
The chart/kafka-operator cannot be avoided yet, since the circle orb needs this, to work properly.
This should not break original functionality

