### PR TITLE
Factor out cluster registry owned resource filtering into common function

### DIFF
--- a/controllers/controller_common.go
+++ b/controllers/controller_common.go
@@ -18,6 +18,10 @@ import (
 	"fmt"
 	"time"
 
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	"github.com/banzaicloud/koperator/pkg/util"
+
 	"emperror.dev/errors"
 	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -117,4 +121,24 @@ func applyClusterRefLabel(cluster *v1beta1.KafkaCluster, labels map[string]strin
 
 func SetNewKafkaFromCluster(f func(k8sclient client.Client, cluster *v1beta1.KafkaCluster) (kafkaclient.KafkaClient, func(), error)) {
 	newKafkaFromCluster = f
+}
+
+// SkipClusterRegistryOwnedResourcePredicate returns controller event filter that filters
+// out events triggered by Cluster Registry owned resources
+type SkipClusterRegistryOwnedResourcePredicate struct{}
+
+func (SkipClusterRegistryOwnedResourcePredicate) Create(e event.CreateEvent) bool {
+	return !util.ObjectManagedByClusterRegistry(e.Object)
+}
+
+func (SkipClusterRegistryOwnedResourcePredicate) Delete(e event.DeleteEvent) bool {
+	return !util.ObjectManagedByClusterRegistry(e.Object)
+}
+
+func (p SkipClusterRegistryOwnedResourcePredicate) Update(e event.UpdateEvent) bool {
+	return !util.ObjectManagedByClusterRegistry(e.ObjectNew)
+}
+
+func (p SkipClusterRegistryOwnedResourcePredicate) Generic(e event.GenericEvent) bool {
+	return !util.ObjectManagedByClusterRegistry(e.Object)
 }

--- a/controllers/controller_common.go
+++ b/controllers/controller_common.go
@@ -123,7 +123,7 @@ func SetNewKafkaFromCluster(f func(k8sclient client.Client, cluster *v1beta1.Kaf
 	newKafkaFromCluster = f
 }
 
-// SkipClusterRegistryOwnedResourcePredicate returns controller event filter that filters
+// SkipClusterRegistryOwnedResourcePredicate returns a controller event filter that filters
 // out events triggered by Cluster Registry owned resources
 type SkipClusterRegistryOwnedResourcePredicate struct{}
 

--- a/controllers/kafkatopic_controller.go
+++ b/controllers/kafkatopic_controller.go
@@ -21,13 +21,10 @@ import (
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/banzaicloud/koperator/api/v1alpha1"
@@ -41,45 +38,12 @@ var topicFinalizer = "finalizer.kafkatopics.kafka.banzaicloud.io"
 
 // SetupKafkaTopicWithManager registers kafka topic controller with manager
 func SetupKafkaTopicWithManager(mgr ctrl.Manager, maxConcurrentReconciles int) *ctrl.Builder {
-	builder := ctrl.NewControllerManagedBy(mgr).For(&v1alpha1.KafkaTopic{}).Named("KafkaTopic")
+	builder := ctrl.NewControllerManagedBy(mgr).
+		For(&v1alpha1.KafkaTopic{}).
+		WithEventFilter(SkipClusterRegistryOwnedResourcePredicate{}).
+		Named("KafkaTopic")
 	builder.WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles})
 
-	builder.WithEventFilter(
-		predicate.Funcs{
-			CreateFunc: func(e event.CreateEvent) bool {
-				object, err := meta.Accessor(e.Object)
-				if err != nil {
-					return false
-				}
-				// Skip object if v1alpha1.OwnershipAnnotation is set as it is owned by other system.
-				if ok := util.ObjectManagedByClusterRegistry(object); ok {
-					return false
-				}
-				return true
-			},
-			DeleteFunc: func(e event.DeleteEvent) bool {
-				object, err := meta.Accessor(e.Object)
-				if err != nil {
-					return false
-				}
-				// Skip object if v1alpha1.OwnershipAnnotation is set as it is owned by other system.
-				if ok := util.ObjectManagedByClusterRegistry(object); ok {
-					return false
-				}
-				return true
-			},
-			UpdateFunc: func(e event.UpdateEvent) bool {
-				object, err := meta.Accessor(e.ObjectNew)
-				if err != nil {
-					return false
-				}
-				// Skip object if v1alpha1.OwnershipAnnotation is set as it is owned by other system.
-				if ok := util.ObjectManagedByClusterRegistry(object); ok {
-					return false
-				}
-				return true
-			},
-		})
 	return builder
 }
 

--- a/controllers/kafkauser_controller.go
+++ b/controllers/kafkauser_controller.go
@@ -102,7 +102,7 @@ type csrMapper struct {
 	log    logr.Logger
 }
 
-// mapToKafkaUser maps CertificateSigningRequest event to KafkaUser reconcile event
+// mapToKafkaUser maps CertificateSigningRequest events to KafkaUser reconcile events
 func (m *csrMapper) mapToKafkaUser(obj client.Object) []ctrl.Request {
 	certSigningReqAnnotations := obj.GetAnnotations()
 	kafkaUserResourceNamespacedName, ok := certSigningReqAnnotations[pkicommon.KafkaUserAnnotationName]

--- a/controllers/kafkauser_controller.go
+++ b/controllers/kafkauser_controller.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"emperror.dev/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 
 	"github.com/banzaicloud/k8s-objectmatcher/patch"
 
@@ -59,52 +58,22 @@ var userFinalizer = "finalizer.kafkausers.kafka.banzaicloud.io"
 func SetupKafkaUserWithManager(mgr ctrl.Manager, certSigningEnabled bool, certManagerNamespace bool) *ctrl.Builder {
 	log := mgr.GetLogger()
 	builder := ctrl.NewControllerManagedBy(mgr).
-		For(&v1alpha1.KafkaUser{}).Named("KafkaUser")
+		For(&v1alpha1.KafkaUser{}).
+		WithEventFilter(SkipClusterRegistryOwnedResourcePredicate{}).
+		Named("KafkaUser")
 	if certSigningEnabled {
+		csrMapper := csrMapper{
+			client: mgr.GetClient(),
+			log:    log,
+		}
 		builder.Watches(
 			&source.Kind{Type: &certsigningreqv1.CertificateSigningRequest{}},
-			handler.EnqueueRequestsFromMapFunc(certificateSigningRequestMapper),
+			handler.EnqueueRequestsFromMapFunc(csrMapper.mapToKafkaUser),
 			ctrlBuilder.WithPredicates(certificateSigningRequestFilter(log)))
 	}
 	if certManagerNamespace {
 		builder.Owns(&certv1.Certificate{})
 	}
-	builder.WithEventFilter(
-		predicate.Funcs{
-			CreateFunc: func(e event.CreateEvent) bool {
-				object, err := meta.Accessor(e.Object)
-				if err != nil {
-					return false
-				}
-				// Skip object if v1alpha1.OwnershipAnnotation is set as it is owned by other system.
-				if ok := util.ObjectManagedByClusterRegistry(object); ok {
-					return false
-				}
-				return true
-			},
-			DeleteFunc: func(e event.DeleteEvent) bool {
-				object, err := meta.Accessor(e.Object)
-				if err != nil {
-					return false
-				}
-				// Skip object if v1alpha1.OwnershipAnnotation is set as it is owned by other system.
-				if ok := util.ObjectManagedByClusterRegistry(object); ok {
-					return false
-				}
-				return true
-			},
-			UpdateFunc: func(e event.UpdateEvent) bool {
-				object, err := meta.Accessor(e.ObjectNew)
-				if err != nil {
-					return false
-				}
-				// Skip object if v1alpha1.OwnershipAnnotation is set as it is owned by other system.
-				if ok := util.ObjectManagedByClusterRegistry(object); ok {
-					return false
-				}
-				return true
-			},
-		})
 	return builder
 }
 
@@ -128,7 +97,13 @@ func certificateSigningRequestFilter(log logr.Logger) predicate.Funcs {
 	}
 }
 
-func certificateSigningRequestMapper(obj client.Object) []ctrl.Request {
+type csrMapper struct {
+	client client.Reader
+	log    logr.Logger
+}
+
+// mapToKafkaUser maps CertificateSigningRequest event to KafkaUser reconcile event
+func (m *csrMapper) mapToKafkaUser(obj client.Object) []ctrl.Request {
 	certSigningReqAnnotations := obj.GetAnnotations()
 	kafkaUserResourceNamespacedName, ok := certSigningReqAnnotations[pkicommon.KafkaUserAnnotationName]
 	if !ok {
@@ -138,10 +113,30 @@ func certificateSigningRequestMapper(obj client.Object) []ctrl.Request {
 	if len(namespaceWithName) != 2 {
 		return []ctrl.Request{}
 	}
+
+	namespace := namespaceWithName[0]
+	name := namespaceWithName[1]
+
+	ctx := context.Background()
+	var kafkaUser v1alpha1.KafkaUser
+	err := m.client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, &kafkaUser)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return []ctrl.Request{}
+		}
+		m.log.Error(err, "couldn't retrieve KafkaUser", "namespace", namespace, "name", name)
+		return []ctrl.Request{}
+	}
+
+	// skip reconciling KafkaUser if owned by Schema Registry
+	if ok := util.ObjectManagedByClusterRegistry(&kafkaUser); ok {
+		return []ctrl.Request{}
+	}
+
 	return []ctrl.Request{{
 		NamespacedName: types.NamespacedName{
-			Namespace: namespaceWithName[0],
-			Name:      namespaceWithName[1],
+			Namespace: namespace,
+			Name:      name,
 		},
 	}}
 }

--- a/controllers/kafkauser_controller.go
+++ b/controllers/kafkauser_controller.go
@@ -128,7 +128,7 @@ func (m *csrMapper) mapToKafkaUser(obj client.Object) []ctrl.Request {
 		return []ctrl.Request{}
 	}
 
-	// skip reconciling KafkaUser if owned by Schema Registry
+	// skip reconciling KafkaUser if owned by Cluster Registry
 	if ok := util.ObjectManagedByClusterRegistry(&kafkaUser); ok {
 		return []ctrl.Request{}
 	}


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Factor out the logic of filtering the cluster registry owned resources from each controller into a common place.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Simplify and reduce code size.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline