### PR TITLE
Pin Istio resources to istio control plane referenced by KafkaCluster

### DIFF
--- a/pkg/resources/istioingress/gateway.go
+++ b/pkg/resources/istioingress/gateway.go
@@ -29,7 +29,7 @@ import (
 )
 
 func (r *Reconciler) gateway(log logr.Logger, externalListenerConfig v1beta1.ExternalListenerConfig,
-	ingressConf v1beta1.IngressConfig, ingressConfigName, defaultIngressConfigName string) runtime.Object {
+	ingressConf v1beta1.IngressConfig, ingressConfigName, defaultIngressConfigName, istioRevision string) runtime.Object {
 	eListenerLabelName := util.ConstructEListenerLabelName(ingressConfigName, externalListenerConfig.Name)
 
 	var gatewayName string
@@ -40,9 +40,9 @@ func (r *Reconciler) gateway(log logr.Logger, externalListenerConfig v1beta1.Ext
 	}
 	return &istioclientv1beta1.Gateway{
 		ObjectMeta: templates.ObjectMeta(gatewayName,
-			labelsForIstioIngress(r.KafkaCluster.Name, eListenerLabelName), r.KafkaCluster),
+			labelsForIstioIngress(r.KafkaCluster.Name, eListenerLabelName, istioRevision), r.KafkaCluster),
 		Spec: istioclientv1beta1.GatewaySpec{
-			Selector: labelsForIstioIngress(r.KafkaCluster.Name, eListenerLabelName),
+			Selector: labelsForIstioIngress(r.KafkaCluster.Name, eListenerLabelName, istioRevision),
 			Servers: generateServers(r.KafkaCluster, externalListenerConfig, log, ingressConf,
 				ingressConfigName, defaultIngressConfigName),
 		},

--- a/pkg/resources/istioingress/meshgateway.go
+++ b/pkg/resources/istioingress/meshgateway.go
@@ -32,7 +32,7 @@ import (
 )
 
 func (r *Reconciler) meshgateway(log logr.Logger, externalListenerConfig v1beta1.ExternalListenerConfig,
-	ingressConfig v1beta1.IngressConfig, ingressConfigName, defaultIngressConfigName string) runtime.Object {
+	ingressConfig v1beta1.IngressConfig, ingressConfigName, defaultIngressConfigName, istioRevision string) runtime.Object {
 	eListenerLabelName := util.ConstructEListenerLabelName(ingressConfigName, externalListenerConfig.Name)
 
 	var meshgatewayName string
@@ -46,11 +46,11 @@ func (r *Reconciler) meshgateway(log logr.Logger, externalListenerConfig v1beta1
 	mgateway := &istioOperatorApi.IstioMeshGateway{
 		ObjectMeta: templates.ObjectMeta(
 			meshgatewayName,
-			labelsForIstioIngress(r.KafkaCluster.Name, eListenerLabelName), r.KafkaCluster),
+			labelsForIstioIngress(r.KafkaCluster.Name, eListenerLabelName, istioRevision), r.KafkaCluster),
 		Spec: &istioOperatorApi.IstioMeshGatewaySpec{
 			Deployment: &istioOperatorApi.BaseKubernetesResourceConfig{
 				Metadata: &istioOperatorApi.K8SObjectMeta{
-					Labels:      labelsForIstioIngress(r.KafkaCluster.Name, eListenerLabelName),
+					Labels:      labelsForIstioIngress(r.KafkaCluster.Name, eListenerLabelName, istioRevision),
 					Annotations: ingressConfig.IstioIngressConfig.GetAnnotations(),
 				},
 				Env:          ingressConfig.IstioIngressConfig.Envs,

--- a/pkg/resources/istioingress/virtualservice.go
+++ b/pkg/resources/istioingress/virtualservice.go
@@ -29,7 +29,7 @@ import (
 )
 
 func (r *Reconciler) virtualService(log logr.Logger, externalListenerConfig v1beta1.ExternalListenerConfig,
-	ingressConfig v1beta1.IngressConfig, ingressConfigName, defaultIngressConfigName string) runtime.Object {
+	ingressConfig v1beta1.IngressConfig, ingressConfigName, defaultIngressConfigName, istioRevision string) runtime.Object {
 	eListenerLabelName := util.ConstructEListenerLabelName(ingressConfigName, externalListenerConfig.Name)
 
 	var gatewayName, virtualSName string
@@ -56,7 +56,7 @@ func (r *Reconciler) virtualService(log logr.Logger, externalListenerConfig v1be
 	return &istioclientv1beta1.VirtualService{
 		ObjectMeta: templates.ObjectMetaWithAnnotations(
 			virtualSName,
-			labelsForIstioIngress(r.KafkaCluster.Name, eListenerLabelName),
+			labelsForIstioIngress(r.KafkaCluster.Name, eListenerLabelName, istioRevision),
 			ingressConfig.IstioIngressConfig.GetVirtualServiceAnnotations(),
 			r.KafkaCluster),
 		Spec: vServiceSpec,

--- a/pkg/resources/reconciler.go
+++ b/pkg/resources/reconciler.go
@@ -51,6 +51,13 @@ type ResourceWithLogAndExternalListenerSpecificInfos func(log logr.Logger,
 	externalListenerConfig v1beta1.ExternalListenerConfig, ingressConfig v1beta1.IngressConfig,
 	ingressConfigName, defaultIngressConfigName string) runtime.Object
 
+// ResourceWithLogAndExternalListenerSpecificInfosAndIstioRevision function with
+// log and externalListenerConfig and ingressConfig parameter with name and default ingress config name
+// and istio revision
+type ResourceWithLogAndExternalListenerSpecificInfosAndIstioRevision func(log logr.Logger,
+	externalListenerConfig v1beta1.ExternalListenerConfig, ingressConfig v1beta1.IngressConfig,
+	ingressConfigName, defaultIngressConfigName, istioRevision string) runtime.Object
+
 // ResourceWithBrokerConfigAndVolume function with brokerConfig, persistentVolumeClaims and log parameters
 type ResourceWithBrokerConfigAndVolume func(id int32, brokerConfig *v1beta1.BrokerConfig, pvcs []corev1.PersistentVolumeClaim, log logr.Logger) runtime.Object
 


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no |
| New feature?    | yes |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Set `istio.io/rev` label on all Istio custom resources created by `koperator` pointing to the referenced Istio control plane.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
On Kubernetes clusters where there are multiple Istio Control planes running each control plane will reconcile the same Istio custom resources unless the Istio custom resources is pinned to a specific control plane. Multiple control planes reconciling the same Istio custom resources potentially may lead to incorrect/undesired Istio configuration.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
