### PR TITLE
Use logger from context given by controller runtime wherever it's applicable

### DIFF
--- a/controllers/kafkacluster_controller.go
+++ b/controllers/kafkacluster_controller.go
@@ -84,7 +84,7 @@ type KafkaClusterReconciler struct {
 // +kubebuilder:rbac:groups=networking.istio.io,resources=*,verbs=*
 
 func (r *KafkaClusterReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	log := logr.FromContextOrDiscard(ctx).WithValues("Request.Namespace", request.NamespacedName, "Request.Name", request.Name)
+	log := logr.FromContextOrDiscard(ctx)
 
 	log.Info("Reconciling KafkaCluster")
 

--- a/controllers/kafkacluster_controller.go
+++ b/controllers/kafkacluster_controller.go
@@ -60,7 +60,6 @@ var clusterUsersFinalizer = "users.kafkaclusters.kafka.banzaicloud.io"
 type KafkaClusterReconciler struct {
 	client.Client
 	DirectClient        client.Reader
-	Log                 logr.Logger
 	Namespaces          []string
 	KafkaClientProvider kafkaclient.Provider
 }
@@ -85,7 +84,7 @@ type KafkaClusterReconciler struct {
 // +kubebuilder:rbac:groups=networking.istio.io,resources=*,verbs=*
 
 func (r *KafkaClusterReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	log := r.Log.WithValues("Request.Namespace", request.NamespacedName, "Request.Name", request.Name)
+	log := logr.FromContextOrDiscard(ctx).WithValues("Request.Namespace", request.NamespacedName, "Request.Name", request.Name)
 
 	log.Info("Reconciling KafkaCluster")
 
@@ -104,7 +103,7 @@ func (r *KafkaClusterReconciler) Reconcile(ctx context.Context, request ctrl.Req
 
 	// Check if marked for deletion and run finalizers
 	if k8sutil.IsMarkedForDeletion(instance.ObjectMeta) {
-		return r.checkFinalizers(ctx, log, instance)
+		return r.checkFinalizers(ctx, instance)
 	}
 
 	if instance.Status.State != v1beta1.KafkaClusterRollingUpgrading {
@@ -192,7 +191,8 @@ func (r *KafkaClusterReconciler) Reconcile(ctx context.Context, request ctrl.Req
 	return reconciled()
 }
 
-func (r *KafkaClusterReconciler) checkFinalizers(ctx context.Context, log logr.Logger, cluster *v1beta1.KafkaCluster) (ctrl.Result, error) {
+func (r *KafkaClusterReconciler) checkFinalizers(ctx context.Context, cluster *v1beta1.KafkaCluster) (ctrl.Result, error) {
+	log := logr.FromContextOrDiscard(ctx)
 	log.Info("KafkaCluster is marked for deletion, checking for children")
 
 	// If the main finalizer is gone then we've already finished up
@@ -287,7 +287,7 @@ func (r *KafkaClusterReconciler) checkFinalizers(ctx context.Context, log logr.L
 		// Do any necessary PKI cleanup - a PKI backend should make sure any
 		// user finalizations are done before it does its final cleanup
 		log.Info("Tearing down any PKI resources for the kafkacluster")
-		if err = pki.GetPKIManager(r.Client, cluster, v1beta1.PKIBackendProvided, r.Log).FinalizePKI(ctx, log); err != nil {
+		if err = pki.GetPKIManager(r.Client, cluster, v1beta1.PKIBackendProvided).FinalizePKI(ctx); err != nil {
 			switch err.(type) {
 			case errorfactory.ResourceNotReady:
 				log.Info("The PKI is not ready to be torn down")
@@ -349,7 +349,8 @@ func (r *KafkaClusterReconciler) updateAndFetchLatest(ctx context.Context, clust
 }
 
 // SetupKafkaClusterWithManager registers kafka cluster controller to the manager
-func SetupKafkaClusterWithManager(mgr ctrl.Manager, log logr.Logger) *ctrl.Builder {
+func SetupKafkaClusterWithManager(mgr ctrl.Manager) *ctrl.Builder {
+	log := mgr.GetLogger()
 	builder := ctrl.NewControllerManagedBy(mgr).
 		For(&v1beta1.KafkaCluster{}).Named("KafkaCluster")
 

--- a/controllers/kafkatopic_controller.go
+++ b/controllers/kafkatopic_controller.go
@@ -99,7 +99,7 @@ type KafkaTopicReconciler struct {
 
 // Reconcile reconciles the kafka topic
 func (r *KafkaTopicReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	reqLogger := logr.FromContextOrDiscard(ctx).WithValues("kafkatopic", request.NamespacedName, "Request.Name", request.Name)
+	reqLogger := logr.FromContextOrDiscard(ctx)
 	reqLogger.Info("Reconciling KafkaTopic")
 	var err error
 

--- a/controllers/kafkauser_controller.go
+++ b/controllers/kafkauser_controller.go
@@ -167,7 +167,7 @@ type KafkaUserReconciler struct {
 // Reconcile reads that state of the cluster for a KafkaUser object and makes changes based on the state read
 // and what is in the KafkaUser.Spec
 func (r *KafkaUserReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	reqLogger := logr.FromContextOrDiscard(ctx).WithValues("kafkauser", request.NamespacedName, "Request.Name", request.Name)
+	reqLogger := logr.FromContextOrDiscard(ctx)
 	reqLogger.Info("Reconciling KafkaUser")
 	var err error
 

--- a/controllers/kafkauser_controller.go
+++ b/controllers/kafkauser_controller.go
@@ -56,7 +56,8 @@ import (
 var userFinalizer = "finalizer.kafkausers.kafka.banzaicloud.io"
 
 // SetupKafkaUserWithManager registers KafkaUser controller to the manager
-func SetupKafkaUserWithManager(mgr ctrl.Manager, certSigningEnabled bool, certManagerNamespace bool, log logr.Logger) *ctrl.Builder {
+func SetupKafkaUserWithManager(mgr ctrl.Manager, certSigningEnabled bool, certManagerNamespace bool) *ctrl.Builder {
+	log := mgr.GetLogger()
 	builder := ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.KafkaUser{}).Named("KafkaUser")
 	if certSigningEnabled {
@@ -154,7 +155,6 @@ type KafkaUserReconciler struct {
 	// that reads objects from the cache and writes to the apiserver
 	Client client.Client
 	Scheme *runtime.Scheme
-	Log    logr.Logger
 }
 
 // +kubebuilder:rbac:groups=kafka.banzaicloud.io,resources=kafkausers,verbs=get;list;watch;create;update;patch;delete;deletecollection
@@ -167,7 +167,7 @@ type KafkaUserReconciler struct {
 // Reconcile reads that state of the cluster for a KafkaUser object and makes changes based on the state read
 // and what is in the KafkaUser.Spec
 func (r *KafkaUserReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	reqLogger := r.Log.WithValues("kafkauser", request.NamespacedName, "Request.Name", request.Name)
+	reqLogger := logr.FromContextOrDiscard(ctx).WithValues("kafkauser", request.NamespacedName, "Request.Name", request.Name)
 	reqLogger.Info("Reconciling KafkaUser")
 	var err error
 
@@ -212,7 +212,7 @@ func (r *KafkaUserReconciler) Reconcile(ctx context.Context, request reconcile.R
 			backend = v1beta1.PKIBackendProvided
 		}
 
-		pkiManager := pki.GetPKIManager(r.Client, cluster, backend, r.Log)
+		pkiManager := pki.GetPKIManager(r.Client, cluster, backend)
 
 		user, err := pkiManager.ReconcileUserCertificate(ctx, instance, r.Scheme, cluster.Spec.GetKubernetesClusterDomain())
 		if err != nil {
@@ -257,7 +257,7 @@ func (r *KafkaUserReconciler) Reconcile(ctx context.Context, request reconcile.R
 
 	// check if marked for deletion and remove kafka ACLs
 	if k8sutil.IsMarkedForDeletion(instance.ObjectMeta) {
-		return r.checkFinalizers(ctx, reqLogger, cluster, instance, kafkaUser)
+		return r.checkFinalizers(ctx, cluster, instance, kafkaUser)
 	}
 
 	// ensure a kafkaCluster label
@@ -324,7 +324,8 @@ func (r *KafkaUserReconciler) updateAndFetchLatest(ctx context.Context, user *v1
 	return user, nil
 }
 
-func (r *KafkaUserReconciler) checkFinalizers(ctx context.Context, reqLogger logr.Logger, cluster *v1beta1.KafkaCluster, instance *v1alpha1.KafkaUser, user string) (reconcile.Result, error) {
+func (r *KafkaUserReconciler) checkFinalizers(ctx context.Context, cluster *v1beta1.KafkaCluster, instance *v1alpha1.KafkaUser, user string) (reconcile.Result, error) {
+	reqLogger := logr.FromContextOrDiscard(ctx)
 	// run finalizers
 	var err error
 	if util.StringSliceContains(instance.GetFinalizers(), userFinalizer) {

--- a/controllers/tests/clusterregistry/suite_test.go
+++ b/controllers/tests/clusterregistry/suite_test.go
@@ -133,7 +133,7 @@ var _ = BeforeSuite(func() {
 	Expect(mgr).ToNot(BeNil())
 
 	kafkaClusterReconciler = NewTestReconciler()
-	err = controllers.SetupKafkaClusterWithManager(mgr, logf.Log).Named("KafkaCluster").Complete(kafkaClusterReconciler)
+	err = controllers.SetupKafkaClusterWithManager(mgr).Named("KafkaCluster").Complete(kafkaClusterReconciler)
 	Expect(err).NotTo(HaveOccurred())
 
 	kafkaTopicReconciler = NewTestReconciler()
@@ -142,7 +142,7 @@ var _ = BeforeSuite(func() {
 
 	// Create a new  kafka user reconciler
 	kafkaUserReconciler = NewTestReconciler()
-	err = controllers.SetupKafkaUserWithManager(mgr, true, true, logf.Log).Named("KafkaUser").Complete(kafkaUserReconciler)
+	err = controllers.SetupKafkaUserWithManager(mgr, true, true).Named("KafkaUser").Complete(kafkaUserReconciler)
 	Expect(err).NotTo(HaveOccurred())
 
 	cruiseControlTaskReconciler = NewTestReconciler()

--- a/controllers/tests/suite_test.go
+++ b/controllers/tests/suite_test.go
@@ -144,8 +144,8 @@ var _ = BeforeSuite(func() {
 		})
 
 	kafkaClusterReconciler := controllers.KafkaClusterReconciler{
-		Client:       mgr.GetClient(),
-		DirectClient: mgr.GetAPIReader(),
+		Client:              mgr.GetClient(),
+		DirectClient:        mgr.GetAPIReader(),
 		KafkaClientProvider: kafkaclient.NewMockProvider(),
 	}
 

--- a/controllers/tests/suite_test.go
+++ b/controllers/tests/suite_test.go
@@ -144,19 +144,17 @@ var _ = BeforeSuite(func() {
 		})
 
 	kafkaClusterReconciler := controllers.KafkaClusterReconciler{
-		Client:              mgr.GetClient(),
-		DirectClient:        mgr.GetAPIReader(),
-		Log:                 ctrl.Log.WithName("controllers").WithName("KafkaCluster"),
+		Client:       mgr.GetClient(),
+		DirectClient: mgr.GetAPIReader(),
 		KafkaClientProvider: kafkaclient.NewMockProvider(),
 	}
 
-	err = controllers.SetupKafkaClusterWithManager(mgr, kafkaClusterReconciler.Log).Complete(&kafkaClusterReconciler)
+	err = controllers.SetupKafkaClusterWithManager(mgr).Complete(&kafkaClusterReconciler)
 	Expect(err).NotTo(HaveOccurred())
 
 	kafkaTopicReconciler := &controllers.KafkaTopicReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
-		Log:    ctrl.Log.WithName("controllers").WithName("KafkaTopic"),
 	}
 
 	err = controllers.SetupKafkaTopicWithManager(mgr, 10).Complete(kafkaTopicReconciler)
@@ -166,10 +164,9 @@ var _ = BeforeSuite(func() {
 	kafkaUserReconciler := controllers.KafkaUserReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
-		Log:    ctrl.Log.WithName("controllers").WithName("KafkaUser"),
 	}
 
-	err = controllers.SetupKafkaUserWithManager(mgr, true, true, kafkaUserReconciler.Log).Complete(&kafkaUserReconciler)
+	err = controllers.SetupKafkaUserWithManager(mgr, true, true).Complete(&kafkaUserReconciler)
 	Expect(err).NotTo(HaveOccurred())
 
 	kafkaClusterCCReconciler := controllers.CruiseControlTaskReconciler{

--- a/main.go
+++ b/main.go
@@ -149,9 +149,9 @@ func main() {
 	}
 
 	kafkaClusterReconciler := &controllers.KafkaClusterReconciler{
-		Client:       mgr.GetClient(),
-		DirectClient: mgr.GetAPIReader(),
-		Namespaces:   namespaceList,
+		Client:              mgr.GetClient(),
+		DirectClient:        mgr.GetAPIReader(),
+		Namespaces:          namespaceList,
 		KafkaClientProvider: kafkaclient.NewDefaultProvider(),
 	}
 

--- a/main.go
+++ b/main.go
@@ -149,14 +149,13 @@ func main() {
 	}
 
 	kafkaClusterReconciler := &controllers.KafkaClusterReconciler{
-		Client:              mgr.GetClient(),
-		DirectClient:        mgr.GetAPIReader(),
-		Namespaces:          namespaceList,
-		Log:                 ctrl.Log.WithName("controllers").WithName("KafkaCluster"),
+		Client:       mgr.GetClient(),
+		DirectClient: mgr.GetAPIReader(),
+		Namespaces:   namespaceList,
 		KafkaClientProvider: kafkaclient.NewDefaultProvider(),
 	}
 
-	if err = controllers.SetupKafkaClusterWithManager(mgr, kafkaClusterReconciler.Log).Complete(kafkaClusterReconciler); err != nil {
+	if err = controllers.SetupKafkaClusterWithManager(mgr).Complete(kafkaClusterReconciler); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KafkaCluster")
 		os.Exit(1)
 	}
@@ -164,7 +163,6 @@ func main() {
 	kafkaTopicReconciler := &controllers.KafkaTopicReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
-		Log:    ctrl.Log.WithName("controllers").WithName("KafkaTopic"),
 	}
 
 	if err = controllers.SetupKafkaTopicWithManager(mgr, maxKafkaTopicConcurrentReconciles).Complete(kafkaTopicReconciler); err != nil {
@@ -176,10 +174,9 @@ func main() {
 	kafkaUserReconciler := &controllers.KafkaUserReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
-		Log:    ctrl.Log.WithName("controllers").WithName("KafkaUser"),
 	}
 
-	if err = controllers.SetupKafkaUserWithManager(mgr, !certSigningDisabled, certManagerEnabled, kafkaUserReconciler.Log).Complete(kafkaUserReconciler); err != nil {
+	if err = controllers.SetupKafkaUserWithManager(mgr, !certSigningDisabled, certManagerEnabled).Complete(kafkaUserReconciler); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KafkaUser")
 		os.Exit(1)
 	}

--- a/pkg/k8sutil/status.go
+++ b/pkg/k8sutil/status.go
@@ -261,8 +261,9 @@ func UpdateRollingUpgradeState(c client.Client, cluster *banzaicloudv1beta1.Kafk
 	return nil
 }
 
-func UpdateListenerStatuses(ctx context.Context, c client.Client, cluster *banzaicloudv1beta1.KafkaCluster, logger logr.Logger,
-	intListenerStatuses, extListenerStatuses map[string]banzaicloudv1beta1.ListenerStatusList) error {
+func UpdateListenerStatuses(ctx context.Context, c client.Client, cluster *banzaicloudv1beta1.KafkaCluster, intListenerStatuses, extListenerStatuses map[string]banzaicloudv1beta1.ListenerStatusList) error {
+	logger := logr.FromContextOrDiscard(ctx)
+
 	typeMeta := cluster.TypeMeta
 
 	cluster.Status.ListenerStatuses = banzaicloudv1beta1.ListenerStatuses{

--- a/pkg/kafkaclient/config.go
+++ b/pkg/kafkaclient/config.go
@@ -49,7 +49,7 @@ func ClusterConfig(client client.Client, cluster *v1beta1.KafkaCluster) (*KafkaC
 		if cluster.Spec.GetClientSSLCertSecretName() != "" {
 			tlsConfig, err = util.GetClientTLSConfig(client, types.NamespacedName{Name: cluster.Spec.GetClientSSLCertSecretName(), Namespace: cluster.Namespace})
 		} else if cluster.Spec.ListenersConfig.SSLSecrets != nil {
-			tlsConfig, err = pki.GetPKIManager(client, cluster, v1beta1.PKIBackendProvided, log).GetControllerTLSConfig()
+			tlsConfig, err = pki.GetPKIManager(client, cluster, v1beta1.PKIBackendProvided).GetControllerTLSConfig()
 		} else {
 			err = errors.New("either 'clientSSLCertSecret' or 'sslSecrets' must be specified as internal listener used for inner communication uses SSL")
 		}

--- a/pkg/pki/certmanagerpki/certmanager_pki.go
+++ b/pkg/pki/certmanagerpki/certmanager_pki.go
@@ -35,7 +35,8 @@ import (
 	pkicommon "github.com/banzaicloud/koperator/pkg/util/pki"
 )
 
-func (c *certManager) FinalizePKI(ctx context.Context, logger logr.Logger) error {
+func (c *certManager) FinalizePKI(ctx context.Context) error {
+	logger := logr.FromContextOrDiscard(ctx)
 	logger.Info("Removing cert-manager certificates and secrets")
 
 	// Safety check that we are actually doing something
@@ -87,7 +88,8 @@ func (c *certManager) FinalizePKI(ctx context.Context, logger logr.Logger) error
 	return nil
 }
 
-func (c *certManager) ReconcilePKI(ctx context.Context, logger logr.Logger, extListenerStatuses map[string]v1beta1.ListenerStatusList) (err error) {
+func (c *certManager) ReconcilePKI(ctx context.Context, extListenerStatuses map[string]v1beta1.ListenerStatusList) (err error) {
+	logger := logr.FromContextOrDiscard(ctx)
 	logger.Info("Reconciling cert-manager PKI")
 
 	resources, err := c.kafkapki(ctx, extListenerStatuses)
@@ -96,7 +98,7 @@ func (c *certManager) ReconcilePKI(ctx context.Context, logger logr.Logger, extL
 	}
 
 	for _, o := range resources {
-		if err := reconcile(ctx, logger, c.client, o); err != nil {
+		if err := reconcile(ctx, c.client, o); err != nil {
 			return err
 		}
 	}

--- a/pkg/pki/certmanagerpki/certmanager_pki_test.go
+++ b/pkg/pki/certmanagerpki/certmanager_pki_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/banzaicloud/koperator/api/v1alpha1"
 	"github.com/banzaicloud/koperator/api/v1beta1"
@@ -29,8 +28,6 @@ import (
 	certutil "github.com/banzaicloud/koperator/pkg/util/cert"
 	pkicommon "github.com/banzaicloud/koperator/pkg/util/pki"
 )
-
-var log = ctrl.Log.WithName("testing")
 
 const (
 	testNamespace = "test-namespace"
@@ -93,7 +90,7 @@ func TestFinalizePKI(t *testing.T) {
 		t.Error("Expected no error during initialization, got:", err)
 	}
 
-	if err := manager.FinalizePKI(context.Background(), log); err != nil {
+	if err := manager.FinalizePKI(context.Background()); err != nil {
 		t.Error("Expected no error on finalize, got:", err)
 	}
 }
@@ -109,7 +106,7 @@ func TestReconcilePKI(t *testing.T) {
 	if err := manager.client.Create(ctx, newServerSecret()); err != nil {
 		t.Error("error during server secret creation", reflect.TypeOf(err))
 	}
-	if err := manager.ReconcilePKI(ctx, log, make(map[string]v1beta1.ListenerStatusList)); err != nil {
+	if err := manager.ReconcilePKI(ctx, make(map[string]v1beta1.ListenerStatusList)); err != nil {
 		if reflect.TypeOf(err) != reflect.TypeOf(errorfactory.ResourceNotReady{}) {
 			t.Error("Expected not ready error, got:", reflect.TypeOf(err))
 		}
@@ -118,7 +115,7 @@ func TestReconcilePKI(t *testing.T) {
 	if err := manager.client.Create(ctx, newControllerSecret()); err != nil {
 		t.Error("error during controller secret creation", reflect.TypeOf(err))
 	}
-	if err := manager.ReconcilePKI(ctx, log, make(map[string]v1beta1.ListenerStatusList)); err != nil {
+	if err := manager.ReconcilePKI(ctx, make(map[string]v1beta1.ListenerStatusList)); err != nil {
 		if reflect.TypeOf(err) != reflect.TypeOf(errorfactory.ResourceNotReady{}) {
 			t.Error("Expected not ready error, got:", reflect.TypeOf(err))
 		}
@@ -127,7 +124,7 @@ func TestReconcilePKI(t *testing.T) {
 	if err := manager.client.Create(ctx, newCASecret()); err != nil {
 		t.Error("error during CA secret creation", reflect.TypeOf(err))
 	}
-	if err := manager.ReconcilePKI(ctx, log, make(map[string]v1beta1.ListenerStatusList)); err != nil {
+	if err := manager.ReconcilePKI(ctx, make(map[string]v1beta1.ListenerStatusList)); err != nil {
 		t.Error("Expected successful reconcile, got:", err)
 	}
 
@@ -136,7 +133,7 @@ func TestReconcilePKI(t *testing.T) {
 	if err != nil {
 		t.Error("Expected no error during mocking the cluster, got:", err)
 	}
-	if err := manager.ReconcilePKI(ctx, log, make(map[string]v1beta1.ListenerStatusList)); err == nil {
+	if err := manager.ReconcilePKI(ctx, make(map[string]v1beta1.ListenerStatusList)); err == nil {
 		t.Error("Expected error got nil")
 	} else if reflect.TypeOf(err) != reflect.TypeOf(errorfactory.ResourceNotReady{}) {
 		t.Error("Expected not ready error, got:", reflect.TypeOf(err))
@@ -144,7 +141,7 @@ func TestReconcilePKI(t *testing.T) {
 	if err := manager.client.Create(ctx, newPreCreatedSecret()); err != nil {
 		t.Error("error during pre created secret creation", reflect.TypeOf(err))
 	}
-	if err := manager.ReconcilePKI(ctx, log, make(map[string]v1beta1.ListenerStatusList)); err != nil {
+	if err := manager.ReconcilePKI(ctx, make(map[string]v1beta1.ListenerStatusList)); err != nil {
 		t.Error("Expected successful reconcile, got:", err)
 	}
 }

--- a/pkg/pki/certmanagerpki/reconcile.go
+++ b/pkg/pki/certmanagerpki/reconcile.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/go-logr/logr"
 	certv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -31,23 +30,23 @@ import (
 )
 
 // reconcile ensures the given kubernetes object
-func reconcile(ctx context.Context, log logr.Logger, client client.Client, object runtime.Object) (err error) {
+func reconcile(ctx context.Context, client client.Client, object runtime.Object) (err error) {
 	switch o := object.(type) {
 	case *certv1.ClusterIssuer:
-		return reconcileClusterIssuer(ctx, log, client, o)
+		return reconcileClusterIssuer(ctx, client, o)
 	case *certv1.Certificate:
-		return reconcileCertificate(ctx, log, client, o)
+		return reconcileCertificate(ctx, client, o)
 	case *corev1.Secret:
-		return reconcileSecret(ctx, log, client, o)
+		return reconcileSecret(ctx, client, o)
 	case *v1alpha1.KafkaUser:
-		return reconcileUser(ctx, log, client, o)
+		return reconcileUser(ctx, client, o)
 	default:
 		panic(fmt.Sprintf("Invalid object type: %v", reflect.TypeOf(object)))
 	}
 }
 
 // reconcileClusterIssuer ensures a cert-manager ClusterIssuer
-func reconcileClusterIssuer(ctx context.Context, _ logr.Logger, client client.Client, issuer *certv1.ClusterIssuer) error {
+func reconcileClusterIssuer(ctx context.Context, client client.Client, issuer *certv1.ClusterIssuer) error {
 	obj := &certv1.ClusterIssuer{}
 	var err error
 	if err = client.Get(ctx, types.NamespacedName{Name: issuer.Name, Namespace: issuer.Namespace}, obj); err != nil {
@@ -60,7 +59,7 @@ func reconcileClusterIssuer(ctx context.Context, _ logr.Logger, client client.Cl
 }
 
 // reconcileCertificate ensures a cert-manager certificate
-func reconcileCertificate(ctx context.Context, _ logr.Logger, client client.Client, cert *certv1.Certificate) error {
+func reconcileCertificate(ctx context.Context, client client.Client, cert *certv1.Certificate) error {
 	obj := &certv1.Certificate{}
 	var err error
 	if err = client.Get(ctx, types.NamespacedName{Name: cert.Name, Namespace: cert.Namespace}, obj); err != nil {
@@ -73,7 +72,7 @@ func reconcileCertificate(ctx context.Context, _ logr.Logger, client client.Clie
 }
 
 // reconcileSecret ensures a Kubernetes secret
-func reconcileSecret(ctx context.Context, _ logr.Logger, client client.Client, secret *corev1.Secret) error {
+func reconcileSecret(ctx context.Context, client client.Client, secret *corev1.Secret) error {
 	obj := &corev1.Secret{}
 	var err error
 	if err = client.Get(ctx, types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace}, obj); err != nil {
@@ -86,7 +85,7 @@ func reconcileSecret(ctx context.Context, _ logr.Logger, client client.Client, s
 }
 
 // reconcileUser ensures a v1alpha1.KafkaUser
-func reconcileUser(ctx context.Context, _ logr.Logger, client client.Client, user *v1alpha1.KafkaUser) error {
+func reconcileUser(ctx context.Context, client client.Client, user *v1alpha1.KafkaUser) error {
 	obj := &v1alpha1.KafkaUser{}
 	var err error
 	if err = client.Get(ctx, types.NamespacedName{Name: user.Name, Namespace: user.Namespace}, obj); err != nil {

--- a/pkg/pki/k8scsrpki/k8scsr.go
+++ b/pkg/pki/k8scsrpki/k8scsr.go
@@ -18,7 +18,6 @@ import (
 	"github.com/banzaicloud/koperator/api/v1beta1"
 	"github.com/banzaicloud/koperator/pkg/util/pki"
 
-	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -35,9 +34,8 @@ type K8sCSR interface {
 type k8sCSR struct {
 	client  client.Client
 	cluster *v1beta1.KafkaCluster
-	logger  logr.Logger
 }
 
-func New(client client.Client, cluster *v1beta1.KafkaCluster, logger logr.Logger) K8sCSR {
-	return &k8sCSR{client: client, cluster: cluster, logger: logger}
+func New(client client.Client, cluster *v1beta1.KafkaCluster) K8sCSR {
+	return &k8sCSR{client: client, cluster: cluster}
 }

--- a/pkg/pki/k8scsrpki/k8scsr_pki.go
+++ b/pkg/pki/k8scsrpki/k8scsr_pki.go
@@ -22,11 +22,12 @@ import (
 	"github.com/go-logr/logr"
 )
 
-func (c *k8sCSR) ReconcilePKI(_ context.Context, logger logr.Logger, _ map[string]v1beta1.ListenerStatusList) error {
+func (c *k8sCSR) ReconcilePKI(ctx context.Context, externalHostnames map[string]v1beta1.ListenerStatusList) error {
+	logger := logr.FromContextOrDiscard(ctx)
 	logger.Info("k8sCSR PKI reconcile is skipped since it is not supported yet for server certs")
 	return nil
 }
 
-func (c *k8sCSR) FinalizePKI(_ context.Context, _ logr.Logger) error {
+func (c *k8sCSR) FinalizePKI(ctx context.Context) error {
 	return nil
 }

--- a/pkg/pki/k8scsrpki/k8scsr_test.go
+++ b/pkg/pki/k8scsrpki/k8scsr_test.go
@@ -18,9 +18,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/banzaicloud/koperator/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/banzaicloud/koperator/api/v1beta1"
 )
 
 type mockClient struct {

--- a/pkg/pki/k8scsrpki/k8scsr_test.go
+++ b/pkg/pki/k8scsrpki/k8scsr_test.go
@@ -18,11 +18,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/banzaicloud/koperator/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
-
-	"github.com/banzaicloud/koperator/api/v1beta1"
 )
 
 type mockClient struct {
@@ -53,7 +51,7 @@ func newMockCluster() *v1beta1.KafkaCluster {
 }
 
 func TestNew(t *testing.T) {
-	pkiManager := New(&mockClient{}, newMockCluster(), log.Log)
+	pkiManager := New(&mockClient{}, newMockCluster())
 	if reflect.TypeOf(pkiManager) != reflect.TypeOf(&k8sCSR{}) {
 		t.Error("Expected new k8sCSR from New, got:", reflect.TypeOf(pkiManager))
 	}

--- a/pkg/pki/k8scsrpki/k8scsr_user_test.go
+++ b/pkg/pki/k8scsrpki/k8scsr_user_test.go
@@ -96,7 +96,7 @@ func TestReconcileUserCertificate(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 
 	fakeClient := fake.NewClientBuilder().WithScheme(sch).Build()
-	pkiManager := New(fakeClient, newMockCluster(), log.Log)
+	pkiManager := New(fakeClient, newMockCluster())
 	ctx := context.Background()
 	user := createKafkaUser()
 	_, err = pkiManager.ReconcileUserCertificate(ctx, user, sch, "")

--- a/pkg/pki/k8scsrpki/k8scsr_user_test.go
+++ b/pkg/pki/k8scsrpki/k8scsr_user_test.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/banzaicloud/istio-client-go/pkg/networking/v1alpha3"
 	banzaiistiov1alpha1 "github.com/banzaicloud/istio-operator/api/v2/v1alpha1"

--- a/pkg/pki/pki_manager.go
+++ b/pkg/pki/pki_manager.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"crypto/tls"
 
-	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -33,7 +32,7 @@ import (
 var MockBackend = v1beta1.PKIBackend("mock")
 
 // GetPKIManager returns a PKI/User manager interface for a given cluster
-func GetPKIManager(client client.Client, cluster *v1beta1.KafkaCluster, pkiBackend v1beta1.PKIBackend, log logr.Logger) pki.Manager {
+func GetPKIManager(client client.Client, cluster *v1beta1.KafkaCluster, pkiBackend v1beta1.PKIBackend) pki.Manager {
 	var backend v1beta1.PKIBackend
 	if pkiBackend == v1beta1.PKIBackendProvided {
 		backend = cluster.Spec.ListenersConfig.SSLSecrets.PKIBackend
@@ -47,7 +46,7 @@ func GetPKIManager(client client.Client, cluster *v1beta1.KafkaCluster, pkiBacke
 		return certmanagerpki.New(client, cluster)
 	// Use k8s csr api for pki backend
 	case v1beta1.PKIBackendK8sCSR:
-		return k8scsrpki.New(client, cluster, log)
+		return k8scsrpki.New(client, cluster)
 	// Return mock backend for testing - cannot be triggered by CR due to enum in api schema
 	case MockBackend:
 		return newMockPKIManager(client, cluster)
@@ -69,11 +68,11 @@ func newMockPKIManager(client client.Client, cluster *v1beta1.KafkaCluster) pki.
 	return &mockPKIManager{client: client, cluster: cluster}
 }
 
-func (m *mockPKIManager) ReconcilePKI(ctx context.Context, logger logr.Logger, extListenerStatuses map[string]v1beta1.ListenerStatusList) error {
+func (m *mockPKIManager) ReconcilePKI(ctx context.Context, externalHostnames map[string]v1beta1.ListenerStatusList) error {
 	return nil
 }
 
-func (m *mockPKIManager) FinalizePKI(ctx context.Context, logger logr.Logger) error {
+func (m *mockPKIManager) FinalizePKI(ctx context.Context) error {
 	return nil
 }
 

--- a/pkg/pki/pki_manager_test.go
+++ b/pkg/pki/pki_manager_test.go
@@ -52,7 +52,7 @@ func newMockCluster() *v1beta1.KafkaCluster {
 
 func TestGetPKIManager(t *testing.T) {
 	cluster := newMockCluster()
-	mock := GetPKIManager(&mockClient{}, cluster, v1beta1.PKIBackendProvided, log)
+	mock := GetPKIManager(&mockClient{}, cluster, v1beta1.PKIBackendProvided)
 	if reflect.TypeOf(mock) != reflect.TypeOf(&mockPKIManager{}) {
 		t.Error("Expected mock client got:", reflect.TypeOf(mock))
 	}
@@ -60,11 +60,11 @@ func TestGetPKIManager(t *testing.T) {
 
 	// Test mock functions
 	var err error
-	if err = mock.ReconcilePKI(ctx, log, make(map[string]v1beta1.ListenerStatusList)); err != nil {
+	if err = mock.ReconcilePKI(ctx, make(map[string]v1beta1.ListenerStatusList)); err != nil {
 		t.Error("Expected nil error got:", err)
 	}
 
-	if err = mock.FinalizePKI(ctx, log); err != nil {
+	if err = mock.FinalizePKI(ctx); err != nil {
 		t.Error("Expected nil error got:", err)
 	}
 
@@ -82,7 +82,7 @@ func TestGetPKIManager(t *testing.T) {
 
 	// Test other getters
 	cluster.Spec.ListenersConfig.SSLSecrets.PKIBackend = v1beta1.PKIBackendCertManager
-	certmanager := GetPKIManager(&mockClient{}, cluster, v1beta1.PKIBackendProvided, log)
+	certmanager := GetPKIManager(&mockClient{}, cluster, v1beta1.PKIBackendProvided)
 	pkiType := reflect.TypeOf(certmanager).String()
 	expected := "*certmanagerpki.certManager"
 	if pkiType != expected {
@@ -91,7 +91,7 @@ func TestGetPKIManager(t *testing.T) {
 
 	// Default should be cert-manager also
 	cluster.Spec.ListenersConfig.SSLSecrets.PKIBackend = ""
-	certmanager = GetPKIManager(&mockClient{}, cluster, v1beta1.PKIBackendProvided, log)
+	certmanager = GetPKIManager(&mockClient{}, cluster, v1beta1.PKIBackendProvided)
 	pkiType = reflect.TypeOf(certmanager).String()
 	expected = "*certmanagerpki.certManager"
 	if pkiType != expected {

--- a/pkg/pki/pki_manager_test.go
+++ b/pkg/pki/pki_manager_test.go
@@ -19,15 +19,12 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/go-logr/logr"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/banzaicloud/koperator/api/v1alpha1"
 	"github.com/banzaicloud/koperator/api/v1beta1"
 )
-
-var log logr.Logger
 
 type mockClient struct {
 	client.Client

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -182,7 +182,7 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 		return errors.WrapIf(err, "could not update status for external listeners")
 	}
 	intListenerStatuses, controllerIntListenerStatuses := k8sutil.CreateInternalListenerStatuses(r.KafkaCluster)
-	err = k8sutil.UpdateListenerStatuses(context.Background(), r.Client, r.KafkaCluster, log, intListenerStatuses, extListenerStatuses)
+	err = k8sutil.UpdateListenerStatuses(context.Background(), r.Client, r.KafkaCluster, intListenerStatuses, extListenerStatuses)
 	if err != nil {
 		return errors.WrapIf(err, "failed to update listener statuses")
 	}
@@ -190,7 +190,7 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 	// Setup the PKI if using SSL
 	if r.KafkaCluster.Spec.ListenersConfig.SSLSecrets != nil {
 		// reconcile the PKI
-		if err := pki.GetPKIManager(r.Client, r.KafkaCluster, v1beta1.PKIBackendProvided, log).ReconcilePKI(context.TODO(), log, extListenerStatuses); err != nil {
+		if err := pki.GetPKIManager(r.Client, r.KafkaCluster, v1beta1.PKIBackendProvided).ReconcilePKI(context.TODO(), extListenerStatuses); err != nil {
 			return err
 		}
 	}

--- a/pkg/util/pki/common.go
+++ b/pkg/util/pki/common.go
@@ -24,7 +24,6 @@ import (
 	"github.com/banzaicloud/koperator/pkg/errorfactory"
 	"github.com/banzaicloud/koperator/pkg/k8sutil"
 
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -65,10 +64,10 @@ type Manager interface {
 	// ReconcilePKI ensures a PKI for a kafka cluster - should be idempotent.
 	// This method should at least setup any issuer needed for user certificates
 	// as well as broker/cruise-control secrets
-	ReconcilePKI(ctx context.Context, logger logr.Logger, externalHostnames map[string]v1beta1.ListenerStatusList) error
+	ReconcilePKI(ctx context.Context, externalHostnames map[string]v1beta1.ListenerStatusList) error
 
 	// FinalizePKI performs any cleanup steps necessary for a PKI backend
-	FinalizePKI(ctx context.Context, logger logr.Logger) error
+	FinalizePKI(ctx context.Context) error
 
 	// ReconcileUserCertificate ensures and returns a user certificate - should be idempotent
 	ReconcileUserCertificate(


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | fixes #743 |
| License         | Apache 2.0 |


### What's in this PR?
Use logger from the context given by the controller runtime wherever it is applicable

### Why?
Simplify the codebase by :
- Reducing the number of loggers that we initialized for the controllers
- Reducing the number of parameters that get passed to a lot of functions

### Additional context
Example logs with the changes:
```
I0203 22:11:43.591047       1 request.go:665] Waited for 1.044370458s due to client-side throttling, not priority and fairness, request: GET:https://10.10.0.1:443/apis/telemetry.istio.io/v1alpha1?timeout=32s
{"level":"info","ts":"2022-02-03T22:11:43.592Z","logger":"controller-runtime.metrics","msg":"Metrics server is starting to listen","addr":":8080"}
{"level":"info","ts":"2022-02-03T22:11:43.593Z","logger":"controller-runtime.webhook","msg":"Registering webhook","path":"/validate"}
{"level":"info","ts":"2022-02-03T22:11:43.593Z","logger":"setup","msg":"starting manager"}
{"level":"info","ts":"2022-02-03T22:11:43.593Z","logger":"controller-runtime.webhook.webhooks","msg":"Starting webhook server"}
{"level":"info","ts":"2022-02-03T22:11:43.593Z","msg":"Starting server","path":"/metrics","kind":"metrics","addr":"[::]:8080"}
{"level":"info","ts":"2022-02-03T22:11:43.594Z","logger":"controller-runtime.certwatcher","msg":"Updated current TLS certificate"}
{"level":"info","ts":"2022-02-03T22:11:43.594Z","logger":"controller-runtime.webhook","msg":"Serving webhook server","host":"","port":443}
{"level":"info","ts":"2022-02-03T22:11:43.594Z","logger":"controller-runtime.certwatcher","msg":"Starting certificate watcher"}
I0203 22:11:43.694455       1 leaderelection.go:248] attempting to acquire leader lease kafka/controller-leader-election-helper...
I0203 22:11:59.264106       1 leaderelection.go:258] successfully acquired lease kafka/controller-leader-election-helper
{"level":"info","ts":"2022-02-03T22:11:59.264Z","logger":"controller.KafkaTopic","msg":"Starting EventSource","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaTopic","source":"kind source: *v1alpha1.KafkaTopic"}
{"level":"info","ts":"2022-02-03T22:11:59.264Z","logger":"controller.KafkaTopic","msg":"Starting Controller","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaTopic"}
{"level":"info","ts":"2022-02-03T22:11:59.265Z","logger":"controller.CruiseControl","msg":"Starting EventSource","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster","source":"kind source: *v1beta1.KafkaCluster"}
{"level":"info","ts":"2022-02-03T22:11:59.265Z","logger":"controller.CruiseControl","msg":"Starting Controller","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster"}
{"level":"info","ts":"2022-02-03T22:11:59.265Z","logger":"controller.KafkaUser","msg":"Starting EventSource","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaUser","source":"kind source: *v1alpha1.KafkaUser"}
{"level":"info","ts":"2022-02-03T22:11:59.265Z","logger":"controller.KafkaUser","msg":"Starting EventSource","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaUser","source":"kind source: *v1.CertificateSigningRequest"}
{"level":"info","ts":"2022-02-03T22:11:59.265Z","logger":"controller.KafkaUser","msg":"Starting Controller","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaUser"}
{"level":"info","ts":"2022-02-03T22:11:59.265Z","logger":"controller.KafkaCluster","msg":"Starting EventSource","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster","source":"kind source: *v1beta1.KafkaCluster"}
{"level":"info","ts":"2022-02-03T22:11:59.265Z","logger":"controller.KafkaCluster","msg":"Starting EventSource","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster","source":"kind source: *v1.Service"}
{"level":"info","ts":"2022-02-03T22:11:59.266Z","logger":"controller.KafkaCluster","msg":"Starting EventSource","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster","source":"kind source: *v1.ConfigMap"}
{"level":"info","ts":"2022-02-03T22:11:59.266Z","logger":"controller.KafkaCluster","msg":"Starting EventSource","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster","source":"kind source: *v1beta1.PodDisruptionBudget"}
{"level":"info","ts":"2022-02-03T22:11:59.266Z","logger":"controller.KafkaCluster","msg":"Starting EventSource","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster","source":"kind source: *v1.PersistentVolumeClaim"}
{"level":"info","ts":"2022-02-03T22:11:59.266Z","logger":"controller.KafkaCluster","msg":"Starting EventSource","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster","source":"kind source: *v1.Pod"}
{"level":"info","ts":"2022-02-03T22:11:59.266Z","logger":"controller.KafkaCluster","msg":"Starting EventSource","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster","source":"kind source: *v1.Service"}
{"level":"info","ts":"2022-02-03T22:11:59.266Z","logger":"controller.KafkaCluster","msg":"Starting EventSource","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster","source":"kind source: *v1.Deployment"}
{"level":"info","ts":"2022-02-03T22:11:59.266Z","logger":"controller.KafkaCluster","msg":"Starting EventSource","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster","source":"kind source: *v1.ConfigMap"}
{"level":"info","ts":"2022-02-03T22:11:59.266Z","logger":"controller.KafkaCluster","msg":"Starting EventSource","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster","source":"kind source: *v1.Service"}
{"level":"info","ts":"2022-02-03T22:11:59.266Z","logger":"controller.KafkaCluster","msg":"Starting EventSource","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster","source":"kind source: *v1.Deployment"}
{"level":"info","ts":"2022-02-03T22:11:59.266Z","logger":"controller.KafkaCluster","msg":"Starting EventSource","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster","source":"kind source: *v1.ConfigMap"}
{"level":"info","ts":"2022-02-03T22:11:59.266Z","logger":"controller.KafkaCluster","msg":"Starting Controller","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster"}
{"level":"info","ts":"2022-02-03T22:11:59.666Z","logger":"controller.KafkaTopic","msg":"Starting workers","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaTopic","worker count":10}
{"level":"info","ts":"2022-02-03T22:11:59.667Z","logger":"controller.KafkaTopic","msg":"Reconciling KafkaTopic","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaTopic","name":"kafkacat-airports","namespace":"kafka","kafkatopic":"kafka/kafkacat-airports","Request.Name":"kafkacat-airports"}
{"level":"info","ts":"2022-02-03T22:11:59.734Z","logger":"controller.CruiseControl","msg":"Starting workers","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster","worker count":1}
{"level":"info","ts":"2022-02-03T22:11:59.735Z","logger":"controller.CruiseControl","msg":"no active tasks found in Kafka Cluster status","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster","name":"kafka","namespace":"kafka"}
{"level":"info","ts":"2022-02-03T22:11:59.737Z","logger":"controller.KafkaUser","msg":"Starting workers","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaUser","worker count":1}
{"level":"info","ts":"2022-02-03T22:11:59.737Z","logger":"controller.KafkaCluster","msg":"Starting workers","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster","worker count":1}
{"level":"info","ts":"2022-02-03T22:11:59.737Z","logger":"controller.KafkaUser","msg":"Reconciling KafkaUser","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaUser","name":"example-kafkauser","namespace":"default","kafkauser":"default/example-kafkauser","Request.Name":"example-kafkauser"}
{"level":"info","ts":"2022-02-03T22:11:59.737Z","logger":"controller.KafkaCluster","msg":"Reconciling KafkaCluster","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster","name":"kafka","namespace":"kafka","Request.Namespace":"kafka/kafka","Request.Name":"kafka"}
{"level":"info","ts":"2022-02-03T22:11:59.834Z","logger":"controller.KafkaCluster","msg":"CR status updated","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster","name":"kafka","namespace":"kafka","Request.Namespace":"kafka/kafka","Request.Name":"kafka","status":"ClusterReconciling"}
{"level":"info","ts":"2022-02-03T22:11:59.934Z","logger":"controller.KafkaUser","msg":"Ensuring read ACLs for User: CN=example-kafkauser -> Topic: kafkacat-airports","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaUser","name":"example-kafkauser","namespace":"default","kafkauser":"default/example-kafkauser","Request.Name":"example-kafkauser"}
{"level":"info","ts":"2022-02-03T22:11:59.944Z","logger":"kafka_util","msg":"Kafka client closed cleanly"}
{"level":"info","ts":"2022-02-03T22:11:59.962Z","logger":"kafka_util","msg":"Kafka client closed cleanly"}
{"level":"info","ts":"2022-02-03T22:11:59.963Z","logger":"controller.KafkaTopic","msg":"Topic already exists, verifying configuration","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaTopic","name":"kafkacat-airports","namespace":"kafka","kafkatopic":"kafka/kafkacat-airports","Request.Name":"kafkacat-airports"}
{"level":"info","ts":"2022-02-03T22:11:59.981Z","logger":"controller.KafkaTopic","msg":"Verified partitions and configuration for topic","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaTopic","name":"kafkacat-airports","namespace":"kafka","kafkatopic":"kafka/kafkacat-airports","Request.Name":"kafkacat-airports"}
{"level":"info","ts":"2022-02-03T22:11:59.982Z","logger":"controller.KafkaTopic","msg":"Ensured topic","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaTopic","name":"kafkacat-airports","namespace":"kafka","kafkatopic":"kafka/kafkacat-airports","Request.Name":"kafkacat-airports"}
{"level":"info","ts":"2022-02-03T22:11:59.982Z","logger":"kafka_util","msg":"Kafka client closed cleanly"}
{"level":"info","ts":"2022-02-03T22:12:00.160Z","logger":"controller.KafkaCluster","msg":"Kafka cluster state updated","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster","name":"kafka","namespace":"kafka","Request.Namespace":"kafka/kafka","Request.Name":"kafka","component":"kafka","clusterName":"kafka","clusterNamespace":"kafka"}
{"level":"info","ts":"2022-02-03T22:12:00.177Z","logger":"kafka_util","msg":"Kafka client closed cleanly"}
{"level":"info","ts":"2022-02-03T22:12:00.304Z","logger":"controller.KafkaCluster","msg":"Kafka cluster state updated","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster","name":"kafka","namespace":"kafka","Request.Namespace":"kafka/kafka","Request.Name":"kafka","component":"kafka","clusterName":"kafka","clusterNamespace":"kafka"}
{"level":"info","ts":"2022-02-03T22:12:00.339Z","logger":"kafka_util","msg":"Kafka client closed cleanly"}
{"level":"info","ts":"2022-02-03T22:12:00.355Z","logger":"kafka_util","msg":"Kafka client closed cleanly"}
{"level":"info","ts":"2022-02-03T22:12:00.355Z","logger":"controller.KafkaCluster.generateCCTopic","msg":"CruiseControl topic has been created by CruiseControl","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster","name":"kafka","namespace":"kafka","Request.Namespace":"kafka/kafka","Request.Name":"kafka","component":"kafka-cruisecontrol"}
{"level":"info","ts":"2022-02-03T22:12:00.367Z","logger":"controller.KafkaCluster","msg":"CR status updated","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster","name":"kafka","namespace":"kafka","Request.Namespace":"kafka/kafka","Request.Name":"kafka","component":"kafka-cruisecontrol","status":"CruiseControlTopicReady"}
{"level":"info","ts":"2022-02-03T22:12:00.367Z","logger":"controller.KafkaCluster","msg":"Generating capacity config","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster","name":"kafka","namespace":"kafka","Request.Namespace":"kafka/kafka","Request.Name":"kafka","component":"kafka-cruisecontrol"}
{"level":"info","ts":"2022-02-03T22:12:00.367Z","logger":"controller.KafkaCluster","msg":"incoming network throughput is not set falling back to default value","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster","name":"kafka","namespace":"kafka","Request.Namespace":"kafka/kafka","Request.Name":"kafka","component":"kafka-cruisecontrol"}
{"level":"info","ts":"2022-02-03T22:12:00.367Z","logger":"controller.KafkaCluster","msg":"outgoing network throughput is not set falling back to default value","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster","name":"kafka","namespace":"kafka","Request.Namespace":"kafka/kafka","Request.Name":"kafka","component":"kafka-cruisecontrol"}
{"level":"info","ts":"2022-02-03T22:12:00.367Z","logger":"controller.KafkaCluster","msg":"The following brokerCapacity was generated","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster","name":"kafka","namespace":"kafka","Request.Namespace":"kafka/kafka","Request.Name":"kafka","component":"kafka-cruisecontrol","brokerCapacity":{"brokerId":"0","capacity":{"DISK":{"/kafka-logs/kafka":"10737"},"CPU":"150","NW_IN":"125000","NW_OUT":"125000"},"doc":"Capacity unit used for disk is in MB, cpu is in percentage, network throughput is in KB."}}
{"level":"info","ts":"2022-02-03T22:12:00.367Z","logger":"controller.KafkaCluster","msg":"incoming network throughput is not set falling back to default value","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster","name":"kafka","namespace":"kafka","Request.Namespace":"kafka/kafka","Request.Name":"kafka","component":"kafka-cruisecontrol"}
{"level":"info","ts":"2022-02-03T22:12:00.367Z","logger":"controller.KafkaCluster","msg":"outgoing network throughput is not set falling back to default value","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster","name":"kafka","namespace":"kafka","Request.Namespace":"kafka/kafka","Request.Name":"kafka","component":"kafka-cruisecontrol"}
{"level":"info","ts":"2022-02-03T22:12:00.367Z","logger":"controller.KafkaCluster","msg":"The following brokerCapacity was generated","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster","name":"kafka","namespace":"kafka","Request.Namespace":"kafka/kafka","Request.Name":"kafka","component":"kafka-cruisecontrol","brokerCapacity":{"brokerId":"1","capacity":{"DISK":{"/kafka-logs/kafka":"10737"},"CPU":"150","NW_IN":"125000","NW_OUT":"125000"},"doc":"Capacity unit used for disk is in MB, cpu is in percentage, network throughput is in KB."}}
{"level":"info","ts":"2022-02-03T22:12:00.367Z","logger":"controller.KafkaCluster","msg":"Generated capacity config was successful with values: {\n    \"brokerCapacities\": [\n        {\n            \"brokerId\": \"0\",\n            \"capacity\": {\n                \"DISK\": {\n                    \"/kafka-logs/kafka\": \"10737\"\n                },\n                \"CPU\": \"150\",\n                \"NW_IN\": \"125000\",\n                \"NW_OUT\": \"125000\"\n            },\n            \"doc\": \"Capacity unit used for disk is in MB, cpu is in percentage, network throughput is in KB.\"\n        },\n        {\n            \"brokerId\": \"1\",\n            \"capacity\": {\n                \"DISK\": {\n                    \"/kafka-logs/kafka\": \"10737\"\n                },\n                \"CPU\": \"150\",\n                \"NW_IN\": \"125000\",\n                \"NW_OUT\": \"125000\"\n            },\n            \"doc\": \"Capacity unit used for disk is in MB, cpu is in percentage, network throughput is in KB.\"\n        },\n        {\n            \"brokerId\": \"-1\",\n            \"capacity\": {\n                \"DISK\": {\n                    \"/kafka-logs/kafka\": \"10737\"\n                },\n                \"CPU\": \"100\",\n                \"NW_IN\": \"125000\",\n                \"NW_OUT\": \"125000\"\n            },\n            \"doc\": \"Capacity unit used for disk is in MB, cpu is in percentage, network throughput is in KB.\"\n        }\n    ]\n}","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster","name":"kafka","namespace":"kafka","Request.Namespace":"kafka/kafka","Request.Name":"kafka","component":"kafka-cruisecontrol"}
{"level":"info","ts":"2022-02-03T22:12:00.374Z","logger":"controller.KafkaCluster","msg":"ensuring finalizers on kafkacluster","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster","name":"kafka","namespace":"kafka","Request.Namespace":"kafka/kafka","Request.Name":"kafka"}
{"level":"info","ts":"2022-02-03T22:12:00.411Z","logger":"controller.KafkaCluster","msg":"CR status updated","reconciler group":"kafka.banzaicloud.io","reconciler kind":"KafkaCluster","name":"kafka","namespace":"kafka","Request.Namespace":"kafka/kafka","Request.Name":"kafka","status":"ClusterRunning"}
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Logging code meets the guideline