### PR TITLE
Fix: kafka topic indexers are not added to manager cache when multinamespace cache is used

### DIFF
--- a/pkg/k8sutil/cache.go
+++ b/pkg/k8sutil/cache.go
@@ -18,43 +18,35 @@ import (
 	"context"
 
 	"emperror.dev/errors"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/banzaicloud/koperator/api/v1alpha1"
 )
 
-func AddKafkaTopicIndexers(ctx context.Context) cache.NewCacheFunc {
-	return func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
-		newCache, err := cache.New(config, opts)
-		if err != nil {
-			return nil, err
-		}
-
-		nameIndexFunc := func(obj client.Object) []string {
-			return []string{obj.(*v1alpha1.KafkaTopic).Spec.Name}
-		}
-		err = newCache.IndexField(ctx, &v1alpha1.KafkaTopic{}, "spec.name", nameIndexFunc)
-		if err != nil {
-			return nil, errors.WrapIfWithDetails(err, "could not setup indexer for field", "field", "spec.name")
-		}
-
-		clusterNameIndexFunc := func(obj client.Object) []string {
-			return []string{obj.(*v1alpha1.KafkaTopic).Spec.ClusterRef.Name}
-		}
-		err = newCache.IndexField(ctx, &v1alpha1.KafkaTopic{}, "spec.clusterRef.name", clusterNameIndexFunc)
-		if err != nil {
-			return nil, errors.WrapIfWithDetails(err, "could not setup indexer for field", "field", "spec.clusterRef.name")
-		}
-
-		clusterNamespaceIndexFunc := func(obj client.Object) []string {
-			return []string{obj.(*v1alpha1.KafkaTopic).Spec.ClusterRef.Namespace}
-		}
-		err = newCache.IndexField(ctx, &v1alpha1.KafkaTopic{}, "spec.clusterRef.namespace", clusterNamespaceIndexFunc)
-		if err != nil {
-			return nil, errors.WrapIfWithDetails(err, "could not setup indexer for field", "field", "spec.clusterRef.namespace")
-		}
-		return newCache, nil
+func AddKafkaTopicIndexers(ctx context.Context, cache cache.Cache) error {
+	nameIndexFunc := func(obj client.Object) []string {
+		return []string{obj.(*v1alpha1.KafkaTopic).Spec.Name}
 	}
+	err := cache.IndexField(ctx, &v1alpha1.KafkaTopic{}, "spec.name", nameIndexFunc)
+	if err != nil {
+		return errors.WrapIfWithDetails(err, "could not setup indexer for field", "field", "spec.name")
+	}
+
+	clusterNameIndexFunc := func(obj client.Object) []string {
+		return []string{obj.(*v1alpha1.KafkaTopic).Spec.ClusterRef.Name}
+	}
+	err = cache.IndexField(ctx, &v1alpha1.KafkaTopic{}, "spec.clusterRef.name", clusterNameIndexFunc)
+	if err != nil {
+		return errors.WrapIfWithDetails(err, "could not setup indexer for field", "field", "spec.clusterRef.name")
+	}
+
+	clusterNamespaceIndexFunc := func(obj client.Object) []string {
+		return []string{obj.(*v1alpha1.KafkaTopic).Spec.ClusterRef.Namespace}
+	}
+	err = cache.IndexField(ctx, &v1alpha1.KafkaTopic{}, "spec.clusterRef.namespace", clusterNamespaceIndexFunc)
+	if err != nil {
+		return errors.WrapIfWithDetails(err, "could not setup indexer for field", "field", "spec.clusterRef.namespace")
+	}
+	return nil
 }


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | fixes #727 |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Add kafka topic indexers to the cache used by the manager regardless the type of the cache

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Kafka topic indexers were not added to the multinamespace cache which is used instead of the default cache when koperator is configured to watch resources only in specific set of namespaces.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
