### PR TITLE
Fix: CC config checksum should include generated config as well

### DIFF
--- a/controllers/tests/kafkacluster_controller_test.go
+++ b/controllers/tests/kafkacluster_controller_test.go
@@ -58,7 +58,8 @@ var _ = Describe("KafkaCluster", func() {
 				Partitions:        7,
 				ReplicationFactor: 2,
 			},
-			Config: "some.config=value",
+			Config:                   "some.config=value",
+			CruiseControlAnnotations: map[string]string{"test-cc-ann": "test-cc-ann-val"},
 		}
 		kafkaCluster.Spec.ReadOnlyConfig = ""
 		// Set some Kafka pod and container related SecurityContext values

--- a/pkg/resources/cruisecontrol/configmap.go
+++ b/pkg/resources/cruisecontrol/configmap.go
@@ -138,7 +138,7 @@ type JBODInvariantCapacityConfig struct {
 	Capacities []interface{} `json:"brokerCapacities"`
 }
 
-// generateCapacityConfig generates a CC capacity config with default values or returns the manually overridden value if it exists
+// GenerateCapacityConfig generates a CC capacity config with default values or returns the manually overridden value if it exists
 func GenerateCapacityConfig(kafkaCluster *v1beta1.KafkaCluster, log logr.Logger, config *corev1.ConfigMap) (string, error) {
 	var err error
 

--- a/pkg/resources/cruisecontrol/cruisecontrol.go
+++ b/pkg/resources/cruisecontrol/cruisecontrol.go
@@ -129,7 +129,10 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 				return errors.WrapIfWithDetails(err, "failed to reconcile resource", "resource", o.GetObjectKind().GroupVersionKind())
 			}
 
-			podAnnotations := GeneratePodAnnotations(r.KafkaCluster, capacityConfig)
+			podAnnotations := GeneratePodAnnotations(
+				r.KafkaCluster.Spec.CruiseControlConfig.GetCruiseControlAnnotations(),
+				o.(*corev1.ConfigMap).Data,
+			)
 
 			o = r.deployment(podAnnotations)
 			err = k8sutil.Reconcile(log, r.Client, o, r.KafkaCluster)


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | fixes #804 |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Compute the configuration checksum annotation from the generated Cruise Control configuration which includes computed fields as well.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
If computed configuration properties are left out from he checksum computation Cruise Control pod won't be restarted when only changes to computed configuration properties happen.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline