### PR TITLE
Fixed JMX exporter config for kafka server quota metrics for users and clients

### DIFF
--- a/api/assets/kafka/jmx-exporter.yml
+++ b/api/assets/kafka/jmx-exporter.yml
@@ -109,14 +109,6 @@ rules:
     cache: true
     type: COUNTER
 
-  - pattern: kafka.server<type=(.+), client-id=(.+)><>([a-z-]+)
-    name: kafka_server_quota_$3
-    cache: true
-    type: GAUGE
-    labels:
-      resource: "$1"
-      clientId: "$2"
-
   - pattern: kafka.server<type=(.+), user=(.+), client-id=(.+)><>([a-z-]+)
     name: kafka_server_quota_$4
     cache: true
@@ -125,6 +117,22 @@ rules:
       resource: "$1"
       user: "$2"
       clientId: "$3"
+
+  - pattern: kafka.server<type=(.+), user=(.+)><>([a-z-]+)
+    name: kafka_server_quota_$3
+    cache: true
+    type: GAUGE
+    labels:
+      resource: "$1"
+      user: "$2"
+
+  - pattern: kafka.server<type=(.+), client-id=(.+)><>([a-z-]+)
+    name: kafka_server_quota_$3
+    cache: true
+    type: GAUGE
+    labels:
+      resource: "$1"
+      clientId: "$2"
 
   # Generic gauges with 0-3 key/value pairs
   - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+), (.+)=(.+), (.+)=(.+)><>Value
@@ -211,7 +219,7 @@ rules:
       "$3": "$4"
       "$5": "$6"
       "$7": "$8"
-  # Catch all other GAUGES with other types with 0-2 key-value pairs   
+  # Catch all other GAUGES with other types with 0-2 key-value pairs
   - pattern : kafka.(\w+)<type=([A-Za-z-]+), (.+)=(.+), (.+)=(.+)><>([A-Za-z-]+)
     name: kafka_$1_$2_$7
     type: GAUGE


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | none  |
| License         | Apache 2.0 |


### What's in this PR?
When setting Kafka quotas, user level only quota metrics would not be properly caught by the JMX config and would end up in a catch-all rule (instead of the quota specific ones). As such I added a new JMX rule that captures quota metrics for user only quota (default-entity) and rearranged the rules to properly catch all cases (<user, clientId>, <user>, <clientId>). 

### Checklist
- [X] Implementation tested
