### PR TITLE
Fix documentation for ClientSSLCertSecret and ServerSSLCertSecret

### DIFF
--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -92,7 +92,7 @@ type KafkaClusterSpec struct {
 	// to communicate on SSL with that internal listener which is used for interbroker communication.
 	// The client certificate must share the same chain of trust as the server certificate used by the corresponding internal listener.
 	// The secret must contain the keystore, truststore jks files and the password for them in base64 encoded format and
-	// the tls certificate, tls private key, CA certificate in PEM and base64 encoded format
+	// the tls certificate, tls private key, CA certificate in PEM format with base64 encoded
 	// under the keystore.jks, truststore.jks, password, tls.crt, tls.key, and ca.crt data fields.
 	ClientSSLCertSecret *corev1.LocalObjectReference `json:"clientSSLCertSecret,omitempty"`
 }
@@ -511,8 +511,9 @@ type CommonListenerSpec struct {
 	// +kubebuilder:validation:Enum=ssl;plaintext;sasl_ssl;sasl_plaintext
 	Type SecurityProtocol `json:"type"`
 	// ServerSSLCertSecret is a reference to the Kubernetes secret that contains the server certificate for the listener to be used for SSL communication.
-	// The secret must contain the keystore, truststore jks files and the password for them in base64 encoded format and the tls certificate in PEM and base64 encoded format
-	// under the keystore.jks, truststore.jks, password data fields.
+	// The secret must contain the keystore, truststore jks files and the password for them in base64 encoded format under the keystore.jks, truststore.jks, password data fields.
+	// When the listener is used for inner broker or controller communication the tls certificate is
+	// also needed in PEM format with base64 encoding under the tls.crt data field.
 	// If this field is omitted koperator will auto-create a self-signed server certificate using the configuration provided in 'sslSecrets' field.
 	ServerSSLCertSecret *corev1.LocalObjectReference `json:"serverSSLCertSecret,omitempty"`
 	// SSLClientAuth specifies whether client authentication is required, requested, or not required.

--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -91,8 +91,9 @@ type KafkaClusterSpec struct {
 	// It will be used by the koperator, cruise control, cruise control metrics reporter
 	// to communicate on SSL with that internal listener which is used for interbroker communication.
 	// The client certificate must share the same chain of trust as the server certificate used by the corresponding internal listener.
-	// The secret must contains the keystore, truststore jks files and the password for them in base64 encoded format
-	// under the keystore.jks, truststore.jks, password data fields.
+	// The secret must contain the keystore, truststore jks files and the password for them in base64 encoded format and
+	// the tls certificate, tls private key, CA certificate in PEM and base64 encoded format
+	// under the keystore.jks, truststore.jks, password, tls.crt, tls.key, and ca.crt data fields.
 	ClientSSLCertSecret *corev1.LocalObjectReference `json:"clientSSLCertSecret,omitempty"`
 }
 
@@ -510,7 +511,7 @@ type CommonListenerSpec struct {
 	// +kubebuilder:validation:Enum=ssl;plaintext;sasl_ssl;sasl_plaintext
 	Type SecurityProtocol `json:"type"`
 	// ServerSSLCertSecret is a reference to the Kubernetes secret that contains the server certificate for the listener to be used for SSL communication.
-	// The secret must contain the keystore, truststore jks files and the password for them in base64 encoded format
+	// The secret must contain the keystore, truststore jks files and the password for them in base64 encoded format and the tls certificate in PEM and base64 encoded format
 	// under the keystore.jks, truststore.jks, password data fields.
 	// If this field is omitted koperator will auto-create a self-signed server certificate using the configuration provided in 'sslSecrets' field.
 	ServerSSLCertSecret *corev1.LocalObjectReference `json:"serverSSLCertSecret,omitempty"`

--- a/charts/kafka-operator/templates/crds.yaml
+++ b/charts/kafka-operator/templates/crds.yaml
@@ -12257,10 +12257,11 @@ spec:
                   reporter to communicate on SSL with that internal listener which
                   is used for interbroker communication. The client certificate must
                   share the same chain of trust as the server certificate used by
-                  the corresponding internal listener. The secret must contains the
+                  the corresponding internal listener. The secret must contain the
                   keystore, truststore jks files and the password for them in base64
-                  encoded format under the keystore.jks, truststore.jks, password
-                  data fields.
+                  encoded format and the tls certificate, tls private key, CA certificate
+                  in PEM and base64 encoded format under the keystore.jks, truststore.jks,
+                  password, tls.crt, tls.key, and ca.crt data fields.
                 properties:
                   name:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -19296,7 +19297,8 @@ spec:
                             secret that contains the server certificate for the listener
                             to be used for SSL communication. The secret must contain
                             the keystore, truststore jks files and the password for
-                            them in base64 encoded format under the keystore.jks,
+                            them in base64 encoded format and the tls certificate
+                            in PEM and base64 encoded format under the keystore.jks,
                             truststore.jks, password data fields. If this field is
                             omitted koperator will auto-create a self-signed server
                             certificate using the configuration provided in 'sslSecrets'
@@ -19362,7 +19364,8 @@ spec:
                             secret that contains the server certificate for the listener
                             to be used for SSL communication. The secret must contain
                             the keystore, truststore jks files and the password for
-                            them in base64 encoded format under the keystore.jks,
+                            them in base64 encoded format and the tls certificate
+                            in PEM and base64 encoded format under the keystore.jks,
                             truststore.jks, password data fields. If this field is
                             omitted koperator will auto-create a self-signed server
                             certificate using the configuration provided in 'sslSecrets'

--- a/charts/kafka-operator/templates/crds.yaml
+++ b/charts/kafka-operator/templates/crds.yaml
@@ -12260,7 +12260,7 @@ spec:
                   the corresponding internal listener. The secret must contain the
                   keystore, truststore jks files and the password for them in base64
                   encoded format and the tls certificate, tls private key, CA certificate
-                  in PEM and base64 encoded format under the keystore.jks, truststore.jks,
+                  in PEM format with base64 encoded under the keystore.jks, truststore.jks,
                   password, tls.crt, tls.key, and ca.crt data fields.
                 properties:
                   name:
@@ -19297,9 +19297,11 @@ spec:
                             secret that contains the server certificate for the listener
                             to be used for SSL communication. The secret must contain
                             the keystore, truststore jks files and the password for
-                            them in base64 encoded format and the tls certificate
-                            in PEM and base64 encoded format under the keystore.jks,
-                            truststore.jks, password data fields. If this field is
+                            them in base64 encoded format under the keystore.jks,
+                            truststore.jks, password data fields. When the listener
+                            is used for inner broker or controller communication the
+                            tls certificate is also needed in PEM format with base64
+                            encoding under the tls.crt data field. If this field is
                             omitted koperator will auto-create a self-signed server
                             certificate using the configuration provided in 'sslSecrets'
                             field.
@@ -19364,9 +19366,11 @@ spec:
                             secret that contains the server certificate for the listener
                             to be used for SSL communication. The secret must contain
                             the keystore, truststore jks files and the password for
-                            them in base64 encoded format and the tls certificate
-                            in PEM and base64 encoded format under the keystore.jks,
-                            truststore.jks, password data fields. If this field is
+                            them in base64 encoded format under the keystore.jks,
+                            truststore.jks, password data fields. When the listener
+                            is used for inner broker or controller communication the
+                            tls certificate is also needed in PEM format with base64
+                            encoding under the tls.crt data field. If this field is
                             omitted koperator will auto-create a self-signed server
                             certificate using the configuration provided in 'sslSecrets'
                             field.

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -12256,10 +12256,11 @@ spec:
                   reporter to communicate on SSL with that internal listener which
                   is used for interbroker communication. The client certificate must
                   share the same chain of trust as the server certificate used by
-                  the corresponding internal listener. The secret must contains the
+                  the corresponding internal listener. The secret must contain the
                   keystore, truststore jks files and the password for them in base64
-                  encoded format under the keystore.jks, truststore.jks, password
-                  data fields.
+                  encoded format and the tls certificate, tls private key, CA certificate
+                  in PEM and base64 encoded format under the keystore.jks, truststore.jks,
+                  password, tls.crt, tls.key, and ca.crt data fields.
                 properties:
                   name:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -19295,7 +19296,8 @@ spec:
                             secret that contains the server certificate for the listener
                             to be used for SSL communication. The secret must contain
                             the keystore, truststore jks files and the password for
-                            them in base64 encoded format under the keystore.jks,
+                            them in base64 encoded format and the tls certificate
+                            in PEM and base64 encoded format under the keystore.jks,
                             truststore.jks, password data fields. If this field is
                             omitted koperator will auto-create a self-signed server
                             certificate using the configuration provided in 'sslSecrets'
@@ -19361,7 +19363,8 @@ spec:
                             secret that contains the server certificate for the listener
                             to be used for SSL communication. The secret must contain
                             the keystore, truststore jks files and the password for
-                            them in base64 encoded format under the keystore.jks,
+                            them in base64 encoded format and the tls certificate
+                            in PEM and base64 encoded format under the keystore.jks,
                             truststore.jks, password data fields. If this field is
                             omitted koperator will auto-create a self-signed server
                             certificate using the configuration provided in 'sslSecrets'

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -12259,7 +12259,7 @@ spec:
                   the corresponding internal listener. The secret must contain the
                   keystore, truststore jks files and the password for them in base64
                   encoded format and the tls certificate, tls private key, CA certificate
-                  in PEM and base64 encoded format under the keystore.jks, truststore.jks,
+                  in PEM format with base64 encoded under the keystore.jks, truststore.jks,
                   password, tls.crt, tls.key, and ca.crt data fields.
                 properties:
                   name:
@@ -19296,9 +19296,11 @@ spec:
                             secret that contains the server certificate for the listener
                             to be used for SSL communication. The secret must contain
                             the keystore, truststore jks files and the password for
-                            them in base64 encoded format and the tls certificate
-                            in PEM and base64 encoded format under the keystore.jks,
-                            truststore.jks, password data fields. If this field is
+                            them in base64 encoded format under the keystore.jks,
+                            truststore.jks, password data fields. When the listener
+                            is used for inner broker or controller communication the
+                            tls certificate is also needed in PEM format with base64
+                            encoding under the tls.crt data field. If this field is
                             omitted koperator will auto-create a self-signed server
                             certificate using the configuration provided in 'sslSecrets'
                             field.
@@ -19363,9 +19365,11 @@ spec:
                             secret that contains the server certificate for the listener
                             to be used for SSL communication. The secret must contain
                             the keystore, truststore jks files and the password for
-                            them in base64 encoded format and the tls certificate
-                            in PEM and base64 encoded format under the keystore.jks,
-                            truststore.jks, password data fields. If this field is
+                            them in base64 encoded format under the keystore.jks,
+                            truststore.jks, password data fields. When the listener
+                            is used for inner broker or controller communication the
+                            tls certificate is also needed in PEM format with base64
+                            encoding under the tls.crt data field. If this field is
                             omitted koperator will auto-create a self-signed server
                             certificate using the configuration provided in 'sslSecrets'
                             field.


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | fixes #839  |
| License         | Apache 2.0 |


### What's in this PR?
It fixes the documentation for the ClientSSLCertSecret and ServerSSLCertSecret.


### Why?
The secrets which are referenced by the ClientSSLCertSecret and ServerSSLCertSecret need to contain other fields than the keystore.jks, truststore.jks and password when they are used for inner broker or controller communication
