### PR TITLE
Migrate cluster-registry library to cisco-open

### DIFF
--- a/controllers/tests/clusterregistry/cruisecontroltask_controller_test.go
+++ b/controllers/tests/clusterregistry/cruisecontroltask_controller_test.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"sync/atomic"
 
-	clusterregv1alpha1 "github.com/banzaicloud/cluster-registry/api/v1alpha1"
+	clusterregv1alpha1 "github.com/cisco-open/cluster-registry-controller/api/v1alpha1"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/controllers/tests/clusterregistry/kafkacluster_controller_test.go
+++ b/controllers/tests/clusterregistry/kafkacluster_controller_test.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"sync/atomic"
 
-	clusterregv1alpha1 "github.com/banzaicloud/cluster-registry/api/v1alpha1"
+	clusterregv1alpha1 "github.com/cisco-open/cluster-registry-controller/api/v1alpha1"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/controllers/tests/clusterregistry/kafkatopic_controller_test.go
+++ b/controllers/tests/clusterregistry/kafkatopic_controller_test.go
@@ -21,7 +21,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	clusterregv1alpha1 "github.com/banzaicloud/cluster-registry/api/v1alpha1"
+	clusterregv1alpha1 "github.com/cisco-open/cluster-registry-controller/api/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/controllers/tests/clusterregistry/kafkauser_controller_test.go
+++ b/controllers/tests/clusterregistry/kafkauser_controller_test.go
@@ -21,7 +21,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	clusterregv1alpha1 "github.com/banzaicloud/cluster-registry/api/v1alpha1"
+	clusterregv1alpha1 "github.com/cisco-open/cluster-registry-controller/api/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/go.mod
+++ b/go.mod
@@ -5,13 +5,13 @@ go 1.17
 require (
 	emperror.dev/errors v0.8.0
 	github.com/Shopify/sarama v1.32.0
-	github.com/banzaicloud/cluster-registry v0.0.8
 	github.com/banzaicloud/go-cruise-control v0.0.0-20220324110942-71a3405be337
 	github.com/banzaicloud/istio-client-go v0.0.17
 	github.com/banzaicloud/istio-operator/api/v2 v2.13.1
-	github.com/banzaicloud/k8s-objectmatcher v1.7.0
+	github.com/banzaicloud/k8s-objectmatcher v1.8.0
 	github.com/banzaicloud/koperator/api v0.0.0
 	github.com/banzaicloud/koperator/properties v0.1.0
+	github.com/cisco-open/cluster-registry-controller/api v0.1.9
 	github.com/envoyproxy/go-control-plane v0.10.1
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-logr/logr v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,6 @@ github.com/aws/aws-sdk-go v1.30.27/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZve
 github.com/aws/aws-sdk-go v1.34.9/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.40.21/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
-github.com/banzaicloud/cluster-registry v0.0.8 h1:hFVgNDcNeBo2tL1R/iUVx7MEYCqU12TWH3yVE4oRqnk=
-github.com/banzaicloud/cluster-registry v0.0.8/go.mod h1:4ICSf7IMl2mcBByqZ2kZoDwu0bWXGSpHie+6jobSQBI=
 github.com/banzaicloud/go-cruise-control v0.0.0-20220324110942-71a3405be337 h1:HnA0QC34j8Vd6uwP4priC2eO+0FQT0c41qnBE3DsfWw=
 github.com/banzaicloud/go-cruise-control v0.0.0-20220324110942-71a3405be337/go.mod h1:ZOrxSqMkpjRnA6eyjaSfpnkPLuCy1JKBGIi6h9hyiuM=
 github.com/banzaicloud/istio-client-go v0.0.17 h1:wiplbM7FDiIHopujInAnin3zuovtVcphtKy9En39q5I=
@@ -185,8 +183,9 @@ github.com/banzaicloud/istio-client-go v0.0.17/go.mod h1:rpnEYYGHzisx8nARl2d30Oq
 github.com/banzaicloud/istio-operator/api/v2 v2.13.1 h1:c0LfFVZwltV/t8yws2HAOe6jL3MhgxEGcBYduzgke7Q=
 github.com/banzaicloud/istio-operator/api/v2 v2.13.1/go.mod h1:ZR2D7ekfa2N5r4u/gnPrx2t69IYV9WjBdMSQe7R8BiA=
 github.com/banzaicloud/k8s-objectmatcher v1.5.0/go.mod h1:9MWY5HsM/OaTmoTirczhlO8UALbH722WgdpaaR7Y8OE=
-github.com/banzaicloud/k8s-objectmatcher v1.7.0 h1:6ufo47TaPC0jXJPg8d8/oooCy1ma3vEfM0J8ZbomKaw=
 github.com/banzaicloud/k8s-objectmatcher v1.7.0/go.mod h1:DSctpi6o9FqTfX7RluuEBeRLUahoDC7JavCeuu6Y+sg=
+github.com/banzaicloud/k8s-objectmatcher v1.8.0 h1:Nugn25elKtPMTA2br+JgHNeSQ04sc05MDPmpJnd1N2A=
+github.com/banzaicloud/k8s-objectmatcher v1.8.0/go.mod h1:p2LSNAjlECf07fbhDyebTkPUIYnU05G+WfGgkTmgeMg=
 github.com/banzaicloud/operator-tools v0.21.0/go.mod h1:rbGr9Ud1uQs9KDWDWe6r/gLQdrr1wtBtTP9uo9Aw5Ss=
 github.com/banzaicloud/operator-tools v0.28.0 h1:GSfc0qZr6zo7WrNxdgWZE1LcTChPU8QFYOTDirYVtIM=
 github.com/banzaicloud/operator-tools v0.28.0/go.mod h1:t0dyFGJUR9Q5CwsUcq1nDJC0wSZqeh6nzUZkUp3vCXg=
@@ -242,6 +241,8 @@ github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJ
 github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
+github.com/cisco-open/cluster-registry-controller/api v0.1.9 h1:dJfvj2umr1fIIOeNDxRR2u1WEpjT0zW+giOczCV/rBY=
+github.com/cisco-open/cluster-registry-controller/api v0.1.9/go.mod h1:+SGsAzdHbD+v+CovGDNqbfEg48p/EiopbLvYZj56Vgg=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cloudflare-go v0.20.0/go.mod h1:sPWL/lIC6biLEdyGZwBQ1rGQKF1FhM7N60fuNiFdYTI=

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -41,13 +41,13 @@ import (
 	clientCtrl "sigs.k8s.io/controller-runtime/pkg/client"
 	k8s_zap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	clusterregv1alpha1 "github.com/banzaicloud/cluster-registry/api/v1alpha1"
 	"github.com/banzaicloud/koperator/api/v1alpha1"
 	"github.com/banzaicloud/koperator/api/v1beta1"
 	"github.com/banzaicloud/koperator/pkg/errorfactory"
 	envoyutils "github.com/banzaicloud/koperator/pkg/util/envoy"
 	"github.com/banzaicloud/koperator/pkg/util/istioingress"
 	properties "github.com/banzaicloud/koperator/properties/pkg"
+	clusterregv1alpha1 "github.com/cisco-open/cluster-registry-controller/api/v1alpha1"
 )
 
 const (

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -47,6 +47,7 @@ import (
 	envoyutils "github.com/banzaicloud/koperator/pkg/util/envoy"
 	"github.com/banzaicloud/koperator/pkg/util/istioingress"
 	properties "github.com/banzaicloud/koperator/properties/pkg"
+
 	clusterregv1alpha1 "github.com/cisco-open/cluster-registry-controller/api/v1alpha1"
 )
 


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
Change cluster registry controller dependency to https://github.com/cisco-open/cluster-registry-controller


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)