### PR TITLE
Fix: topic validation should skip cluster registry owned KafkaTopic CRs

### DIFF
--- a/controllers/kafkatopic_controller.go
+++ b/controllers/kafkatopic_controller.go
@@ -81,7 +81,7 @@ func (r *KafkaTopicReconciler) Reconcile(ctx context.Context, request reconcile.
 	// Get the referenced kafkacluster
 	clusterNamespace := getClusterRefNamespace(instance.Namespace, instance.Spec.ClusterRef)
 	var cluster *v1beta1.KafkaCluster
-	if cluster, err = k8sutil.LookupKafkaCluster(r.Client, instance.Spec.ClusterRef.Name, clusterNamespace); err != nil {
+	if cluster, err = k8sutil.LookupKafkaCluster(ctx, r.Client, instance.Spec.ClusterRef.Name, clusterNamespace); err != nil {
 		// This shouldn't trigger anymore, but leaving it here as a safetybelt
 		if k8sutil.IsMarkedForDeletion(instance.ObjectMeta) {
 			reqLogger.Info("Cluster is already gone, there is nothing we can do")

--- a/controllers/kafkauser_controller.go
+++ b/controllers/kafkauser_controller.go
@@ -180,7 +180,7 @@ func (r *KafkaUserReconciler) Reconcile(ctx context.Context, request reconcile.R
 	// Get the referenced kafkacluster
 	clusterNamespace := getClusterRefNamespace(instance.Namespace, instance.Spec.ClusterRef)
 	var cluster *v1beta1.KafkaCluster
-	if cluster, err = k8sutil.LookupKafkaCluster(r.Client, instance.Spec.ClusterRef.Name, clusterNamespace); err != nil {
+	if cluster, err = k8sutil.LookupKafkaCluster(ctx, r.Client, instance.Spec.ClusterRef.Name, clusterNamespace); err != nil {
 		// This shouldn't trigger anymore, but leaving it here as a safetybelt
 		if k8sutil.IsMarkedForDeletion(instance.ObjectMeta) {
 			reqLogger.Info("Cluster is gone already, there is nothing we can do")

--- a/pkg/k8sutil/lookup.go
+++ b/pkg/k8sutil/lookup.go
@@ -24,9 +24,9 @@ import (
 )
 
 // LookupKafkaCluster returns the running cluster instance based on its name and namespace
-func LookupKafkaCluster(client runtimeClient.Client, clusterName, clusterNamespace string) (cluster *v1beta1.KafkaCluster, err error) {
+func LookupKafkaCluster(ctx context.Context, client runtimeClient.Reader, clusterName, clusterNamespace string) (cluster *v1beta1.KafkaCluster, err error) {
 	cluster = &v1beta1.KafkaCluster{}
-	err = client.Get(context.TODO(), types.NamespacedName{Name: clusterName, Namespace: clusterNamespace}, cluster)
+	err = client.Get(ctx, types.NamespacedName{Name: clusterName, Namespace: clusterNamespace}, cluster)
 	return
 }
 


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Topic validation skips `KafkaTopic` CRs owned by cluster registry as those represent remote kafka topics created.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Remote `KafkaTopic` may have the same name and reference Kafka clusters with the same as local `KafkaTopic` CRs thus validation will incorrectly reject the KafkaTopic create/updated/delete request.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline