### PR TITLE
Update supported AdmissionReview versions

### DIFF
--- a/api/v1alpha1/kafkatopic_types.go
+++ b/api/v1alpha1/kafkatopic_types.go
@@ -37,7 +37,7 @@ type KafkaTopicStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // +k8s:openapi-gen=true
-// +kubebuilder:webhook:failurePolicy="fail",sideEffects="None",name="kafkatopics.kafka.banzaicloud.io",path="/validate",mutating=false,resources={"kafkatopics"},verbs={"create","update"},groups={"kafka.banzaicloud.io"},versions={"v1alpha1"},admissionReviewVersions={"v1beta1"}
+// +kubebuilder:webhook:failurePolicy="fail",sideEffects="None",name="kafkatopics.kafka.banzaicloud.io",path="/validate",mutating=false,resources={"kafkatopics"},verbs={"create","update"},groups={"kafka.banzaicloud.io"},versions={"v1alpha1"},admissionReviewVersions={"v1"}
 
 // KafkaTopic is the Schema for the kafkatopics API
 // +kubebuilder:object:root=true

--- a/charts/kafka-operator/templates/operator-deployment-with-webhook.yaml
+++ b/charts/kafka-operator/templates/operator-deployment-with-webhook.yaml
@@ -31,7 +31,7 @@ metadata:
   name: {{ include "kafka-operator.name" . }}-validating-webhook
 webhooks:
 - admissionReviewVersions:
-  - v1beta1
+  - v1
   clientConfig:
     caBundle: {{ $caCrt }}
     service:

--- a/config/base/webhook/manifests.yaml
+++ b/config/base/webhook/manifests.yaml
@@ -6,7 +6,7 @@ metadata:
   name: validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
-  - v1beta1
+  - v1
   clientConfig:
     service:
       name: webhook-service


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Update supported AdmissionReview versions

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
`AdmissionReview` version `v1` has been introduced in Kubernetes version 1.16 to replace version `v1beta1` which was deprecated in Kubernetes version 1.19.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested