### PR TITLE
Fix Kafka topic creation bug due to recent upgrade of AdmissionReview version

### DIFF
--- a/pkg/webhook/request.go
+++ b/pkg/webhook/request.go
@@ -98,7 +98,7 @@ func (s *webhookServer) serve(w http.ResponseWriter, r *http.Request) {
 		// APIVersion and Kind must be set for admission/v1, or the request would fail
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: admissionv1.SchemeGroupVersion.String(),
-			Kind: "AdmissionReview",
+			Kind:       "AdmissionReview",
 		},
 	}
 	if admissionResponse != nil {

--- a/pkg/webhook/request.go
+++ b/pkg/webhook/request.go
@@ -94,17 +94,19 @@ func (s *webhookServer) serve(w http.ResponseWriter, r *http.Request) {
 		admissionResponse = s.validate(&ar)
 	}
 
-	admissionReview := admissionv1.AdmissionReview{}
+	admissionReview := admissionv1.AdmissionReview{
+		// APIVersion and Kind must be set for admission/v1, or the request would fail
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: admissionv1.SchemeGroupVersion.String(),
+			Kind: "AdmissionReview",
+		},
+	}
 	if admissionResponse != nil {
 		admissionReview.Response = admissionResponse
 		if ar.Request != nil {
 			admissionReview.Response.UID = ar.Request.UID
 		}
 	}
