### PR TITLE
Add support to set broker group specific labels to Kafka broker pods

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -11,6 +11,7 @@ require (
 	k8s.io/api v0.23.1
 	k8s.io/apimachinery v0.23.1
 	sigs.k8s.io/controller-runtime v0.11.0
+	github.com/banzaicloud/koperator v0.21.2
 )
 
 require (
@@ -34,4 +35,8 @@ require (
 	k8s.io/utils v0.0.0-20211208161948-7d6a63dca704 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
+)
+
+replace (
+	github.com/banzaicloud/koperator => ../
 )

--- a/api/go.mod
+++ b/api/go.mod
@@ -11,7 +11,6 @@ require (
 	k8s.io/api v0.23.1
 	k8s.io/apimachinery v0.23.1
 	sigs.k8s.io/controller-runtime v0.11.0
-	github.com/banzaicloud/koperator v0.21.2
 )
 
 require (
@@ -35,8 +34,4 @@ require (
 	k8s.io/utils v0.0.0-20211208161948-7d6a63dca704 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
-)
-
-replace (
-	github.com/banzaicloud/koperator => ../
 )

--- a/api/util/util.go
+++ b/api/util/util.go
@@ -21,3 +21,21 @@ func CloneMap(original map[string]string) map[string]string {
 	}
 	return m
 }
+
+// MergeLabels merges two given labels
+func MergeLabels(l ...map[string]string) map[string]string {
+	res := make(map[string]string)
+
+	for _, v := range l {
+		for lKey, lValue := range v {
+			res[lKey] = lValue
+		}
+	}
+	return res
+}
+
+// LabelsForKafka returns the labels for selecting the resources
+// belonging to the given kafka CR name.
+func LabelsForKafka(name string) map[string]string {
+	return map[string]string{"app": "kafka", "kafka_cr": name}
+}

--- a/api/util/util_test.go
+++ b/api/util/util_test.go
@@ -1,0 +1,37 @@
+// Copyright © 2022 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMergeLabels(t *testing.T) {
+	m1 := map[string]string{"key1": "value1"}
+	m2 := map[string]string{"key2": "value2"}
+	expected := map[string]string{"key1": "value1", "key2": "value2"}
+	merged := MergeLabels(m1, m2)
+	if !reflect.DeepEqual(merged, expected) {
+		t.Error("Expected:", expected, "Got:", merged)
+	}
+
+	m1 = nil
+	expected = m2
+	merged = MergeLabels(m1, m2)
+	if !reflect.DeepEqual(merged, expected) {
+		t.Error("Expected:", expected, "Got:", merged)
+	}
+}

