### PR TITLE
Updated istio-operator tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/banzaicloud/cluster-registry v0.0.8
 	github.com/banzaicloud/go-cruise-control v0.0.0-20220324110942-71a3405be337
 	github.com/banzaicloud/istio-client-go v0.0.17
-	github.com/banzaicloud/istio-operator/api/v2 v2.13.0-rc.0
+	github.com/banzaicloud/istio-operator/api/v2 v2.13.1
 	github.com/banzaicloud/k8s-objectmatcher v1.7.0
 	github.com/banzaicloud/koperator/api v0.0.0
 	github.com/banzaicloud/koperator/properties v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,8 @@ github.com/banzaicloud/go-cruise-control v0.0.0-20220324110942-71a3405be337 h1:H
 github.com/banzaicloud/go-cruise-control v0.0.0-20220324110942-71a3405be337/go.mod h1:ZOrxSqMkpjRnA6eyjaSfpnkPLuCy1JKBGIi6h9hyiuM=
 github.com/banzaicloud/istio-client-go v0.0.17 h1:wiplbM7FDiIHopujInAnin3zuovtVcphtKy9En39q5I=
 github.com/banzaicloud/istio-client-go v0.0.17/go.mod h1:rpnEYYGHzisx8nARl2d30Oq38EeCX0/PPaxMaREfE9I=
-github.com/banzaicloud/istio-operator/api/v2 v2.13.0-rc.0 h1:M3iI/fVG3Nq6hOGgci6bVdLAsUiJxPiSH6X3Cxm65ck=
-github.com/banzaicloud/istio-operator/api/v2 v2.13.0-rc.0/go.mod h1:ZR2D7ekfa2N5r4u/gnPrx2t69IYV9WjBdMSQe7R8BiA=
+github.com/banzaicloud/istio-operator/api/v2 v2.13.1 h1:c0LfFVZwltV/t8yws2HAOe6jL3MhgxEGcBYduzgke7Q=
+github.com/banzaicloud/istio-operator/api/v2 v2.13.1/go.mod h1:ZR2D7ekfa2N5r4u/gnPrx2t69IYV9WjBdMSQe7R8BiA=
 github.com/banzaicloud/k8s-objectmatcher v1.5.0/go.mod h1:9MWY5HsM/OaTmoTirczhlO8UALbH722WgdpaaR7Y8OE=
 github.com/banzaicloud/k8s-objectmatcher v1.7.0 h1:6ufo47TaPC0jXJPg8d8/oooCy1ma3vEfM0J8ZbomKaw=
 github.com/banzaicloud/k8s-objectmatcher v1.7.0/go.mod h1:DSctpi6o9FqTfX7RluuEBeRLUahoDC7JavCeuu6Y+sg=


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
This is just to not have an rc release in go.mod since we now have a full release available for istio operator.

### Checklist

- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
