### PR TITLE
Fix kafka broker pod label selector used when reconciling broker pod deletion

### DIFF
--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -297,11 +297,9 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 
 func (r *Reconciler) reconcileKafkaPodDelete(log logr.Logger) error {
 	podList := &corev1.PodList{}
-
 	err := r.Client.List(context.TODO(), podList,
-		client.ListOption(client.InNamespace(r.KafkaCluster.Namespace)),
-		client.ListOption(client.MatchingLabels(kafka.LabelsForKafka(r.KafkaCluster.Name))),
-		client.ListOption(client.HasLabels{"brokerId"}),
+		client.InNamespace(r.KafkaCluster.Namespace),
+		client.MatchingLabels(kafka.LabelsForKafka(r.KafkaCluster.Name)),
 	)
 	if err != nil {
 		return errors.WrapIf(err, "failed to reconcile resource")


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | fixes #792 |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Remove the `client.HasLabels` from the used label selector to find kafka broker pods that belong to cluster during broker pod deletion reconciliation.
The `client.MatchingLabels(kafka.LabelsForKafka(r.KafkaCluster.Name))` label selector is enough to match broker pods that belong to a cluster in a given namespace.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
`controller-runtime` doesn't support multiple label selector option to be specified for selecting pods. When multiple label selector option is used it doesn't return an error but rather silently uses only the last label selector option from the list. This resulted to select pods in the given namespace that have `brokerId` label regardless what Kafka cluster the pods belong to as the first option `client.MatchingLabels(kafka.LabelsForKafka(r.KafkaCluster.Name))` was ignored. 


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
