### PR TITLE
Some broker pods get stuck caused by a terminated container when there is no healthy broker in the kafka cluster.

### DIFF
--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -140,6 +140,7 @@ func getLoadBalancerIP(foundLBService *corev1.Service) (string, error) {
 }
 
 // Reconcile implements the reconcile logic for Kafka
+//gocyclo:ignore
 func (r *Reconciler) Reconcile(log logr.Logger) error {
 	log = log.WithValues("component", componentName, "clusterName", r.KafkaCluster.Name, "clusterNamespace", r.KafkaCluster.Namespace)
 


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
 If reconcilePerBrokerDynamicConfig gets an error then I let the loop continue to the next broker. A combined error will be returned after the broker loop so the operator will try again later. 

### Why?
When in a kafka cluster there is not any working kafka broker present, but there are multiple broker pods with terminated container, only one broker pod will be restarted. Other brokers with terminated containers will not until  at least one healthy broker will be present in the kafka cluster. The root cause of this that brokers are unreachable and reconcilePerBrokerDynamicConfig function can't set dynamic configs and It will be ended with an error.

### Checklist
- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