--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -168,6 +168,10 @@ type BrokerConfig struct {
 	// prometheus.io/scrape: "true"
 	// prometheus.io/port: "9020"
 	BrokerAnnotations map[string]string `json:"brokerAnnotations,omitempty"`
+	// Custom labels for the broker pods, example use case: for Prometheus monitoring to capture the group for each broker as a label, e.g.:
+	// kafka_broker_group: "default_group"
+	// +optional
+	BrokerLabels map[string]string `json:"brokerLabels,omitempty"`
 	// Network throughput information in kB/s used by Cruise Control to determine broker network capacity.
 	// By default it is set to `125000` which means 1Gbit/s in network throughput.
 	NetworkConfig *NetworkConfig `json:"networkConfig,omitempty"`

--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 
 	"emperror.dev/errors"
-	kafkautils "github.com/banzaicloud/koperator/pkg/util/kafka"
 
 	"github.com/imdario/mergo"
 
@@ -32,8 +31,6 @@ import (
 
 	"github.com/banzaicloud/koperator/api/assets"
 	"github.com/banzaicloud/koperator/api/util"
-
-	pkgutil "github.com/banzaicloud/koperator/pkg/util"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -768,9 +765,9 @@ func (bConfig *BrokerConfig) GetBrokerAnnotations() map[string]string {
 
 // GetBrokerLabels return the labels which applied to broker pods
 func (bConfig *BrokerConfig) GetBrokerLabels(kafkaClusterName string, brokerId int32) map[string]string {
-	return pkgutil.MergeLabels(
+	return util.MergeLabels(
 		bConfig.BrokerLabels,
-		kafkautils.LabelsForKafka(kafkaClusterName),
+		util.LabelsForKafka(kafkaClusterName),
 		map[string]string{"brokerId": fmt.Sprintf("%d", brokerId)},
 	)
 }

--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -758,12 +758,12 @@ func (bConfig *BrokerConfig) GetImagePullSecrets() []corev1.LocalObjectReference
 	return bConfig.ImagePullSecrets
 }
 
-// GetBrokerAnnotations return the annotations which applied to broker pods
+// GetBrokerAnnotations returns the annotations that are applied to broker pods
 func (bConfig *BrokerConfig) GetBrokerAnnotations() map[string]string {
 	return util.CloneMap(bConfig.BrokerAnnotations)
 }
 
-// GetBrokerLabels return the labels which applied to broker pods
+// GetBrokerLabels returns the labels that are applied to broker pods
 func (bConfig *BrokerConfig) GetBrokerLabels(kafkaClusterName string, brokerId int32) map[string]string {
 	return util.MergeLabels(
 		bConfig.BrokerLabels,

--- a/api/v1beta1/kafkacluster_types_test.go
+++ b/api/v1beta1/kafkacluster_types_test.go
@@ -432,7 +432,7 @@ func TestGetBrokerLabels(t *testing.T) {
 		expectedDefaultLabelApp = "kafka"
 		expectedKafkaCRName     = "kafka"
 
-		expectedBrokerId        = 0
+		expectedBrokerId = 0
 	)
 
 	expected := map[string]string{

--- a/api/v1beta1/kafkacluster_types_test.go
+++ b/api/v1beta1/kafkacluster_types_test.go
@@ -438,7 +438,7 @@ func TestGetBrokerLabels(t *testing.T) {
 
 	expected := map[string]string{
 		"app":            expectedDefaultLabelApp,
-		"brokerId":       strconv.Itoa(0),
+		"brokerId":       strconv.Itoa(expectedBrokerId),
 		"kafka_cr":       expectedKafkaCRName,
 		"test_label_key": "test_label_value",
 	}

--- a/api/v1beta1/kafkacluster_types_test.go
+++ b/api/v1beta1/kafkacluster_types_test.go
@@ -16,6 +16,7 @@ package v1beta1
 
 import (
 	"reflect"
+	"strconv"
 	"testing"
 
 	"gotest.tools/assert"
@@ -428,15 +429,17 @@ func TestGetBrokerConfigEnvs(t *testing.T) {
 
 func TestGetBrokerLabels(t *testing.T) {
 	const (
-		expectedLabelApp    = "kafka"
-		expectedBrokerId    = int32(0)
-		expectedKafkaCRName = "kafka"
+		expectedDefaultLabelApp = "kafka"
+		expectedKafkaCRName     = "kafka"
+
+		expectedBrokerId        = 0
 	)
 
 	expected := map[string]string{
-		"app":      expectedLabelApp,
-		"brokerId": string(expectedBrokerId),
-		"kafka_cr": expectedKafkaCRName,
+		"app":            expectedDefaultLabelApp,
+		"brokerId":       strconv.Itoa(0),
+		"kafka_cr":       expectedKafkaCRName,
+		"test_label_key": "test_label_value",
 	}
 
 	brokerConfig := &BrokerConfig{
@@ -444,7 +447,7 @@ func TestGetBrokerLabels(t *testing.T) {
 			"app":            "test-app",
 			"brokerId":       "test-id",
 			"kafka_cr":       "test-cr-name",
-			"test_label_key": "test-label-value",
+			"test_label_key": "test_label_value",
 		},
 	}
 

--- a/api/v1beta1/kafkacluster_types_test.go
+++ b/api/v1beta1/kafkacluster_types_test.go
@@ -425,3 +425,32 @@ func TestGetBrokerConfigEnvs(t *testing.T) {
 		t.Error("Expected:", expected, "Got:", result)
 	}
 }
+
+func TestGetBrokerLabels(t *testing.T) {
+	const (
+		expectedLabelApp    = "kafka"
+		expectedBrokerId    = int32(0)
+		expectedKafkaCRName = "kafka"
+	)
+
+	expected := map[string]string{
+		"app":      expectedLabelApp,
+		"brokerId": string(expectedBrokerId),
+		"kafka_cr": expectedKafkaCRName,
+	}
+
+	brokerConfig := &BrokerConfig{
+		BrokerLabels: map[string]string{
+			"app":            "test-app",
+			"brokerId":       "test-id",
+			"kafka_cr":       "test-cr-name",
+			"test_label_key": "test-label-value",
+		},
+	}
+
+	result := brokerConfig.GetBrokerLabels(expectedKafkaCRName, expectedBrokerId)
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Error("Expected:", expected, "Got:", result)
+	}
+}

--- a/api/v1beta1/kafkacluster_types_test.go
+++ b/api/v1beta1/kafkacluster_types_test.go
@@ -427,6 +427,7 @@ func TestGetBrokerConfigEnvs(t *testing.T) {
 	}
 }
 
+// TestGetBrokerLabels makes sure the reserved labels "app", "brokerId", and "kafka_cr" are not overridden by the BrokerConfig
 func TestGetBrokerLabels(t *testing.T) {
 	const (
 		expectedDefaultLabelApp = "kafka"

--- a/api/v1beta1/kafkacluster_types_test.go
+++ b/api/v1beta1/kafkacluster_types_test.go
@@ -444,9 +444,9 @@ func TestGetBrokerLabels(t *testing.T) {
 
 	brokerConfig := &BrokerConfig{
 		BrokerLabels: map[string]string{
-			"app":            "test-app",
-			"brokerId":       "test-id",
-			"kafka_cr":       "test-cr-name",
+			"app":            "test_app",
+			"brokerId":       "test_id",
+			"kafka_cr":       "test_cr_name",
 			"test_label_key": "test_label_value",
 		},
 	}

--- a/charts/kafka-operator/templates/crds.yaml
+++ b/charts/kafka-operator/templates/crds.yaml
@@ -973,6 +973,13 @@ spec:
                       items:
                         type: string
                       type: array
+                    brokerLabels:
+                      additionalProperties:
+                        type: string
+                      description: 'Custom labels for the broker pods, example use
+                        case: for Prometheus monitoring to capture the group for each
+                        broker as a label, e.g.: kafka_broker_group: "default_group"'
+                      type: object
                     config:
                       type: string
                     containers:
@@ -6861,6 +6868,14 @@ spec:
                           items:
                             type: string
                           type: array
+                        brokerLabels:
+                          additionalProperties:
+                            type: string
+                          description: 'Custom labels for the broker pods, example
+                            use case: for Prometheus monitoring to capture the group
+                            for each broker as a label, e.g.: kafka_broker_group:
+                            "default_group"'
+                          type: object
                         config:
                           type: string
                         containers:

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -972,6 +972,13 @@ spec:
                       items:
                         type: string
                       type: array
+                    brokerLabels:
+                      additionalProperties:
+                        type: string
+                      description: 'Custom labels for the broker pods, example use
+                        case: for Prometheus monitoring to capture the group for each
+                        broker as a label, e.g.: kafka_broker_group: "default_group"'
+                      type: object
                     config:
                       type: string
                     containers:
@@ -6860,6 +6867,14 @@ spec:
                           items:
                             type: string
                           type: array
+                        brokerLabels:
+                          additionalProperties:
+                            type: string
+                          description: 'Custom labels for the broker pods, example
+                            use case: for Prometheus monitoring to capture the group
+                            for each broker as a label, e.g.: kafka_broker_group:
+                            "default_group"'
+                          type: object
                         config:
                           type: string
                         containers:

--- a/config/samples/banzaicloud_v1beta1_kafkacluster.yaml
+++ b/config/samples/banzaicloud_v1beta1_kafkacluster.yaml
@@ -56,6 +56,9 @@ spec:
             resources:
               requests:
                 storage: 10Gi
+      # Add custom labels to the config group
+      # brokerLabels:
+      #   kafka_broker_group: "default_group"
   # All Broker requires an image, unique id, and storageConfigs settings
   brokers:
       # Unique broker id which is used as kafka config broker.id

--- a/config/samples/banzaicloud_v1beta1_kafkacluster.yaml
+++ b/config/samples/banzaicloud_v1beta1_kafkacluster.yaml
@@ -56,7 +56,7 @@ spec:
             resources:
               requests:
                 storage: 10Gi
-      # Add custom labels to the config group
+      # Add custom labels to broker pods within the config group
       # brokerLabels:
       #   kafka_broker_group: "default_group"
   # All Broker requires an image, unique id, and storageConfigs settings

--- a/config/samples/simplekafkacluster.yaml
+++ b/config/samples/simplekafkacluster.yaml
@@ -35,6 +35,8 @@ spec:
       brokerAnnotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9020"
+      # brokerLabels:
+      #   kafka_broker_group: "default_group"
   brokers:
     - id: 0
       brokerConfigGroup: "default"

--- a/go.sum
+++ b/go.sum
@@ -188,7 +188,6 @@ github.com/banzaicloud/istio-operator/api/v2 v2.11.8/go.mod h1:od/KmI8+QoNB4CZxw
 github.com/banzaicloud/k8s-objectmatcher v1.5.0/go.mod h1:9MWY5HsM/OaTmoTirczhlO8UALbH722WgdpaaR7Y8OE=
 github.com/banzaicloud/k8s-objectmatcher v1.7.0 h1:6ufo47TaPC0jXJPg8d8/oooCy1ma3vEfM0J8ZbomKaw=
 github.com/banzaicloud/k8s-objectmatcher v1.7.0/go.mod h1:DSctpi6o9FqTfX7RluuEBeRLUahoDC7JavCeuu6Y+sg=
-github.com/banzaicloud/koperator v0.21.2/go.mod h1:e7kMnnmAgtt95LCos1jA21niYNQw+89ZlcJzkQ5HFwA=
 github.com/banzaicloud/operator-tools v0.21.0/go.mod h1:rbGr9Ud1uQs9KDWDWe6r/gLQdrr1wtBtTP9uo9Aw5Ss=
 github.com/banzaicloud/operator-tools v0.28.0 h1:GSfc0qZr6zo7WrNxdgWZE1LcTChPU8QFYOTDirYVtIM=
 github.com/banzaicloud/operator-tools v0.28.0/go.mod h1:t0dyFGJUR9Q5CwsUcq1nDJC0wSZqeh6nzUZkUp3vCXg=

--- a/go.sum
+++ b/go.sum
@@ -188,6 +188,7 @@ github.com/banzaicloud/istio-operator/api/v2 v2.11.8/go.mod h1:od/KmI8+QoNB4CZxw
 github.com/banzaicloud/k8s-objectmatcher v1.5.0/go.mod h1:9MWY5HsM/OaTmoTirczhlO8UALbH722WgdpaaR7Y8OE=
 github.com/banzaicloud/k8s-objectmatcher v1.7.0 h1:6ufo47TaPC0jXJPg8d8/oooCy1ma3vEfM0J8ZbomKaw=
 github.com/banzaicloud/k8s-objectmatcher v1.7.0/go.mod h1:DSctpi6o9FqTfX7RluuEBeRLUahoDC7JavCeuu6Y+sg=
+github.com/banzaicloud/koperator v0.21.2/go.mod h1:e7kMnnmAgtt95LCos1jA21niYNQw+89ZlcJzkQ5HFwA=
 github.com/banzaicloud/operator-tools v0.21.0/go.mod h1:rbGr9Ud1uQs9KDWDWe6r/gLQdrr1wtBtTP9uo9Aw5Ss=
 github.com/banzaicloud/operator-tools v0.28.0 h1:GSfc0qZr6zo7WrNxdgWZE1LcTChPU8QFYOTDirYVtIM=
 github.com/banzaicloud/operator-tools v0.28.0/go.mod h1:t0dyFGJUR9Q5CwsUcq1nDJC0wSZqeh6nzUZkUp3vCXg=

--- a/pkg/resources/cruisecontrol/configmap.go
+++ b/pkg/resources/cruisecontrol/configmap.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	apiutil "github.com/banzaicloud/koperator/api/util"
 	"github.com/banzaicloud/koperator/api/v1alpha1"
 	"github.com/banzaicloud/koperator/api/v1beta1"
 	"github.com/banzaicloud/koperator/pkg/resources/templates"
@@ -76,7 +77,7 @@ func (r *Reconciler) configMap(clientPass, capacityConfig string, log logr.Logge
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: templates.ObjectMeta(
 			fmt.Sprintf(configAndVolumeNameTemplate, r.KafkaCluster.Name),
-			util.MergeLabels(ccLabelSelector(r.KafkaCluster.Name), r.KafkaCluster.Labels),
+			apiutil.MergeLabels(ccLabelSelector(r.KafkaCluster.Name), r.KafkaCluster.Labels),
 			r.KafkaCluster,
 		),
 		Data: map[string]string{

--- a/pkg/resources/cruisecontrol/service.go
+++ b/pkg/resources/cruisecontrol/service.go
@@ -21,15 +21,15 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	apiutil "github.com/banzaicloud/koperator/api/util"
 	"github.com/banzaicloud/koperator/pkg/resources/templates"
-	"github.com/banzaicloud/koperator/pkg/util"
 )
 
 func (r *Reconciler) service() runtime.Object {
 	return &corev1.Service{
 		ObjectMeta: templates.ObjectMeta(
 			fmt.Sprintf(serviceNameTemplate, r.KafkaCluster.Name),
-			util.MergeLabels(ccLabelSelector(r.KafkaCluster.Name), r.KafkaCluster.Labels),
+			apiutil.MergeLabels(ccLabelSelector(r.KafkaCluster.Name), r.KafkaCluster.Labels),
 			r.KafkaCluster,
 		),
 		Spec: corev1.ServiceSpec{

--- a/pkg/resources/kafka/allBrokerService.go
+++ b/pkg/resources/kafka/allBrokerService.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	apiutil "github.com/banzaicloud/koperator/api/util"
 	"github.com/banzaicloud/koperator/pkg/resources/templates"
 	kafkautils "github.com/banzaicloud/koperator/pkg/util/kafka"
 )
@@ -46,13 +47,13 @@ func (r *Reconciler) allBrokerService() runtime.Object {
 	return &corev1.Service{
 		ObjectMeta: templates.ObjectMetaWithAnnotations(
 			fmt.Sprintf(kafkautils.AllBrokerServiceTemplate, r.KafkaCluster.GetName()),
-			kafkautils.LabelsForKafka(r.KafkaCluster.GetName()),
+			apiutil.LabelsForKafka(r.KafkaCluster.GetName()),
 			r.KafkaCluster.Spec.ListenersConfig.GetServiceAnnotations(),
 			r.KafkaCluster),
 		Spec: corev1.ServiceSpec{
 			Type:            corev1.ServiceTypeClusterIP,
 			SessionAffinity: corev1.ServiceAffinityNone,
-			Selector:        kafkautils.LabelsForKafka(r.KafkaCluster.GetName()),
+			Selector:        apiutil.LabelsForKafka(r.KafkaCluster.GetName()),
 			Ports:           usedPorts,
 		},
 	}
@@ -81,7 +82,7 @@ func (r *Reconciler) deleteNonHeadlessServices() error {
 
 	// delete broker services
 	labelSelector := labels.NewSelector()
-	for k, v := range kafkautils.LabelsForKafka(r.KafkaCluster.GetName()) {
+	for k, v := range apiutil.LabelsForKafka(r.KafkaCluster.GetName()) {
 		req, err := labels.NewRequirement(k, selection.Equals, []string{v})
 		if err != nil {
 			return err

--- a/pkg/resources/kafka/configmap.go
+++ b/pkg/resources/kafka/configmap.go
@@ -24,6 +24,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
+	apiutil "github.com/banzaicloud/koperator/api/util"
 	"github.com/banzaicloud/koperator/api/v1alpha1"
 	"github.com/banzaicloud/koperator/api/v1beta1"
 	"github.com/banzaicloud/koperator/pkg/resources/templates"
@@ -137,8 +138,8 @@ func (r *Reconciler) configMap(id int32, brokerConfig *v1beta1.BrokerConfig, ext
 	brokerConf := &corev1.ConfigMap{
 		ObjectMeta: templates.ObjectMeta(
 			fmt.Sprintf(brokerConfigTemplate+"-%d", r.KafkaCluster.Name, id),
-			util.MergeLabels(
-				kafkautils.LabelsForKafka(r.KafkaCluster.Name),
+			apiutil.MergeLabels(
+				apiutil.LabelsForKafka(r.KafkaCluster.Name),
 				map[string]string{"brokerId": fmt.Sprintf("%d", id)},
 			),
 			r.KafkaCluster,

--- a/pkg/resources/kafka/headlessService.go
+++ b/pkg/resources/kafka/headlessService.go
@@ -24,8 +24,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	apiutil "github.com/banzaicloud/koperator/api/util"
 	"github.com/banzaicloud/koperator/pkg/resources/templates"
-	"github.com/banzaicloud/koperator/pkg/util"
 	kafkautils "github.com/banzaicloud/koperator/pkg/util/kafka"
 )
 
@@ -50,14 +50,14 @@ func (r *Reconciler) headlessService() runtime.Object {
 	return &corev1.Service{
 		ObjectMeta: templates.ObjectMetaWithAnnotations(
 			fmt.Sprintf(kafkautils.HeadlessServiceTemplate, r.KafkaCluster.GetName()),
-			util.MergeLabels(kafkautils.LabelsForKafka(r.KafkaCluster.GetName()), r.KafkaCluster.GetLabels()),
+			apiutil.MergeLabels(apiutil.LabelsForKafka(r.KafkaCluster.GetName()), r.KafkaCluster.GetLabels()),
 			r.KafkaCluster.Spec.ListenersConfig.GetServiceAnnotations(),
 			r.KafkaCluster,
 		),
 		Spec: corev1.ServiceSpec{
 			Type:                     corev1.ServiceTypeClusterIP,
 			SessionAffinity:          corev1.ServiceAffinityNone,
-			Selector:                 kafkautils.LabelsForKafka(r.KafkaCluster.Name),
+			Selector:                 apiutil.LabelsForKafka(r.KafkaCluster.Name),
 			Ports:                    usedPorts,
 			ClusterIP:                corev1.ClusterIPNone,
 			PublishNotReadyAddresses: true,

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -31,6 +31,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	apiutil "github.com/banzaicloud/koperator/api/util"
+
 	"github.com/banzaicloud/k8s-objectmatcher/patch"
 
 	"github.com/banzaicloud/koperator/api/v1alpha1"
@@ -104,8 +106,8 @@ func New(client client.Client, directClient client.Reader, cluster *v1beta1.Kafk
 func getCreatedPvcForBroker(c client.Client, brokerID int32, namespace, crName string) ([]corev1.PersistentVolumeClaim, error) {
 	foundPvcList := &corev1.PersistentVolumeClaimList{}
 	matchingLabels := client.MatchingLabels(
-		util.MergeLabels(
-			kafka.LabelsForKafka(crName),
+		apiutil.MergeLabels(
+			apiutil.LabelsForKafka(crName),
 			map[string]string{"brokerId": fmt.Sprintf("%d", brokerID)},
 		),
 	)
@@ -228,7 +230,7 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 	}
 
 	var brokerPods corev1.PodList
-	matchingLabels := client.MatchingLabels(kafka.LabelsForKafka(r.KafkaCluster.Name))
+	matchingLabels := client.MatchingLabels(apiutil.LabelsForKafka(r.KafkaCluster.Name))
 	err = r.Client.List(context.TODO(), &brokerPods, client.ListOption(client.InNamespace(r.KafkaCluster.Namespace)), client.ListOption(matchingLabels))
 	if err != nil {
 		return errors.WrapIf(err, "failed to list broker pods that belong to Kafka cluster")
@@ -326,7 +328,7 @@ func (r *Reconciler) reconcileKafkaPodDelete(log logr.Logger) error {
 	podList := &corev1.PodList{}
 	err := r.Client.List(context.TODO(), podList,
 		client.InNamespace(r.KafkaCluster.Namespace),
-		client.MatchingLabels(kafka.LabelsForKafka(r.KafkaCluster.Name)),
+		client.MatchingLabels(apiutil.LabelsForKafka(r.KafkaCluster.Name)),
 	)
 	if err != nil {
 		return errors.WrapIf(err, "failed to reconcile resource")
@@ -431,7 +433,7 @@ func (r *Reconciler) reconcileKafkaPodDelete(log logr.Logger) error {
 			}
 			log.Info("broker pod deleted", "brokerId", broker.Labels["brokerId"], "pod", broker.GetName())
 			configMapName := fmt.Sprintf(brokerConfigTemplate+"-%s", r.KafkaCluster.Name, broker.Labels["brokerId"])
-			err = r.Client.Delete(context.TODO(), &corev1.ConfigMap{ObjectMeta: templates.ObjectMeta(configMapName, kafka.LabelsForKafka(r.KafkaCluster.Name), r.KafkaCluster)})
+			err = r.Client.Delete(context.TODO(), &corev1.ConfigMap{ObjectMeta: templates.ObjectMeta(configMapName, apiutil.LabelsForKafka(r.KafkaCluster.Name), r.KafkaCluster)})
 			if err != nil {
 				if apierrors.IsNotFound(err) {
 					// can happen when broker was not fully initialized and now is deleted
@@ -444,7 +446,7 @@ func (r *Reconciler) reconcileKafkaPodDelete(log logr.Logger) error {
 			}
 			if !r.KafkaCluster.Spec.HeadlessServiceEnabled {
 				serviceName := fmt.Sprintf("%s-%s", r.KafkaCluster.Name, broker.Labels["brokerId"])
-				err = r.Client.Delete(context.TODO(), &corev1.Service{ObjectMeta: templates.ObjectMeta(serviceName, kafka.LabelsForKafka(r.KafkaCluster.Name), r.KafkaCluster)})
+				err = r.Client.Delete(context.TODO(), &corev1.Service{ObjectMeta: templates.ObjectMeta(serviceName, apiutil.LabelsForKafka(r.KafkaCluster.Name), r.KafkaCluster)})
 				if err != nil {
 					if apierrors.IsNotFound(err) {
 						// can happen when broker was not fully initialized and now is deleted
@@ -636,8 +638,8 @@ func (r *Reconciler) reconcileKafkaPod(log logr.Logger, desiredPod *corev1.Pod, 
 	podList := &corev1.PodList{}
 
 	matchingLabels := client.MatchingLabels(
-		util.MergeLabels(
-			kafka.LabelsForKafka(r.KafkaCluster.Name),
+		apiutil.MergeLabels(
+			apiutil.LabelsForKafka(r.KafkaCluster.Name),
 			map[string]string{"brokerId": desiredPod.Labels["brokerId"]},
 		),
 	)
@@ -792,7 +794,7 @@ func (r *Reconciler) handleRollingUpgrade(log logr.Logger, desiredPod, currentPo
 		if r.KafkaCluster.Status.State == v1beta1.KafkaClusterRollingUpgrading {
 			// Check if any kafka pod is in terminating or pending state
 			podList := &corev1.PodList{}
-			matchingLabels := client.MatchingLabels(kafka.LabelsForKafka(r.KafkaCluster.Name))
+			matchingLabels := client.MatchingLabels(apiutil.LabelsForKafka(r.KafkaCluster.Name))
 			err := r.Client.List(context.TODO(), podList, client.ListOption(client.InNamespace(r.KafkaCluster.Namespace)), client.ListOption(matchingLabels))
 			if err != nil {
 				return errors.WrapIf(err, "failed to reconcile resource")
@@ -873,8 +875,8 @@ func (r *Reconciler) reconcileKafkaPvc(log logr.Logger, brokersDesiredPvcs map[s
 		pvcList := &corev1.PersistentVolumeClaimList{}
 
 		matchingLabels := client.MatchingLabels(
-			util.MergeLabels(
-				kafka.LabelsForKafka(r.KafkaCluster.Name),
+			apiutil.MergeLabels(
+				apiutil.LabelsForKafka(r.KafkaCluster.Name),
 				map[string]string{"brokerId": brokerId},
 			),
 		)

--- a/pkg/resources/kafka/pod.go
+++ b/pkg/resources/kafka/pod.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	apiutil "github.com/banzaicloud/koperator/api/util"
 	"github.com/banzaicloud/koperator/api/v1beta1"
 	"github.com/banzaicloud/koperator/pkg/k8sutil"
 	"github.com/banzaicloud/koperator/pkg/resources/kafkamonitoring"
@@ -317,7 +318,7 @@ func generatePodAntiAffinity(clusterName string, hardRuleEnabled bool) *corev1.P
 			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
 				{
 					LabelSelector: &metav1.LabelSelector{
-						MatchLabels: kafkautils.LabelsForKafka(clusterName),
+						MatchLabels: apiutil.LabelsForKafka(clusterName),
 					},
 					TopologyKey: "kubernetes.io/hostname",
 				},
@@ -330,7 +331,7 @@ func generatePodAntiAffinity(clusterName string, hardRuleEnabled bool) *corev1.P
 					Weight: int32(100),
 					PodAffinityTerm: corev1.PodAffinityTerm{
 						LabelSelector: &metav1.LabelSelector{
-							MatchLabels: kafkautils.LabelsForKafka(clusterName),
+							MatchLabels: apiutil.LabelsForKafka(clusterName),
 						},
 						TopologyKey: "kubernetes.io/hostname",
 					},

--- a/pkg/resources/kafka/pod.go
+++ b/pkg/resources/kafka/pod.go
@@ -87,11 +87,7 @@ func (r *Reconciler) pod(id int32, brokerConfig *v1beta1.BrokerConfig, pvcs []co
 	pod := &corev1.Pod{
 		ObjectMeta: templates.ObjectMetaWithGeneratedNameAndAnnotations(
 			fmt.Sprintf("%s-%d-", r.KafkaCluster.Name, id),
-			util.MergeLabels(
-				kafkautils.LabelsForKafka(r.KafkaCluster.Name),
-				map[string]string{"brokerId": fmt.Sprintf("%d", id)},
-				brokerConfig.BrokerLabels,
-			),
+			brokerConfig.GetBrokerLabels(r.KafkaCluster.Name, id),
 			brokerConfig.GetBrokerAnnotations(),
 			r.KafkaCluster,
 		),

--- a/pkg/resources/kafka/pod.go
+++ b/pkg/resources/kafka/pod.go
@@ -90,6 +90,7 @@ func (r *Reconciler) pod(id int32, brokerConfig *v1beta1.BrokerConfig, pvcs []co
 			util.MergeLabels(
 				kafkautils.LabelsForKafka(r.KafkaCluster.Name),
 				map[string]string{"brokerId": fmt.Sprintf("%d", id)},
+				brokerConfig.BrokerLabels,
 			),
 			brokerConfig.GetBrokerAnnotations(),
 			r.KafkaCluster,

--- a/pkg/resources/kafka/poddisruptionbudget.go
+++ b/pkg/resources/kafka/poddisruptionbudget.go
@@ -20,13 +20,13 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/banzaicloud/koperator/pkg/resources/templates"
-	"github.com/banzaicloud/koperator/pkg/util"
-	"github.com/banzaicloud/koperator/pkg/util/kafka"
-
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	apiutil "github.com/banzaicloud/koperator/api/util"
+	"github.com/banzaicloud/koperator/pkg/resources/templates"
+	"github.com/banzaicloud/koperator/pkg/util"
 
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,14 +46,14 @@ func (r *Reconciler) podDisruptionBudget(log logr.Logger) (runtime.Object, error
 		},
 		ObjectMeta: templates.ObjectMetaWithAnnotations(
 			fmt.Sprintf("%s-pdb", r.KafkaCluster.Name),
-			util.MergeLabels(kafka.LabelsForKafka(r.KafkaCluster.Name), r.KafkaCluster.Labels),
+			apiutil.MergeLabels(apiutil.LabelsForKafka(r.KafkaCluster.Name), r.KafkaCluster.Labels),
 			r.KafkaCluster.Spec.ListenersConfig.GetServiceAnnotations(),
 			r.KafkaCluster,
 		),
 		Spec: policyv1beta1.PodDisruptionBudgetSpec{
 			MinAvailable: &minAvailable,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: kafka.LabelsForKafka(r.KafkaCluster.Name),
+				MatchLabels: apiutil.LabelsForKafka(r.KafkaCluster.Name),
 			},
 		},
 	}, nil

--- a/pkg/resources/kafka/pvc.go
+++ b/pkg/resources/kafka/pvc.go
@@ -17,22 +17,21 @@ package kafka
 import (
 	"fmt"
 
-	"github.com/banzaicloud/koperator/api/v1beta1"
-	"github.com/banzaicloud/koperator/pkg/resources/templates"
-	"github.com/banzaicloud/koperator/pkg/util"
-	"github.com/banzaicloud/koperator/pkg/util/kafka"
-
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	apiutil "github.com/banzaicloud/koperator/api/util"
+	"github.com/banzaicloud/koperator/api/v1beta1"
+	"github.com/banzaicloud/koperator/pkg/resources/templates"
 )
 
 func (r *Reconciler) pvc(brokerId int32, storageIndex int, storage v1beta1.StorageConfig, _ logr.Logger) runtime.Object {
 	return &corev1.PersistentVolumeClaim{
 		ObjectMeta: templates.ObjectMetaWithGeneratedNameAndAnnotations(
 			fmt.Sprintf(brokerStorageTemplate, r.KafkaCluster.Name, brokerId, storageIndex),
-			util.MergeLabels(
-				kafka.LabelsForKafka(r.KafkaCluster.Name),
+			apiutil.MergeLabels(
+				apiutil.LabelsForKafka(r.KafkaCluster.Name),
 				map[string]string{"brokerId": fmt.Sprintf("%d", brokerId)},
 			),
 			map[string]string{"mountPath": storage.MountPath}, r.KafkaCluster),

--- a/pkg/resources/kafka/service.go
+++ b/pkg/resources/kafka/service.go
@@ -17,13 +17,12 @@ package kafka
 import (
 	"fmt"
 
-	"github.com/banzaicloud/koperator/api/v1beta1"
-	"github.com/banzaicloud/koperator/pkg/resources/templates"
-	"github.com/banzaicloud/koperator/pkg/util"
-	"github.com/banzaicloud/koperator/pkg/util/kafka"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	apiutil "github.com/banzaicloud/koperator/api/util"
+	"github.com/banzaicloud/koperator/api/v1beta1"
+	"github.com/banzaicloud/koperator/pkg/resources/templates"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -46,8 +45,8 @@ func (r *Reconciler) service(id int32, _ *v1beta1.BrokerConfig) runtime.Object {
 
 	return &corev1.Service{
 		ObjectMeta: templates.ObjectMetaWithAnnotations(fmt.Sprintf("%s-%d", r.KafkaCluster.Name, id),
-			util.MergeLabels(
-				kafka.LabelsForKafka(r.KafkaCluster.Name),
+			apiutil.MergeLabels(
+				apiutil.LabelsForKafka(r.KafkaCluster.Name),
 				map[string]string{"brokerId": fmt.Sprintf("%d", id)},
 			),
 			r.KafkaCluster.Spec.ListenersConfig.GetServiceAnnotations(),
@@ -55,7 +54,7 @@ func (r *Reconciler) service(id int32, _ *v1beta1.BrokerConfig) runtime.Object {
 		Spec: corev1.ServiceSpec{
 			Type:            corev1.ServiceTypeClusterIP,
 			SessionAffinity: corev1.ServiceAffinityNone,
-			Selector:        util.MergeLabels(kafka.LabelsForKafka(r.KafkaCluster.Name), map[string]string{"brokerId": fmt.Sprintf("%d", id)}),
+			Selector:        apiutil.MergeLabels(apiutil.LabelsForKafka(r.KafkaCluster.Name), map[string]string{"brokerId": fmt.Sprintf("%d", id)}),
 			Ports:           usedPorts,
 		},
 	}

--- a/pkg/resources/nodeportexternalaccess/service.go
+++ b/pkg/resources/nodeportexternalaccess/service.go
@@ -22,9 +22,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	apiutil "github.com/banzaicloud/koperator/api/util"
 	"github.com/banzaicloud/koperator/api/v1beta1"
 	"github.com/banzaicloud/koperator/pkg/resources/templates"
-	"github.com/banzaicloud/koperator/pkg/util"
 	"github.com/banzaicloud/koperator/pkg/util/kafka"
 )
 
@@ -38,10 +38,10 @@ func (r *Reconciler) service(_ logr.Logger, id int32,
 	service := &corev1.Service{
 		ObjectMeta: templates.ObjectMetaWithAnnotations(
 			fmt.Sprintf(kafka.NodePortServiceTemplate, r.KafkaCluster.GetName(), id, extListener.Name),
-			util.MergeLabels(kafka.LabelsForKafka(r.KafkaCluster.Name), map[string]string{"brokerId": fmt.Sprintf("%d", id)}),
+			apiutil.MergeLabels(apiutil.LabelsForKafka(r.KafkaCluster.Name), map[string]string{"brokerId": fmt.Sprintf("%d", id)}),
 			extListener.GetServiceAnnotations(), r.KafkaCluster),
 		Spec: corev1.ServiceSpec{
-			Selector: util.MergeLabels(kafka.LabelsForKafka(r.KafkaCluster.Name),
+			Selector: apiutil.MergeLabels(apiutil.LabelsForKafka(r.KafkaCluster.Name),
 				map[string]string{"brokerId": fmt.Sprintf("%d", id)}),
 			Type: corev1.ServiceTypeNodePort,
 			Ports: []corev1.ServicePort{{

--- a/pkg/resources/templates/templates.go
+++ b/pkg/resources/templates/templates.go
@@ -17,6 +17,7 @@ package templates
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	apiutil "github.com/banzaicloud/koperator/api/util"
 	"github.com/banzaicloud/koperator/api/v1alpha1"
 	"github.com/banzaicloud/koperator/api/v1beta1"
 	"github.com/banzaicloud/koperator/pkg/util"
@@ -89,7 +90,7 @@ func ObjectMetaWithGeneratedName(namePrefix string, labels map[string]string, cl
 
 func ObjectMetaLabels(cluster *v1beta1.KafkaCluster, l map[string]string) map[string]string {
 	if cluster.Spec.PropagateLabels {
-		return util.MergeLabels(cluster.Labels, l)
+		return apiutil.MergeLabels(cluster.Labels, l)
 	}
 	return l
 }

--- a/pkg/util/kafka/common.go
+++ b/pkg/util/kafka/common.go
@@ -53,12 +53,6 @@ var PerBrokerConfigs = []string{
 	securityProtocolMapConfigName,
 }
 
-// LabelsForKafka returns the labels for selecting the resources
-// belonging to the given kafka CR name.
-func LabelsForKafka(name string) map[string]string {
-	return map[string]string{"app": "kafka", "kafka_cr": name}
-}
-
 // commonACLString is the raw representation of an ACL allowing Describe on a Topic
 var commonACLString = "User:%s,Topic,%s,%s,Describe,Allow,*"
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -100,18 +100,6 @@ func MapStringStringPointer(in map[string]string) (out map[string]*string) {
 	return
 }
 
-// MergeLabels merges two given labels
-func MergeLabels(l ...map[string]string) map[string]string {
-	res := make(map[string]string)
-
-	for _, v := range l {
-		for lKey, lValue := range v {
-			res[lKey] = lValue
-		}
-	}
-	return res
-}
-
 func MergeAnnotations(annotations ...map[string]string) map[string]string {
 	rtn := make(map[string]string)
 	for _, a := range annotations {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -88,23 +88,6 @@ func TestMapStringStringPointer(t *testing.T) {
 	}
 }
 
-func TestMergeLabels(t *testing.T) {
-	m1 := map[string]string{"key1": "value1"}
-	m2 := map[string]string{"key2": "value2"}
-	expected := map[string]string{"key1": "value1", "key2": "value2"}
-	merged := MergeLabels(m1, m2)
-	if !reflect.DeepEqual(merged, expected) {
-		t.Error("Expected:", expected, "Got:", merged)
-	}
-
-	m1 = nil
-	expected = m2
-	merged = MergeLabels(m1, m2)
-	if !reflect.DeepEqual(merged, expected) {
-		t.Error("Expected:", expected, "Got:", merged)
-	}
-}
-
 func TestConvertStringToInt32(t *testing.T) {
 	i := ConvertStringToInt32("10")
 	if i != 10 {


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no |
| New feature?    | yes |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | fixes #605 |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Add a new optional field to KafkaCluster spec: `brokerConfigGroups.<group>.brokerLabels` that's appended to the current list of pod labels when set

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Community request

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)