### PR TITLE
Bump up chart version for dev release

### DIFF
--- a/charts/kafka-operator/Chart.yaml
+++ b/charts/kafka-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kafka-operator
-version: 0.22.0-dev.0
+version: 0.22.0-dev.1
 description: kafka-operator manages Kafka deployments on Kubernetes
 sources:
   - https://github.com/banzaicloud/koperator
-appVersion: v0.22.0-dev.0
+appVersion: v0.22.0-dev.1

--- a/charts/kafka-operator/README.md
+++ b/charts/kafka-operator/README.md
@@ -53,7 +53,7 @@ The following table lists the configurable parameters of the Banzaicloud Kafka O
 Parameter | Description | Default
 --------- | ----------- | -------
 `operator.image.repository` | Operator container image repository | `ghcr.io/banzaicloud/kafka-operator`
-`operator.image.tag` | Operator container image tag | `v0.22.0-dev.0`
+`operator.image.tag` | Operator container image tag | `v0.22.0-dev.1`
 `operator.image.pullPolicy` | Operator container image pull policy | `IfNotPresent`
 `operator.serviceAccount.name` | ServiceAccount used by the operator pod | `kafka-operator`
 `operator.serviceAccount.create` | If true, create the `operator.serviceAccount.name` service account | `true`


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no|
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Bump up chart version for dev release

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
So the chart uses the kopertaor image that built with Go 1.18

