### PR TITLE
Delete old kafka service when headlessServiceEnabled changed

### DIFF
--- a/pkg/resources/kafka/allBrokerService.go
+++ b/pkg/resources/kafka/allBrokerService.go
@@ -15,7 +15,16 @@
 package kafka
 
 import (
+	"context"
 	"fmt"
+
+	"emperror.dev/errors"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -36,15 +45,79 @@ func (r *Reconciler) allBrokerService() runtime.Object {
 
 	return &corev1.Service{
 		ObjectMeta: templates.ObjectMetaWithAnnotations(
-			fmt.Sprintf(kafkautils.AllBrokerServiceTemplate, r.KafkaCluster.Name),
-			kafkautils.LabelsForKafka(r.KafkaCluster.Name),
+			fmt.Sprintf(kafkautils.AllBrokerServiceTemplate, r.KafkaCluster.GetName()),
+			kafkautils.LabelsForKafka(r.KafkaCluster.GetName()),
 			r.KafkaCluster.Spec.ListenersConfig.GetServiceAnnotations(),
 			r.KafkaCluster),
 		Spec: corev1.ServiceSpec{
 			Type:            corev1.ServiceTypeClusterIP,
 			SessionAffinity: corev1.ServiceAffinityNone,
-			Selector:        kafkautils.LabelsForKafka(r.KafkaCluster.Name),
+			Selector:        kafkautils.LabelsForKafka(r.KafkaCluster.GetName()),
 			Ports:           usedPorts,
 		},
 	}
+}
+
+// deleteNonHeadlessServices deletes the all-broker service that was created for the current KafkaCluster
+// if there is any and also the service of each broker
+func (r *Reconciler) deleteNonHeadlessServices() error {
+	ctx := context.Background()
+
+	svc := corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "Service",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: r.KafkaCluster.GetNamespace(),
+			Name:      fmt.Sprintf(kafkautils.AllBrokerServiceTemplate, r.KafkaCluster.GetName()),
+		},
+	}
+
+	err := r.Client.Delete(ctx, &svc)
+	if err != nil && client.IgnoreNotFound(err) != nil {
+		return err
+	}
+
+	// delete broker services
+	labelSelector := labels.NewSelector()
+	for k, v := range kafkautils.LabelsForKafka(r.KafkaCluster.GetName()) {
+		req, err := labels.NewRequirement(k, selection.Equals, []string{v})
+		if err != nil {
+			return err
+		}
+		labelSelector = labelSelector.Add(*req)
+	}
+
+	// add "has label 'brokerId' to matching labels selector expression
+	req, err := labels.NewRequirement("brokerId", selection.Exists, nil)
+	if err != nil {
+		return err
+	}
+	labelSelector = labelSelector.Add(*req)
+
+	var services corev1.ServiceList
+	err = r.Client.List(ctx, &services,
+		client.InNamespace(r.KafkaCluster.GetNamespace()),
+		client.MatchingLabelsSelector{Selector: labelSelector},
+	)
+
+	if err != nil {
+		return errors.WrapIfWithDetails(err, "failed to list services",
+			"namespace", r.KafkaCluster.GetNamespace(),
+			"label selector", labelSelector.String())
+	}
+
+	for i := range services.Items {
+		svc := services.Items[i]
+		if !svc.GetDeletionTimestamp().IsZero() {
+			continue
+		}
+		err := r.Client.Delete(ctx, &svc)
+		if err != nil && client.IgnoreNotFound(err) != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/pkg/resources/kafka/allBrokerService.go
+++ b/pkg/resources/kafka/allBrokerService.go
@@ -109,11 +109,11 @@ func (r *Reconciler) deleteNonHeadlessServices() error {
 	}
 
 	for i := range services.Items {
-		svc := services.Items[i]
+		svc = services.Items[i]
 		if !svc.GetDeletionTimestamp().IsZero() {
 			continue
 		}
-		err := r.Client.Delete(ctx, &svc)
+		err = r.Client.Delete(ctx, &svc)
 		if err != nil && client.IgnoreNotFound(err) != nil {
 			return err
 		}


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | fixes #532 |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Delete old kafka broker service when the `headlessServiceEnabled` is changed. 

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
When `headlessServiceEnabled` is changed new Kubernetes service is created and the old one is not deleted even though is not needed any more.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