-
-	// APIVersion and Kind must be set for admission/v1, or the request would fail
-	admissionReview.APIVersion = "admission.k8s.io/v1"
-	admissionReview.Kind = "AdmissionReview"
 
 	resp, err := json.Marshal(admissionReview)
 	if err != nil {

--- a/pkg/webhook/request_test.go
+++ b/pkg/webhook/request_test.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"testing"
 
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	authv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -41,9 +41,9 @@ func newRawTopic() []byte {
 	return out
 }
 
-func newAdmissionReview() *admissionv1beta1.AdmissionReview {
-	return &admissionv1beta1.AdmissionReview{
-		Request: &admissionv1beta1.AdmissionRequest{
+func newAdmissionReview() *admissionv1.AdmissionReview {
+	return &admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
 			Kind: metav1.GroupVersionKind{
 				Kind: "non-topic-kind",
 			},
@@ -170,7 +170,7 @@ func TestServe(t *testing.T) {
 		if err != nil {
 			t.Error("Expected admission review response, got error")
 		}
-		admissionReview := admissionv1beta1.AdmissionReview{}
+		admissionReview := admissionv1.AdmissionReview{}
 		if err := json.Unmarshal(body, &admissionReview); err != nil {
 			t.Error("Expected no error got:", err)
 		}
@@ -196,7 +196,7 @@ func TestServe(t *testing.T) {
 		if err != nil {
 			t.Error("Expected admission review response, got error")
 		}
-		admissionReview := admissionv1beta1.AdmissionReview{}
+		admissionReview := admissionv1.AdmissionReview{}
 		if err := json.Unmarshal(body, &admissionReview); err != nil {
 			t.Error("Expected no error got:", err)
 		}

--- a/pkg/webhook/topic_validator.go
+++ b/pkg/webhook/topic_validator.go
@@ -20,15 +20,11 @@ import (
 
 	"github.com/banzaicloud/koperator/pkg/util"
 
-	banzaicloudv1alpha1 "github.com/banzaicloud/koperator/api/v1alpha1"
-	banzaicloudv1beta1 "github.com/banzaicloud/koperator/api/v1beta1"
-	"github.com/banzaicloud/koperator/pkg/k8sutil"
 	admissionv1 "k8s.io/api/admission/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
 )
 
 const (

--- a/pkg/webhook/topic_validator.go
+++ b/pkg/webhook/topic_validator.go
@@ -25,6 +25,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	banzaicloudv1alpha1 "github.com/banzaicloud/koperator/api/v1alpha1"
+	banzaicloudv1beta1 "github.com/banzaicloud/koperator/api/v1beta1"
+	"github.com/banzaicloud/koperator/pkg/k8sutil"
 )
 
 const (

--- a/pkg/webhook/topic_validator.go
+++ b/pkg/webhook/topic_validator.go
@@ -20,15 +20,15 @@ import (
 
 	"github.com/banzaicloud/koperator/pkg/util"
 
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	banzaicloudv1alpha1 "github.com/banzaicloud/koperator/api/v1alpha1"
+	banzaicloudv1beta1 "github.com/banzaicloud/koperator/api/v1beta1"
+	"github.com/banzaicloud/koperator/pkg/k8sutil"
+	admissionv1 "k8s.io/api/admission/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	banzaicloudv1alpha1 "github.com/banzaicloud/koperator/api/v1alpha1"
-	banzaicloudv1beta1 "github.com/banzaicloud/koperator/api/v1beta1"
-	"github.com/banzaicloud/koperator/pkg/k8sutil"
 )
 
 const (
@@ -36,7 +36,7 @@ const (
 	invalidReplicationFactorErrMsg = "Replication factor is larger than the number of nodes in the kafka cluster"
 )
 
-func (s *webhookServer) validateKafkaTopic(topic *banzaicloudv1alpha1.KafkaTopic) *admissionv1beta1.AdmissionResponse {
+func (s *webhookServer) validateKafkaTopic(topic *banzaicloudv1alpha1.KafkaTopic) *admissionv1.AdmissionResponse {
 	ctx := context.Background()
 	log.Info(fmt.Sprintf("Doing pre-admission validation of kafka topic %s", topic.Spec.Name))
 
@@ -54,25 +54,21 @@ func (s *webhookServer) validateKafkaTopic(topic *banzaicloudv1alpha1.KafkaTopic
 		if apierrors.IsNotFound(err) {
 			if k8sutil.IsMarkedForDeletion(topic.ObjectMeta) {
 				log.Info("Deleted as a result of a cluster deletion")
-				return &admissionv1beta1.AdmissionResponse{
+				return &admissionv1.AdmissionResponse{
 					Allowed: true,
 				}
 			}
 			log.Error(err, "Referenced kafka cluster does not exist")
-			return notAllowed(
-				fmt.Sprintf("KafkaCluster '%s' in the namespace '%s' does not exist", topic.Spec.ClusterRef.Name, topic.Spec.ClusterRef.Namespace),
-				metav1.StatusReasonNotFound,
-			)
+			return notAllowed(fmt.Sprintf("KafkaCluster '%s' in the namespace '%s' does not exist", topic.Spec.ClusterRef.Name, topic.Spec.ClusterRef.Namespace), metav1.StatusReasonNotFound)
 		}
 		log.Error(err, "API failure while running topic validation")
 		return notAllowed("API failure while validating topic, please try again", metav1.StatusReasonServiceUnavailable)
 	}
-
 	if k8sutil.IsMarkedForDeletion(cluster.ObjectMeta) {
 		// Let this through, it's a delete topic request from a parent cluster being
 		// deleted
 		log.Info("Cluster is going down for deletion, assuming a delete topic request")
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: true,
 		}
 	}
@@ -96,7 +92,7 @@ func (s *webhookServer) validateKafkaTopic(topic *banzaicloudv1alpha1.KafkaTopic
 	}
 
 	// everything looks a-okay
-	return &admissionv1beta1.AdmissionResponse{
+	return &admissionv1.AdmissionResponse{
 		Allowed: true,
 	}
 }
@@ -104,7 +100,7 @@ func (s *webhookServer) validateKafkaTopic(topic *banzaicloudv1alpha1.KafkaTopic
 // checkKafka creates a Kafka admin client and connects to the Kafka brokers to check
 // whether the referred topic exists, and what are its properties
 func (s *webhookServer) checkKafka(ctx context.Context, topic *banzaicloudv1alpha1.KafkaTopic,
-	cluster *banzaicloudv1beta1.KafkaCluster) *admissionv1beta1.AdmissionResponse {
+	cluster *banzaicloudv1beta1.KafkaCluster) *admissionv1.AdmissionResponse {
 	// retrieve an admin client for the cluster
 	broker, closeClient, err := s.newKafkaFromCluster(s.client, cluster)
 	if err != nil {
@@ -128,10 +124,7 @@ func (s *webhookServer) checkKafka(ctx context.Context, topic *banzaicloudv1alph
 			if apierrors.IsNotFound(err) {
 				// User is trying to overwrite an existing topic - bad user
 				log.Info("User attempted to create topic with name that already exists in the kafka cluster")
-				return notAllowed(
-					fmt.Sprintf("Topic '%s' already exists on kafka cluster '%s'", topic.Spec.Name, topic.Spec.ClusterRef.Name),
-					metav1.StatusReasonAlreadyExists,
-				)
+				return notAllowed(fmt.Sprintf("Topic '%s' already exists on kafka cluster '%s'", topic.Spec.Name, topic.Spec.ClusterRef.Name), metav1.StatusReasonAlreadyExists)
 			}
 			log.Error(err, "API failure while running topic validation")
 			return notAllowed("API failure while validating topic, please try again", metav1.StatusReasonServiceUnavailable)
@@ -160,7 +153,7 @@ func (s *webhookServer) checkKafka(ctx context.Context, topic *banzaicloudv1alph
 // checkExistingKafkaTopicCRs checks whether there's any other duplicate KafkaTopic CR exists
 // that refers to the same KafkaCluster's same topic
 func (s *webhookServer) checkExistingKafkaTopicCRs(ctx context.Context,
-	clusterNamespace string, topic *banzaicloudv1alpha1.KafkaTopic) *admissionv1beta1.AdmissionResponse {
+	clusterNamespace string, topic *banzaicloudv1alpha1.KafkaTopic) *admissionv1.AdmissionResponse {
 	// check KafkaTopic in the referred KafkaCluster's namespace
 	kafkaTopicList := banzaicloudv1alpha1.KafkaTopicList{}
 	err := s.client.List(ctx, &kafkaTopicList, client.MatchingFields{"spec.name": topic.Spec.Name})


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
- Rename the imported admission pkg name from `admissionv1beta1` to `admissionv1` so it matches the version with kubebuilder to avoid confusion
- Add `Kind` and `APIVersion` to the `AdmissionReview` since they are required for "admission.k8s.io/v1" requests, reference: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#webhook-request-and-response

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
`Kind` and `APIVersion` are not required for "admission.k8s.io/v1beta1" requests but required for "admission.k8s.io/v1", without the necessary fields, the API server reports an InternalError, for example:
```
Error from server (InternalError): error when creating "STDIN": Internal error occurred: failed calling webhook "kafkatopics.kafka.banzaicloud.io": expected webhook response of admission.k8s.io/v1, Kind=AdmissionReview, got /, Kind=
```

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
In #789 we upgraded the AdmissionReview from v1beta1 to v1, which causes the topic creation to fail. With the fix, kafka topics are created successfully 

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
