### PR TITLE
Update sample kafkacluster-prometheus.yaml to use port name that match koperator's alertmanager-service

### DIFF
--- a/config/samples/kafkacluster-prometheus.yaml
+++ b/config/samples/kafkacluster-prometheus.yaml
@@ -193,7 +193,7 @@ spec:
     alertmanagers:
     - namespace: kafka
       name: kafka-operator-alertmanager
-      port: alerts
+      port: http-alerts
   serviceMonitorSelector:
     matchLabels:
       kafka_cr: kafka


### PR DESCRIPTION

| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no|
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Update sample yaml to match port name here: https://github.com/banzaicloud/koperator/blob/master/charts/kafka-operator/templates/alertmanager-service.yaml#L27

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
To registry `koperator` as alert manager with the use of the sample yaml config

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
