### PR TITLE
Update cc version

### DIFF
--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -878,7 +878,7 @@ func (cConfig *CruiseControlConfig) GetCCImage() string {
 	if cConfig.Image != "" {
 		return cConfig.Image
 	}
-	return "ghcr.io/banzaicloud/cruise-control:2.5.85"
+	return "ghcr.io/banzaicloud/cruise-control:2.5.86"
 }
 
 // GetCCLog4jConfig returns the used Cruise Control log4j configuration

--- a/config/samples/kafkacluster_with_ssl_groups.yaml
+++ b/config/samples/kafkacluster_with_ssl_groups.yaml
@@ -20,7 +20,7 @@ spec:
     cruise.control.metrics.topic.auto.create=true
     cruise.control.metrics.topic.num.partitions=1
     cruise.control.metrics.topic.replication.factor=2
-    authorizer.class.name=kafka.security.auth.SimpleAclAuthorizer
+    authorizer.class.name=kafka.security.authorizer.AclAuthorizer
     allow.everyone.if.no.acl.found=false
   brokerConfigGroups:
     default:

--- a/config/samples/kafkacluster_with_ssl_groups_customcert.yaml
+++ b/config/samples/kafkacluster_with_ssl_groups_customcert.yaml
@@ -20,7 +20,7 @@ spec:
     cruise.control.metrics.topic.auto.create=true
     cruise.control.metrics.topic.num.partitions=1
     cruise.control.metrics.topic.replication.factor=2
-    authorizer.class.name=kafka.security.auth.SimpleAclAuthorizer
+    authorizer.class.name=kafka.security.authorizer.AclAuthorizer
     allow.everyone.if.no.acl.found=false
   brokerConfigGroups:
     default:

--- a/config/samples/kafkacluster_with_ssl_hybrid_customcert.yaml
+++ b/config/samples/kafkacluster_with_ssl_hybrid_customcert.yaml
@@ -20,7 +20,7 @@ spec:
     cruise.control.metrics.topic.auto.create=true
     cruise.control.metrics.topic.num.partitions=1
     cruise.control.metrics.topic.replication.factor=2
-    authorizer.class.name=kafka.security.auth.SimpleAclAuthorizer
+    authorizer.class.name=kafka.security.authorizer.AclAuthorizer
     allow.everyone.if.no.acl.found=false
   brokerConfigGroups:
     default:

--- a/config/samples/simplekafkacluster.yaml
+++ b/config/samples/simplekafkacluster.yaml
@@ -78,7 +78,7 @@ spec:
 #      limits:
 #        cpu: 500m
 #        memory: 1Gi
-#    image: "ghcr.io/banzaicloud/cruise-control:2.5.85"
+#    image: "ghcr.io/banzaicloud/cruise-control:2.5.86"
     config: |
       # Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
       #

--- a/controllers/tests/kafkacluster_controller_cruisecontrol_test.go
+++ b/controllers/tests/kafkacluster_controller_cruisecontrol_test.go
@@ -259,7 +259,7 @@ func expectCruiseControlDeployment(kafkaCluster *v1beta1.KafkaCluster) {
 	Expect(container.Lifecycle).NotTo(BeNil())
 	Expect(container.Lifecycle.PreStop).NotTo(BeNil())
 	Expect(container.Lifecycle.PreStop.Exec).NotTo(BeNil())
-	Expect(container.Image).To(Equal("ghcr.io/banzaicloud/cruise-control:2.5.85"))
+	Expect(container.Image).To(Equal("ghcr.io/banzaicloud/cruise-control:2.5.86"))
 	Expect(container.Ports).To(ConsistOf(
 		corev1.ContainerPort{
 			ContainerPort: 8090,

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	emperror.dev/errors v0.8.0
 	github.com/Shopify/sarama v1.30.0
 	github.com/banzaicloud/cluster-registry v0.0.7
-	github.com/banzaicloud/go-cruise-control v0.0.0-20220121135324-9178f00469c5
+	github.com/banzaicloud/go-cruise-control v0.0.0-20220324110942-71a3405be337
 	github.com/banzaicloud/istio-client-go v0.0.15
 	github.com/banzaicloud/istio-operator/api/v2 v2.11.8
 	github.com/banzaicloud/k8s-objectmatcher v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -180,6 +180,8 @@ github.com/banzaicloud/cluster-registry v0.0.7 h1:R7hE9YBybCWKOJSzrNPDIO+l8P03kG
 github.com/banzaicloud/cluster-registry v0.0.7/go.mod h1:2tcT4bq6UaWOOeIBsjcrqawOfrybamYUJSM4jRVHQic=
 github.com/banzaicloud/go-cruise-control v0.0.0-20220121135324-9178f00469c5 h1:6QjGAJrjVBf+7pjnnY6XE+D1DeMZmliv6DdpHeJW+EU=
 github.com/banzaicloud/go-cruise-control v0.0.0-20220121135324-9178f00469c5/go.mod h1:ZOrxSqMkpjRnA6eyjaSfpnkPLuCy1JKBGIi6h9hyiuM=
+github.com/banzaicloud/go-cruise-control v0.0.0-20220324110942-71a3405be337 h1:HnA0QC34j8Vd6uwP4priC2eO+0FQT0c41qnBE3DsfWw=
+github.com/banzaicloud/go-cruise-control v0.0.0-20220324110942-71a3405be337/go.mod h1:ZOrxSqMkpjRnA6eyjaSfpnkPLuCy1JKBGIi6h9hyiuM=
 github.com/banzaicloud/istio-client-go v0.0.11/go.mod h1:rpnEYYGHzisx8nARl2d30Oq38EeCX0/PPaxMaREfE9I=
 github.com/banzaicloud/istio-client-go v0.0.15 h1:F2rr1tI/+19kDddLawft8scT8mGLNgBq23gV+I0zsh4=
 github.com/banzaicloud/istio-client-go v0.0.15/go.mod h1:rpnEYYGHzisx8nARl2d30Oq38EeCX0/PPaxMaREfE9I=


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
- Update the used default Cruise Control version to `2.5.86`
- Replaced deprecated `kafka.security.auth.SimpleAclAuthorizer` with `kafka.security.authorizer.AclAuthorizer` in samples

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
- Latest Cruise Control version that support Kafka `3.1.0` is `2.5.86`
- `kafka.security.auth.SimpleAclAuthorizer` was removed in Kafka `3.1.0`

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)

