### PR TITLE
Add validation for partitions number and replication factor during KafkaTopic creation

### DIFF
--- a/api/v1alpha1/kafkatopic_types.go
+++ b/api/v1alpha1/kafkatopic_types.go
@@ -18,7 +18,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-
 const MinPartitions = 1
 
 // KafkaTopicSpec defines the desired state of KafkaTopic

--- a/api/v1alpha1/kafkatopic_types.go
+++ b/api/v1alpha1/kafkatopic_types.go
@@ -18,14 +18,20 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const MinPartitions = 1
+const (
+	MinPartitions        = -1
+	MinReplicationFactor = -1
+)
 
 // KafkaTopicSpec defines the desired state of KafkaTopic
 // +k8s:openapi-gen=true
 type KafkaTopicSpec struct {
 	Name string `json:"name"`
-	// +kubebuilder:validation:Minimum=1
-	Partitions        int32             `json:"partitions"`
+	// Partitions defines the desired number of partitions; must be positive, or -1 to signify using the broker's default
+	// +kubebuilder:validation:Minimum=-1
+	Partitions int32 `json:"partitions"`
+	// ReplicationFactor defines the desired replication factor; must be positive, or -1 to signify using the broker's default
+	// +kubebuilder:validation:Minimum=-1
 	ReplicationFactor int32             `json:"replicationFactor"`
 	Config            map[string]string `json:"config,omitempty"`
 	ClusterRef        ClusterReference  `json:"clusterRef"`

--- a/api/v1alpha1/kafkatopic_types.go
+++ b/api/v1alpha1/kafkatopic_types.go
@@ -18,10 +18,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+
+const MinPartitions = 1
+
 // KafkaTopicSpec defines the desired state of KafkaTopic
 // +k8s:openapi-gen=true
 type KafkaTopicSpec struct {
-	Name              string            `json:"name"`
+	Name string `json:"name"`
+	// +kubebuilder:validation:Minimum=1
 	Partitions        int32             `json:"partitions"`
 	ReplicationFactor int32             `json:"replicationFactor"`
 	Config            map[string]string `json:"config,omitempty"`

--- a/charts/kafka-operator/templates/crds.yaml
+++ b/charts/kafka-operator/templates/crds.yaml
@@ -19348,11 +19348,16 @@ spec:
               name:
                 type: string
               partitions:
+                description: Partitions defines the desired number of partitions;
+                  must be positive, or -1 to signify using the broker's default
                 format: int32
-                minimum: 1
+                minimum: -1
                 type: integer
               replicationFactor:
+                description: ReplicationFactor defines the desired replication factor;
+                  must be positive, or -1 to signify using the broker's default
                 format: int32
+                minimum: -1
                 type: integer
             required:
             - clusterRef

--- a/charts/kafka-operator/templates/crds.yaml
+++ b/charts/kafka-operator/templates/crds.yaml
@@ -19349,6 +19349,7 @@ spec:
                 type: string
               partitions:
                 format: int32
+                minimum: 1
                 type: integer
               replicationFactor:
                 format: int32

--- a/config/base/crds/kafka.banzaicloud.io_kafkatopics.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkatopics.yaml
@@ -53,11 +53,16 @@ spec:
               name:
                 type: string
               partitions:
+                description: Partitions defines the desired number of partitions;
+                  must be positive, or -1 to signify using the broker's default
                 format: int32
-                minimum: 1
+                minimum: -1
                 type: integer
               replicationFactor:
+                description: ReplicationFactor defines the desired replication factor;
+                  must be positive, or -1 to signify using the broker's default
                 format: int32
+                minimum: -1
                 type: integer
             required:
             - clusterRef

--- a/config/base/crds/kafka.banzaicloud.io_kafkatopics.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkatopics.yaml
@@ -54,6 +54,7 @@ spec:
                 type: string
               partitions:
                 format: int32
+                minimum: 1
                 type: integer
               replicationFactor:
                 format: int32

--- a/config/samples/example-topic.yaml
+++ b/config/samples/example-topic.yaml
@@ -7,8 +7,9 @@ spec:
   clusterRef:
     name: kafka
   name: example-topic
-  # valid partitions values: [1,...]
+  # valid partitions values: [1,...], or -1 to use the broker's default
   partitions: 3
+  # valid repliaction factor values: [1, ...], or -1 to use the broker's default
   replicationFactor: 2
   config:
     "retention.ms": "604800000"

--- a/config/samples/example-topic.yaml
+++ b/config/samples/example-topic.yaml
@@ -7,6 +7,7 @@ spec:
   clusterRef:
     name: kafka
   name: example-topic
+  # valid partitions values: [1,...]
   partitions: 3
   replicationFactor: 2
   config:

--- a/pkg/webhook/request_test.go
+++ b/pkg/webhook/request_test.go
@@ -38,16 +38,31 @@ func newRawTopic() []byte {
 		Namespace: "test-namespace",
 	}
 	topic.Spec.Partitions = 1
+	topic.Spec.ReplicationFactor = 1
 	out, _ := json.Marshal(topic)
 	return out
 }
 
-func newRawInvalidTopic() []byte {
+func newRawTopicWithInvalidPartitions() []byte {
 	topic := &v1alpha1.KafkaTopic{}
 	topic.ObjectMeta = metav1.ObjectMeta{
 		Name:      "test-topic",
 		Namespace: "test-namespace",
 	}
+	topic.Spec.Partitions = -2
+	topic.Spec.ReplicationFactor = 1
+	out, _ := json.Marshal(topic)
+	return out
+}
+
+func newRawTopicWithInvalidReplicationFactor() []byte {
+	topic := &v1alpha1.KafkaTopic{}
+	topic.ObjectMeta = metav1.ObjectMeta{
+		Name:      "test-topic",
+		Namespace: "test-namespace",
+	}
+	topic.Spec.Partitions = 1
+	topic.Spec.ReplicationFactor = -2
 	out, _ := json.Marshal(topic)
 	return out
 }
@@ -101,17 +116,25 @@ func TestValidate(t *testing.T) {
 		t.Error("Expected bad request, got:", res.Result.Reason)
 	}
 
-	req.Request.Object.Raw = newRawInvalidTopic()
+	req.Request.Object.Raw = newRawTopicWithInvalidPartitions()
 
-	if res := server.validate(req); res.Allowed {
+	if res = server.validate(req); res.Allowed {
 		t.Error("Expected not allowed, got allowed")
 	} else if res.Result.Reason != metav1.StatusReasonInvalid {
-		t.Error("Expected invalid for no partitions, got:", res.Result.Reason)
+		t.Error("Expected invalid due to invalid partitions, got:", res.Result.Reason)
+	}
+
+	req.Request.Object.Raw = newRawTopicWithInvalidReplicationFactor()
+
+	if res = server.validate(req); res.Allowed {
+		t.Error("Expected not allowed, got allowed")
+	} else if res.Result.Reason != metav1.StatusReasonInvalid {
+		t.Error("Expected invalid due to invalid replication factor, got:", res.Result.Reason)
 	}
 
 	req.Request.Object.Raw = newRawTopic()
 
-	if res := server.validate(req); res.Allowed {
+	if res = server.validate(req); res.Allowed {
 		t.Error("Expected not allowed, got allowed")
 	} else if res.Result.Reason != metav1.StatusReasonNotFound {
 		t.Error("Expected not found for no cluster, got:", res.Result.Reason)

--- a/pkg/webhook/topic_validator.go
+++ b/pkg/webhook/topic_validator.go
@@ -51,7 +51,7 @@ func (s *webhookServer) validateKafkaTopic(topic *banzaicloudv1alpha1.KafkaTopic
 		)
 	}
 
-	if topic.Spec.ReplicationFactor < banzaicloudv1alpha1.MinReplicationFactor || topic.Spec.ReplicationFactor == 0{
+	if topic.Spec.ReplicationFactor < banzaicloudv1alpha1.MinReplicationFactor || topic.Spec.ReplicationFactor == 0 {
 		log.Info(outOfRangeReplicationFactorErrMsg)
 		return notAllowed(
 			fmt.Sprintf("KafkaTopic '%s' is invalid: %s.", topic.Spec.Name, outOfRangeReplicationFactorErrMsg),

--- a/pkg/webhook/topic_validator_test.go
+++ b/pkg/webhook/topic_validator_test.go
@@ -43,7 +43,7 @@ func newMockTopic() *v1alpha1.KafkaTopic {
 		Spec: v1alpha1.KafkaTopicSpec{
 			Name:              "test-topic",
 			Partitions:        0,
-			ReplicationFactor: 1,
+			ReplicationFactor: 0,
 			ClusterRef: v1alpha1.ClusterReference{
 				Name:      "test-cluster",
 				Namespace: "test-namespace",
@@ -70,13 +70,23 @@ func TestValidateTopic(t *testing.T) {
 	}
 	topic := newMockTopic()
 
-	// Test kafka topic with partitions number less than 1
+	// Test kafka topic with invalid partitions
 	res := server.validateKafkaTopic(topic)
 	if res.Allowed {
 		t.Error("Expected not allowed due to invalid partitions number, got allowed")
 	}
 
+	// set a valid partitions
 	topic.Spec.Partitions = 2
+
+	// Test kafka topic with invalid replication factor
+	res = server.validateKafkaTopic(topic)
+	if res.Allowed {
+		t.Error("Expected not allowed due to invalid replication factor, got allowed")
+	}
+
+	// set a valid replication factor
+	topic.Spec.ReplicationFactor = 1
 
 	// Test non-existent kafka cluster
 	res = server.validateKafkaTopic(topic)

--- a/pkg/webhook/topic_validator_test.go
+++ b/pkg/webhook/topic_validator_test.go
@@ -42,7 +42,7 @@ func newMockTopic() *v1alpha1.KafkaTopic {
 		ObjectMeta: metav1.ObjectMeta{Name: "test-topic", Namespace: "test-namespace"},
 		Spec: v1alpha1.KafkaTopicSpec{
 			Name:              "test-topic",
-			Partitions:        2,
+			Partitions:        0,
 			ReplicationFactor: 1,
 			ClusterRef: v1alpha1.ClusterReference{
 				Name:      "test-cluster",
@@ -70,8 +70,16 @@ func TestValidateTopic(t *testing.T) {
 	}
 	topic := newMockTopic()
 
-	// Test non-existent kafka cluster
+	// Test kafka topic with partitions number less than 1
 	res := server.validateKafkaTopic(topic)
+	if res.Allowed {
+		t.Error("Expected not allowed due to invalid partitions number, got allowed")
+	}
+
+	topic.Spec.Partitions = 2
+
+	// Test non-existent kafka cluster
+	res = server.validateKafkaTopic(topic)
 	if res.Result.Reason != metav1.StatusReasonNotFound {
 		t.Error("Expected not found cluster, got:", res.Result)
 	}


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no |
| New feature?    | yes |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Add validation to ensure the partitions number and replication factor are no less than `1` (`-1` is an exception according to Kafka documentation and source code) during `KafkaTopic` creation to improve user experience

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Without this validation, client requests of creating `KafkaTopic` with an invalid partitions number or replication factor would pass and the operator treats the invalid partitions number / replciation factor as the desired state during reconciliation

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
With the implementation, invalid requests will be rejected by the webhook, e.g.:
```
k create -v=8 -f -<<EOF
apiVersion: kafka.banzaicloud.io/v1alpha1
kind: KafkaTopic
metadata:
  name: example-topic-test
  namespace: kafka
spec:
  clusterRef:
    name: kafka
  name: example-topic-test
  # valid partitions values: [1,...]
  partitions: 0
  replicationFactor: 2
  config:
    "retention.ms": "604800000"
    "cleanup.policy": "delete"
EOF
...
I0531 19:26:50.145535   84385 request.go:1181] Request Body: {"apiVersion":"kafka.banzaicloud.io/v1alpha1","kind":"KafkaTopic","metadata":{"name":"example-topic-test","namespace":"kafka"},"spec":{"clusterRef":{"name":"kafka"},"config":{"cleanup.policy":"delete","retention.ms":"604800000"},"name":"example-topic-test","partitions":0,"replicationFactor":2}}
I0531 19:26:50.145608   84385 round_trippers.go:463] POST https://3.15.83.79:6443/apis/kafka.banzaicloud.io/v1alpha1/namespaces/kafka/kafkatopics?fieldManager=kubectl-create
I0531 19:26:50.145635   84385 round_trippers.go:469] Request Headers:
I0531 19:26:50.145647   84385 round_trippers.go:473]     Content-Type: application/json
I0531 19:26:50.145657   84385 round_trippers.go:473]     User-Agent: kubectl/v1.23.2 (darwin/amd64) kubernetes/9d14243
I0531 19:26:50.145667   84385 round_trippers.go:473]     Accept: application/json
I0531 19:26:50.380186   84385 round_trippers.go:574] Response Status: 400 Bad Request in 234 milliseconds
...
I0601 15:02:24.098137   95692 request.go:1181] Response Body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"admission webhook \"kafkatopics.kafka.banzaicloud.io\" denied the request: KafkaTopic 'example-topic-test' is invalid: Number of partitions must be larger than 0 (or set it to be -1 to use the broker's default).","reason":"Invalid","code":400}
F0531 19:26:50.380844   84385 helpers.go:118] The request is invalid
goroutine 1 [running]:
k8s.io/kubernetes/vendor/k8s.io/klog/v2.stacks(0x1)
	/private/tmp/kubernetes-cli-20220119-65987-ldknpz/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/klog/v2/klog.go:1038 +0x8a
k8s.io/kubernetes/vendor/k8s.io/klog/v2.(*loggingT).output(0x6da3220, 0x3, 0x0, 0xc0060ac1c0, 0x2, {0x62c8e1e, 0x10}, 0xc00020c000, 0x0)
...
```

> Note: since invalid requests are rejected by the validation webhook, the `//+kubebuilder:validation:Minimum=-1` kuberbuilder marker is not necessary, but adding this would make the CRD more explicit about the minimum value of the field



### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)