### PR TITLE
Fix: sample Prometheus custom resource has wrong settings

### DIFF
--- a/config/samples/kafkacluster-prometheus.yaml
+++ b/config/samples/kafkacluster-prometheus.yaml
@@ -178,7 +178,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus
-  namespace: default
+  namespace: kafka
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: Prometheus
@@ -196,8 +196,8 @@ spec:
       port: alerts
   serviceMonitorSelector:
     matchLabels:
-      app: kafka
       kafka_cr: kafka
+      release: prometheus-operator
   ruleSelector:
     matchLabels:
       prometheus: kafka-rules


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Sample Prometheus custom resource and ClusterRoleBinding for monitoring the sample Kafka cluster settings fixed.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Sample Prometheus unable to scrape metrics from sample Kafka cluster


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
