### PR TITLE
add Kafka metric support for 3 labels

### DIFF
--- a/api/assets/kafka/jmx-exporter.yml
+++ b/api/assets/kafka/jmx-exporter.yml
@@ -156,6 +156,14 @@ rules:
   # Emulate Prometheus 'Summary' metrics for the exported 'Histogram's.
   #
   # Note that these are missing the '_sum' metric!
+  - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+), (.+)=(.+), (.+)=(.+)><>Count
+    name: kafka_$1_$2_$3_count
+    cache: true
+    type: COUNTER
+    labels:
+      "$4": "$5"
+      "$6": "$7"
+      "$8": "$9"
   - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+), (.+)=(.+)><>Count
     name: kafka_$1_$2_$3_count
     cache: true
@@ -194,7 +202,16 @@ rules:
     type: GAUGE
     labels:
       quantile: "0.$4"
-  # Catch all other GAUGES with other types with 0-2 key-value pairs
+  # Catch all other GAUGES with other types with 0-3 key-value pairs
+  - pattern : kafka.(\w+)<type=([A-Za-z-]+), (.+)=(.+), (.+)=(.+), (.+)=(.+)><>([A-Za-z-]+)
+    name: kafka_$1_$2_$9
+    type: GAUGE
+    cache: true
+    labels:
+      "$3": "$4"
+      "$5": "$6"
+      "$7": "$8"
+  # Catch all other GAUGES with other types with 0-2 key-value pairs   
   - pattern : kafka.(\w+)<type=([A-Za-z-]+), (.+)=(.+), (.+)=(.+)><>([A-Za-z-]+)
     name: kafka_$1_$2_$7
     type: GAUGE


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | n/a |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
PR enables Kafka JMX metrics with 3 labels, for both counters and gauges.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
The current JMX Prometheus agent configuration does not support more than 2 JMX metric labels.
This results in some labels being erroneously parsed e.g.
```
kafka_network_requestmetrics_fifteenminuterate{name_ErrorsPerSec_request="ApiVersions",error="NONE",} 0.7567675751254123
```
instead of:
```
kafka_network_requestmetrics_fifteenminuterate{name="ErrorsPerSec",request="ApiVersions",error="NONE",} 0.786777163057294
```


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)

