### PR TITLE
Refactor koperator reserved label keys

### DIFF
--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -47,6 +47,13 @@ const (
 	DefaultEnvoyAdminPort = 8081
 	// DefaultBrokerTerminationGracePeriod default kafka pod termination grace period
 	DefaultBrokerTerminationGracePeriod = 120
+
+	// AppLabelKey is used to represent the reserved operator label, "app"
+	AppLabelKey = "app"
+	// KafkaCRLabelKey is used to represent the reserved operator label, "kafka_cr"
+	KafkaCRLabelKey = "kafka_cr"
+	// BrokerIdLabelKey is used to represent the reserved operator label, "brokerId"
+	BrokerIdLabelKey = "brokerId"
 )
 
 // KafkaClusterSpec defines the desired state of KafkaCluster
@@ -801,7 +808,7 @@ func (bConfig *BrokerConfig) GetBrokerLabels(kafkaClusterName string, brokerId i
 	return util.MergeLabels(
 		bConfig.BrokerLabels,
 		util.LabelsForKafka(kafkaClusterName),
-		map[string]string{"brokerId": fmt.Sprintf("%d", brokerId)},
+		map[string]string{BrokerIdLabelKey: fmt.Sprintf("%d", brokerId)},
 	)
 }
 

--- a/api/v1beta1/kafkacluster_types_test.go
+++ b/api/v1beta1/kafkacluster_types_test.go
@@ -44,7 +44,7 @@ func TestGetBrokerConfigAffinityMergeBrokerNodeAffinityWithGroupsAntiAffinity(t 
 		PodAntiAffinity: &corev1.PodAntiAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
 				{
-					LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "kafka", "kafka_cr": "kafka_broker"}},
+					LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{AppLabelKey: "kafka", KafkaCRLabelKey: "kafka_broker"}},
 					Namespaces:    nil,
 					TopologyKey:   "kubernetes.io/hostname",
 				},
@@ -87,7 +87,7 @@ func TestGetBrokerConfigAffinityMergeBrokerNodeAffinityWithGroupsAntiAffinity(t 
 					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
 						{
 							LabelSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{"app": "kafka", "kafka_cr": "kafka_broker"},
+								MatchLabels: map[string]string{AppLabelKey: "kafka", KafkaCRLabelKey: "kafka_broker"},
 							},
 							TopologyKey: "kubernetes.io/hostname",
 						},
@@ -122,7 +122,7 @@ func TestGetBrokerConfigAffinityMergeEmptyBrokerConfigWithDefaultConfig(t *testi
 		PodAntiAffinity: &corev1.PodAntiAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
 				{
-					LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "kafka", "kafka_cr": "kafka_config_group"}},
+					LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{AppLabelKey: "kafka", KafkaCRLabelKey: "kafka_config_group"}},
 					Namespaces:    nil,
 					TopologyKey:   "kubernetes.io/hostname",
 				},
@@ -139,7 +139,7 @@ func TestGetBrokerConfigAffinityMergeEmptyBrokerConfigWithDefaultConfig(t *testi
 						RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
 							{
 								LabelSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{"app": "kafka", "kafka_cr": "kafka_config_group"},
+									MatchLabels: map[string]string{AppLabelKey: "kafka", KafkaCRLabelKey: "kafka_config_group"},
 								},
 								TopologyKey: "kubernetes.io/hostname",
 							},
@@ -188,7 +188,7 @@ func TestGetBrokerConfigAffinityMergeEqualPodAntiAffinity(t *testing.T) {
 			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
 				{
 					LabelSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{"app": "kafka", "kafka_cr": "kafka_broker"},
+						MatchLabels: map[string]string{AppLabelKey: "kafka", KafkaCRLabelKey: "kafka_broker"},
 					},
 					TopologyKey: "kubernetes.io/hostname",
 				},
@@ -206,7 +206,7 @@ func TestGetBrokerConfigAffinityMergeEqualPodAntiAffinity(t *testing.T) {
 					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
 						{
 							LabelSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{"app": "kafka", "kafka_cr": "kafka_broker"},
+								MatchLabels: map[string]string{AppLabelKey: "kafka", KafkaCRLabelKey: "kafka_broker"},
 							},
 							TopologyKey: "kubernetes.io/hostname",
 						},
@@ -224,7 +224,7 @@ func TestGetBrokerConfigAffinityMergeEqualPodAntiAffinity(t *testing.T) {
 						RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
 							{
 								LabelSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{"app": "kafka", "kafka_cr": "kafka_config_group"},
+									MatchLabels: map[string]string{AppLabelKey: "kafka", KafkaCRLabelKey: "kafka_config_group"},
 								},
 								TopologyKey: "kubernetes.io/hostname",
 							},
@@ -437,17 +437,17 @@ func TestGetBrokerLabels(t *testing.T) {
 	)
 
 	expected := map[string]string{
-		"app":            expectedDefaultLabelApp,
-		"brokerId":       strconv.Itoa(expectedBrokerId),
-		"kafka_cr":       expectedKafkaCRName,
+		AppLabelKey:      expectedDefaultLabelApp,
+		BrokerIdLabelKey: strconv.Itoa(expectedBrokerId),
+		KafkaCRLabelKey:  expectedKafkaCRName,
 		"test_label_key": "test_label_value",
 	}
 
 	brokerConfig := &BrokerConfig{
 		BrokerLabels: map[string]string{
-			"app":            "test_app",
-			"brokerId":       "test_id",
-			"kafka_cr":       "test_cr_name",
+			AppLabelKey:      "test_app",
+			BrokerIdLabelKey: "test_id",
+			KafkaCRLabelKey:  "test_cr_name",
 			"test_label_key": "test_label_value",
 		},
 	}

--- a/controllers/tests/kafkacluster_controller_cruisecontrol_test.go
+++ b/controllers/tests/kafkacluster_controller_cruisecontrol_test.go
@@ -56,7 +56,7 @@ func expectCruiseControlTopic(kafkaCluster *v1beta1.KafkaCluster) {
 	}).Should(Succeed())
 
 	Expect(topic).NotTo(BeNil())
-	Expect(topic.Labels).To(HaveKeyWithValue("app", "kafka"))
+	Expect(topic.Labels).To(HaveKeyWithValue(v1beta1.AppLabelKey, "kafka"))
 	Expect(topic.Labels).To(HaveKeyWithValue("clusterName", kafkaCluster.Name))
 	Expect(topic.Labels).To(HaveKeyWithValue("clusterNamespace", kafkaCluster.Namespace))
 
@@ -80,8 +80,8 @@ func expectCruiseControlService(kafkaCluster *v1beta1.KafkaCluster) {
 		}, service)
 	}).Should(Succeed())
 
-	Expect(service.Labels).To(HaveKeyWithValue("app", "cruisecontrol"))
-	Expect(service.Labels).To(HaveKeyWithValue("kafka_cr", kafkaCluster.Name))
+	Expect(service.Labels).To(HaveKeyWithValue(v1beta1.AppLabelKey, "cruisecontrol"))
+	Expect(service.Labels).To(HaveKeyWithValue(v1beta1.KafkaCRLabelKey, kafkaCluster.Name))
 	Expect(service.Spec.Ports).To(ConsistOf(
 		corev1.ServicePort{
 			Name:       "cc",
@@ -96,8 +96,8 @@ func expectCruiseControlService(kafkaCluster *v1beta1.KafkaCluster) {
 			TargetPort: intstr.FromInt(9020),
 		},
 	))
-	Expect(service.Spec.Selector).To(HaveKeyWithValue("kafka_cr", "kafkacluster-1"))
-	Expect(service.Spec.Selector).To(HaveKeyWithValue("app", "cruisecontrol"))
+	Expect(service.Spec.Selector).To(HaveKeyWithValue(v1beta1.KafkaCRLabelKey, "kafkacluster-1"))
+	Expect(service.Spec.Selector).To(HaveKeyWithValue(v1beta1.AppLabelKey, "cruisecontrol"))
 }
 
 func expectCruiseControlConfigMap(kafkaCluster *v1beta1.KafkaCluster) {
@@ -109,8 +109,8 @@ func expectCruiseControlConfigMap(kafkaCluster *v1beta1.KafkaCluster) {
 		}, configMap)
 	}).Should(Succeed())
 
-	Expect(configMap.Labels).To(HaveKeyWithValue("app", "cruisecontrol"))
-	Expect(configMap.Labels).To(HaveKeyWithValue("kafka_cr", kafkaCluster.Name))
+	Expect(configMap.Labels).To(HaveKeyWithValue(v1beta1.AppLabelKey, "cruisecontrol"))
+	Expect(configMap.Labels).To(HaveKeyWithValue(v1beta1.KafkaCRLabelKey, kafkaCluster.Name))
 
 	Expect(configMap.Data).To(HaveKeyWithValue("cruisecontrol.properties", fmt.Sprintf(`bootstrap.servers=%s-all-broker.%s.%s:29092
 some.config=value
@@ -233,12 +233,12 @@ func expectCruiseControlDeployment(kafkaCluster *v1beta1.KafkaCluster) {
 		}, deployment)
 	}).Should(Succeed())
 
-	Expect(deployment.Labels).To(HaveKeyWithValue("app", "cruisecontrol"))
-	Expect(deployment.Labels).To(HaveKeyWithValue("kafka_cr", kafkaCluster.Name))
+	Expect(deployment.Labels).To(HaveKeyWithValue(v1beta1.AppLabelKey, "cruisecontrol"))
+	Expect(deployment.Labels).To(HaveKeyWithValue(v1beta1.KafkaCRLabelKey, kafkaCluster.Name))
 
 	Expect(deployment.Spec.Selector).NotTo(BeNil())
-	Expect(deployment.Spec.Selector.MatchLabels).To(HaveKeyWithValue("app", "cruisecontrol"))
-	Expect(deployment.Spec.Selector.MatchLabels).To(HaveKeyWithValue("kafka_cr", kafkaCluster.Name))
+	Expect(deployment.Spec.Selector.MatchLabels).To(HaveKeyWithValue(v1beta1.AppLabelKey, "cruisecontrol"))
+	Expect(deployment.Spec.Selector.MatchLabels).To(HaveKeyWithValue(v1beta1.KafkaCRLabelKey, kafkaCluster.Name))
 
 	Expect(deployment.Spec.Template.Annotations).To(HaveKey("cruiseControlCapacity.json"))
 	Expect(deployment.Spec.Template.Annotations).To(HaveKey("cruiseControlClusterConfig.json"))

--- a/controllers/tests/kafkacluster_controller_envoy_test.go
+++ b/controllers/tests/kafkacluster_controller_envoy_test.go
@@ -29,9 +29,9 @@ import (
 )
 
 func expectEnvoyIngressLabels(labels map[string]string, eListenerName, crName string) {
-	Expect(labels).To(HaveKeyWithValue("app", "envoyingress"))
+	Expect(labels).To(HaveKeyWithValue(v1beta1.AppLabelKey, "envoyingress"))
 	Expect(labels).To(HaveKeyWithValue("eListenerName", eListenerName))
-	Expect(labels).To(HaveKeyWithValue("kafka_cr", crName))
+	Expect(labels).To(HaveKeyWithValue(v1beta1.KafkaCRLabelKey, crName))
 }
 
 func expectEnvoyIngressAnnotations(annotations map[string]string) {
@@ -49,9 +49,9 @@ func expectEnvoyLoadBalancer(kafkaCluster *v1beta1.KafkaCluster, eListenerTempla
 	expectEnvoyIngressLabels(loadBalancer.Labels, eListenerTemplate, kafkaCluster.Name)
 	Expect(loadBalancer.Spec.Type).To(Equal(corev1.ServiceTypeLoadBalancer))
 	Expect(loadBalancer.Spec.Selector).To(Equal(map[string]string{
-		"app":           "envoyingress",
-		"eListenerName": eListenerTemplate,
-		"kafka_cr":      kafkaCluster.Name,
+		v1beta1.AppLabelKey:     "envoyingress",
+		"eListenerName":         eListenerTemplate,
+		v1beta1.KafkaCRLabelKey: kafkaCluster.Name,
 	}))
 	Expect(loadBalancer.Spec.Ports).To(HaveLen(6))
 	for i, port := range loadBalancer.Spec.Ports {

--- a/controllers/tests/kafkacluster_controller_externallistenerbindings_test.go
+++ b/controllers/tests/kafkacluster_controller_externallistenerbindings_test.go
@@ -41,9 +41,9 @@ func expectDefaultBrokerSettingsForExternalListenerBinding(kafkaCluster *v1beta1
 			}, &configMap)
 		}).Should(Succeed())
 
-		Expect(configMap.Labels).To(HaveKeyWithValue("app", "kafka"))
-		Expect(configMap.Labels).To(HaveKeyWithValue("kafka_cr", kafkaCluster.Name))
-		Expect(configMap.Labels).To(HaveKeyWithValue("brokerId", strconv.Itoa(int(broker.Id))))
+		Expect(configMap.Labels).To(HaveKeyWithValue(v1beta1.AppLabelKey, "kafka"))
+		Expect(configMap.Labels).To(HaveKeyWithValue(v1beta1.KafkaCRLabelKey, kafkaCluster.Name))
+		Expect(configMap.Labels).To(HaveKeyWithValue(v1beta1.BrokerIdLabelKey, strconv.Itoa(int(broker.Id))))
 
 		brokerConfig, err := properties.NewFromString(configMap.Data["broker-config"])
 		Expect(err).NotTo(HaveOccurred())
@@ -66,9 +66,9 @@ func expectDefaultBrokerSettingsForExternalListenerBinding(kafkaCluster *v1beta1
 			}, &service)
 		}).Should(Succeed())
 
-		Expect(service.Labels).To(HaveKeyWithValue("app", "kafka"))
-		Expect(service.Labels).To(HaveKeyWithValue("kafka_cr", kafkaCluster.Name))
-		Expect(service.Labels).To(HaveKeyWithValue("brokerId", strconv.Itoa(int(broker.Id))))
+		Expect(service.Labels).To(HaveKeyWithValue(v1beta1.AppLabelKey, "kafka"))
+		Expect(service.Labels).To(HaveKeyWithValue(v1beta1.KafkaCRLabelKey, kafkaCluster.Name))
+		Expect(service.Labels).To(HaveKeyWithValue(v1beta1.BrokerIdLabelKey, strconv.Itoa(int(broker.Id))))
 
 		Expect(service.Spec.Ports).To(ConsistOf(
 			corev1.ServicePort{

--- a/controllers/tests/kafkacluster_controller_externalnodeport_test.go
+++ b/controllers/tests/kafkacluster_controller_externalnodeport_test.go
@@ -154,16 +154,16 @@ var _ = Describe("KafkaClusterNodeportExternalAccess", func() {
 			}).Should(Succeed())
 
 			Expect(svc.Labels).To(Equal(map[string]string{
-				"app":      "kafka",
-				"brokerId": "0",
-				"kafka_cr": kafkaCluster.Name,
+				v1beta1.AppLabelKey:      "kafka",
+				v1beta1.BrokerIdLabelKey: "0",
+				v1beta1.KafkaCRLabelKey:  kafkaCluster.Name,
 			}))
 
 			Expect(svc.Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
 			Expect(svc.Spec.Selector).To(Equal(map[string]string{
-				"app":      "kafka",
-				"brokerId": "0",
-				"kafka_cr": kafkaCluster.Name,
+				v1beta1.AppLabelKey:      "kafka",
+				v1beta1.BrokerIdLabelKey: "0",
+				v1beta1.KafkaCRLabelKey:  kafkaCluster.Name,
 			}))
 
 			Expect(svc.Spec.Ports).To(HaveLen(1))

--- a/controllers/tests/kafkacluster_controller_istioingress_test.go
+++ b/controllers/tests/kafkacluster_controller_istioingress_test.go
@@ -47,9 +47,9 @@ var _ = Describe("KafkaClusterIstioIngressController", func() {
 	)
 
 	ExpectIstioIngressLabels := func(labels map[string]string, eListenerName, crName string) {
-		Expect(labels).To(HaveKeyWithValue("app", "istioingress"))
+		Expect(labels).To(HaveKeyWithValue(v1beta1.AppLabelKey, "istioingress"))
 		Expect(labels).To(HaveKeyWithValue("eListenerName", eListenerName))
-		Expect(labels).To(HaveKeyWithValue("kafka_cr", crName))
+		Expect(labels).To(HaveKeyWithValue(v1beta1.KafkaCRLabelKey, crName))
 	}
 
 	BeforeEach(func() {
@@ -397,9 +397,9 @@ var _ = Describe("KafkaClusterIstioIngressControllerWithBrokerIdBindings", func(
 	)
 
 	ExpectIstioIngressLabels := func(labels map[string]string, eListenerName, crName string) {
-		Expect(labels).To(HaveKeyWithValue("app", "istioingress"))
+		Expect(labels).To(HaveKeyWithValue(v1beta1.AppLabelKey, "istioingress"))
 		Expect(labels).To(HaveKeyWithValue("eListenerName", eListenerName))
-		Expect(labels).To(HaveKeyWithValue("kafka_cr", crName))
+		Expect(labels).To(HaveKeyWithValue(v1beta1.KafkaCRLabelKey, crName))
 	}
 
 	BeforeEach(func() {

--- a/controllers/tests/kafkacluster_controller_kafka_test.go
+++ b/controllers/tests/kafkacluster_controller_kafka_test.go
@@ -59,13 +59,13 @@ func expectKafkaAllBrokerService(kafkaCluster *v1beta1.KafkaCluster) {
 		}, service)
 	}).Should(Succeed())
 
-	Expect(service.Labels).To(HaveKeyWithValue("app", "kafka"))
-	Expect(service.Labels).To(HaveKeyWithValue("kafka_cr", kafkaCluster.Name))
+	Expect(service.Labels).To(HaveKeyWithValue(v1beta1.AppLabelKey, "kafka"))
+	Expect(service.Labels).To(HaveKeyWithValue(v1beta1.KafkaCRLabelKey, kafkaCluster.Name))
 
 	Expect(service.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
 	Expect(service.Spec.SessionAffinity).To(Equal(corev1.ServiceAffinityNone))
-	Expect(service.Spec.Selector).To(HaveKeyWithValue("app", "kafka"))
-	Expect(service.Spec.Selector).To(HaveKeyWithValue("kafka_cr", kafkaCluster.Name))
+	Expect(service.Spec.Selector).To(HaveKeyWithValue(v1beta1.AppLabelKey, "kafka"))
+	Expect(service.Spec.Selector).To(HaveKeyWithValue(v1beta1.KafkaCRLabelKey, kafkaCluster.Name))
 	Expect(service.Spec.Ports).To(ConsistOf(
 		corev1.ServicePort{
 			Name:       "tcp-internal",
@@ -116,12 +116,12 @@ func expectKafkaPDB(kafkaCluster *v1beta1.KafkaCluster) {
 	}).Should(Succeed())
 
 	// make assertions
-	Expect(pdb.Labels).To(HaveKeyWithValue("app", "kafka"))
-	Expect(pdb.Labels).To(HaveKeyWithValue("kafka_cr", kafkaCluster.Name))
+	Expect(pdb.Labels).To(HaveKeyWithValue(v1beta1.AppLabelKey, "kafka"))
+	Expect(pdb.Labels).To(HaveKeyWithValue(v1beta1.KafkaCRLabelKey, kafkaCluster.Name))
 	Expect(pdb.Spec.MinAvailable).To(Equal(util.IntstrPointer(3)))
 	Expect(pdb.Spec.Selector).NotTo(BeNil())
-	Expect(pdb.Spec.Selector.MatchLabels).To(HaveKeyWithValue("app", "kafka"))
-	Expect(pdb.Spec.Selector.MatchLabels).To(HaveKeyWithValue("kafka_cr", kafkaCluster.Name))
+	Expect(pdb.Spec.Selector.MatchLabels).To(HaveKeyWithValue(v1beta1.AppLabelKey, "kafka"))
+	Expect(pdb.Spec.Selector.MatchLabels).To(HaveKeyWithValue(v1beta1.KafkaCRLabelKey, kafkaCluster.Name))
 }
 
 func expectKafkaPVC(kafkaCluster *v1beta1.KafkaCluster) {
@@ -130,15 +130,15 @@ func expectKafkaPVC(kafkaCluster *v1beta1.KafkaCluster) {
 	Eventually(func() error {
 		return k8sClient.List(context.Background(), &pvcs,
 			client.ListOption(client.InNamespace(kafkaCluster.Namespace)),
-			client.ListOption(client.MatchingLabels(map[string]string{"app": "kafka", "kafka_cr": kafkaCluster.Name})))
+			client.ListOption(client.MatchingLabels(map[string]string{v1beta1.AppLabelKey: "kafka", v1beta1.KafkaCRLabelKey: kafkaCluster.Name})))
 	}).Should(Succeed())
 
 	Expect(pvcs.Items).To(HaveLen(3))
 	for i, pvc := range pvcs.Items {
 		Expect(pvc.GenerateName).To(Equal(fmt.Sprintf("%s-%d-storage-0-", kafkaCluster.Name, i)))
-		Expect(pvc.Labels).To(HaveKeyWithValue("app", "kafka"))
-		Expect(pvc.Labels).To(HaveKeyWithValue("brokerId", strconv.Itoa(i)))
-		Expect(pvc.Labels).To(HaveKeyWithValue("kafka_cr", kafkaCluster.Name))
+		Expect(pvc.Labels).To(HaveKeyWithValue(v1beta1.AppLabelKey, "kafka"))
+		Expect(pvc.Labels).To(HaveKeyWithValue(v1beta1.BrokerIdLabelKey, strconv.Itoa(i)))
+		Expect(pvc.Labels).To(HaveKeyWithValue(v1beta1.KafkaCRLabelKey, kafkaCluster.Name))
 		Expect(pvc.Annotations).To(HaveKeyWithValue("mountPath", "/kafka-logs"))
 		Expect(pvc.Spec.AccessModes).To(ConsistOf(corev1.ReadWriteOnce))
 		Expect(pvc.Spec.Resources).To(Equal(corev1.ResourceRequirements{
@@ -158,9 +158,9 @@ func expectKafkaBrokerConfigmap(kafkaCluster *v1beta1.KafkaCluster, broker v1bet
 		}, &configMap)
 	}).Should(Succeed())
 
-	Expect(configMap.Labels).To(HaveKeyWithValue("app", "kafka"))
-	Expect(configMap.Labels).To(HaveKeyWithValue("kafka_cr", kafkaCluster.Name))
-	Expect(configMap.Labels).To(HaveKeyWithValue("brokerId", strconv.Itoa(int(broker.Id))))
+	Expect(configMap.Labels).To(HaveKeyWithValue(v1beta1.AppLabelKey, "kafka"))
+	Expect(configMap.Labels).To(HaveKeyWithValue(v1beta1.KafkaCRLabelKey, kafkaCluster.Name))
+	Expect(configMap.Labels).To(HaveKeyWithValue(v1beta1.BrokerIdLabelKey, strconv.Itoa(int(broker.Id))))
 
 	Expect(configMap.Data).To(HaveKeyWithValue("broker-config", fmt.Sprintf(`advertised.listeners=CONTROLLER://kafkacluster-%d-%d.kafka-%d.svc.cluster.local:29093,INTERNAL://kafkacluster-%d-%d.kafka-%d.svc.cluster.local:29092,TEST://test.host.com:%d
 broker.id=%d
@@ -187,9 +187,9 @@ func expectKafkaBrokerService(kafkaCluster *v1beta1.KafkaCluster, broker v1beta1
 		}, &service)
 	}).Should(Succeed())
 
-	Expect(service.Labels).To(HaveKeyWithValue("app", "kafka"))
-	Expect(service.Labels).To(HaveKeyWithValue("kafka_cr", kafkaCluster.Name))
-	Expect(service.Labels).To(HaveKeyWithValue("brokerId", strconv.Itoa(int(broker.Id))))
+	Expect(service.Labels).To(HaveKeyWithValue(v1beta1.AppLabelKey, "kafka"))
+	Expect(service.Labels).To(HaveKeyWithValue(v1beta1.KafkaCRLabelKey, kafkaCluster.Name))
+	Expect(service.Labels).To(HaveKeyWithValue(v1beta1.BrokerIdLabelKey, strconv.Itoa(int(broker.Id))))
 
 	Expect(service.Spec.Ports).To(ConsistOf(
 		corev1.ServicePort{
@@ -217,9 +217,9 @@ func expectKafkaBrokerService(kafkaCluster *v1beta1.KafkaCluster, broker v1beta1
 			TargetPort: intstr.FromInt(9020),
 		}))
 
-	Expect(service.Spec.Selector).To(HaveKeyWithValue("app", "kafka"))
-	Expect(service.Spec.Selector).To(HaveKeyWithValue("kafka_cr", kafkaCluster.Name))
-	Expect(service.Spec.Selector).To(HaveKeyWithValue("brokerId", strconv.Itoa(int(broker.Id))))
+	Expect(service.Spec.Selector).To(HaveKeyWithValue(v1beta1.AppLabelKey, "kafka"))
+	Expect(service.Spec.Selector).To(HaveKeyWithValue(v1beta1.KafkaCRLabelKey, kafkaCluster.Name))
+	Expect(service.Spec.Selector).To(HaveKeyWithValue(v1beta1.BrokerIdLabelKey, strconv.Itoa(int(broker.Id))))
 	Expect(service.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
 }
 
@@ -228,14 +228,14 @@ func expectKafkaBrokerPod(kafkaCluster *v1beta1.KafkaCluster, broker v1beta1.Bro
 	Eventually(func() ([]corev1.Pod, error) {
 		err := k8sClient.List(context.Background(), &podList,
 			client.ListOption(client.InNamespace(kafkaCluster.Namespace)),
-			client.ListOption(client.MatchingLabels(map[string]string{"app": "kafka", "kafka_cr": kafkaCluster.Name, "brokerId": strconv.Itoa(int(broker.Id))})))
+			client.ListOption(client.MatchingLabels(map[string]string{v1beta1.AppLabelKey: "kafka", v1beta1.KafkaCRLabelKey: kafkaCluster.Name, v1beta1.BrokerIdLabelKey: strconv.Itoa(int(broker.Id))})))
 		return podList.Items, err
 	}).Should(HaveLen(1))
 
 	pod := podList.Items[0]
 
 	Expect(pod.GenerateName).To(Equal(fmt.Sprintf("%s-%d-", kafkaCluster.Name, broker.Id)))
-	Expect(pod.Labels).To(HaveKeyWithValue("brokerId", strconv.Itoa(int(broker.Id))))
+	Expect(pod.Labels).To(HaveKeyWithValue(v1beta1.BrokerIdLabelKey, strconv.Itoa(int(broker.Id))))
 	getContainerName := func(c corev1.Container) string { return c.Name }
 	// test exact order, because if the slice reorders, it triggers another reconcile cycle
 	Expect(pod.Spec.InitContainers).To(HaveLen(4))

--- a/controllers/tests/kafkacluster_controller_test.go
+++ b/controllers/tests/kafkacluster_controller_test.go
@@ -374,7 +374,7 @@ func expectKafkaMonitoring(kafkaCluster *v1beta1.KafkaCluster) {
 		return err
 	}).Should(Succeed())
 
-	Expect(configMap.Labels).To(And(HaveKeyWithValue("app", "kafka-jmx"), HaveKeyWithValue("kafka_cr", kafkaCluster.Name)))
+	Expect(configMap.Labels).To(And(HaveKeyWithValue(v1beta1.AppLabelKey, "kafka-jmx"), HaveKeyWithValue(v1beta1.KafkaCRLabelKey, kafkaCluster.Name)))
 	Expect(configMap.Data).To(HaveKeyWithValue("config.yaml", Not(BeEmpty())))
 }
 
@@ -387,6 +387,6 @@ func expectCruiseControlMonitoring(kafkaCluster *v1beta1.KafkaCluster) {
 		return err
 	}).Should(Succeed())
 
-	Expect(configMap.Labels).To(And(HaveKeyWithValue("app", "cruisecontrol-jmx"), HaveKeyWithValue("kafka_cr", kafkaCluster.Name)))
+	Expect(configMap.Labels).To(And(HaveKeyWithValue(v1beta1.AppLabelKey, "cruisecontrol-jmx"), HaveKeyWithValue(v1beta1.KafkaCRLabelKey, kafkaCluster.Name)))
 	Expect(configMap.Data).To(HaveKeyWithValue("config.yaml", kafkaCluster.Spec.MonitoringConfig.CCJMXExporterConfig))
 }

--- a/internal/alertmanager/currentalert/alert_validator_test.go
+++ b/internal/alertmanager/currentalert/alert_validator_test.go
@@ -17,6 +17,7 @@ package currentalert
 import (
 	"testing"
 
+	"github.com/banzaicloud/koperator/api/v1beta1"
 	"github.com/prometheus/common/model"
 )
 
@@ -79,7 +80,7 @@ func TestAlertValidators_ValidateAlert(t *testing.T) {
 				downScaleValidator{
 					Alert: &currentAlertStruct{
 						Labels: model.LabelSet{
-							"kafka_cr": "kafka",
+							v1beta1.KafkaCRLabelKey: "kafka",
 						},
 						Annotations: model.LabelSet{
 							"command": DownScaleCommand,
@@ -110,7 +111,7 @@ func TestAlertValidators_ValidateAlert(t *testing.T) {
 				downScaleValidator{
 					Alert: &currentAlertStruct{
 						Labels: model.LabelSet{
-							"kafka_cr": "kafka",
+							v1beta1.KafkaCRLabelKey: "kafka",
 						},
 						Annotations: model.LabelSet{
 							"command": "fake-command",
@@ -126,7 +127,7 @@ func TestAlertValidators_ValidateAlert(t *testing.T) {
 				upScaleValidator{
 					Alert: &currentAlertStruct{
 						Labels: model.LabelSet{
-							"kafka_cr": "kafka",
+							v1beta1.KafkaCRLabelKey: "kafka",
 						},
 						Annotations: model.LabelSet{
 							"command": UpScaleCommand,
@@ -157,7 +158,7 @@ func TestAlertValidators_ValidateAlert(t *testing.T) {
 				upScaleValidator{
 					Alert: &currentAlertStruct{
 						Labels: model.LabelSet{
-							"kafka_cr": "kafka",
+							v1beta1.KafkaCRLabelKey: "kafka",
 						},
 						Annotations: model.LabelSet{
 							"command": "fake-command",

--- a/internal/alertmanager/currentalert/alert_validator_test.go
+++ b/internal/alertmanager/currentalert/alert_validator_test.go
@@ -17,8 +17,9 @@ package currentalert
 import (
 	"testing"
 
-	"github.com/banzaicloud/koperator/api/v1beta1"
 	"github.com/prometheus/common/model"
+
+	"github.com/banzaicloud/koperator/api/v1beta1"
 )
 
 func TestAlertValidators_ValidateAlert(t *testing.T) {

--- a/internal/alertmanager/currentalert/current_alerts_test.go
+++ b/internal/alertmanager/currentalert/current_alerts_test.go
@@ -180,10 +180,10 @@ func TestGetCurrentAlerts(t *testing.T) {
 		FingerPrint: model.Fingerprint(1111),
 		Status:      model.AlertStatus(firingAlertStatus),
 		Labels: model.LabelSet{
-			"alertname": "PodAlert",
-			"test":      "test",
-			"kafka_cr":  "kafka",
-			"namespace": "kafka",
+			"alertname":             "PodAlert",
+			"test":                  "test",
+			v1beta1.KafkaCRLabelKey: "kafka",
+			"namespace":             "kafka",
 		},
 		Annotations: map[model.LabelName]model.LabelValue{
 			"command": "testing",

--- a/internal/alertmanager/currentalert/downscale_validator.go
+++ b/internal/alertmanager/currentalert/downscale_validator.go
@@ -16,6 +16,7 @@ package currentalert
 
 import (
 	emperror "emperror.dev/errors"
+	"github.com/banzaicloud/koperator/api/v1beta1"
 )
 
 type downScaleValidator struct {
@@ -29,7 +30,7 @@ func newDownScaleValidator(curerentAlert *currentAlertStruct) downScaleValidator
 }
 
 func (a downScaleValidator) validateAlert() error {
-	if !checkLabelExists(a.Alert.Labels, "kafka_cr") {
+	if !checkLabelExists(a.Alert.Labels, v1beta1.KafkaCRLabelKey) {
 		return emperror.New("kafka_cr label doesn't exist")
 	}
 	if a.Alert.Annotations["command"] != DownScaleCommand {

--- a/internal/alertmanager/currentalert/downscale_validator.go
+++ b/internal/alertmanager/currentalert/downscale_validator.go
@@ -16,6 +16,7 @@ package currentalert
 
 import (
 	emperror "emperror.dev/errors"
+
 	"github.com/banzaicloud/koperator/api/v1beta1"
 )
 

--- a/internal/alertmanager/currentalert/downscale_validator_test.go
+++ b/internal/alertmanager/currentalert/downscale_validator_test.go
@@ -17,8 +17,9 @@ package currentalert
 import (
 	"testing"
 
-	"github.com/banzaicloud/koperator/api/v1beta1"
 	"github.com/prometheus/common/model"
+
+	"github.com/banzaicloud/koperator/api/v1beta1"
 )
 
 func TestDownScaleValidator_validateAlert(t *testing.T) {

--- a/internal/alertmanager/currentalert/downscale_validator_test.go
+++ b/internal/alertmanager/currentalert/downscale_validator_test.go
@@ -17,6 +17,7 @@ package currentalert
 import (
 	"testing"
 
+	"github.com/banzaicloud/koperator/api/v1beta1"
 	"github.com/prometheus/common/model"
 )
 
@@ -34,7 +35,7 @@ func TestDownScaleValidator_validateAlert(t *testing.T) {
 			fields: fields{
 				Alert: &currentAlertStruct{
 					Labels: model.LabelSet{
-						"kafka_cr": "kafka",
+						v1beta1.KafkaCRLabelKey: "kafka",
 					},
 					Annotations: model.LabelSet{
 						"command": DownScaleCommand,
@@ -61,7 +62,7 @@ func TestDownScaleValidator_validateAlert(t *testing.T) {
 			fields: fields{
 				Alert: &currentAlertStruct{
 					Labels: model.LabelSet{
-						"kafka_cr": "kafka",
+						v1beta1.KafkaCRLabelKey: "kafka",
 					},
 					Annotations: model.LabelSet{
 						"command": "fake-command",

--- a/internal/alertmanager/currentalert/process_test.go
+++ b/internal/alertmanager/currentalert/process_test.go
@@ -67,9 +67,9 @@ func Test_resizePvc(t *testing.T) {
 					Name:      "testPvc",
 					Namespace: "kafka",
 					Labels: map[string]string{
-						"app":      "kafka",
-						"brokerId": "0",
-						"kafka_cr": "test-cluster",
+						v1beta1.AppLabelKey:      "kafka",
+						v1beta1.BrokerIdLabelKey: "0",
+						v1beta1.KafkaCRLabelKey:  "test-cluster",
 					},
 					Annotations: map[string]string{
 						"mountPath":                          "/kafka-logs",
@@ -135,9 +135,9 @@ func Test_resizePvc(t *testing.T) {
 					Name:      "testPvc",
 					Namespace: "kafka",
 					Labels: map[string]string{
-						"app":      "kafka",
-						"brokerId": "0",
-						"kafka_cr": "test-cluster",
+						v1beta1.AppLabelKey:      "kafka",
+						v1beta1.BrokerIdLabelKey: "0",
+						v1beta1.KafkaCRLabelKey:  "test-cluster",
 					},
 					Annotations: map[string]string{
 						"mountPath":                          "/kafka-logs",
@@ -268,7 +268,7 @@ func Test_addPvc(t *testing.T) {
 			alertList: []model.Alert{
 				{
 					Labels: model.LabelSet{
-						"kafka_cr":              "kafka",
+						v1beta1.KafkaCRLabelKey: "kafka",
 						"namespace":             "kafka",
 						"persistentvolumeclaim": "testPvc",
 						"node":                  "test-node",
@@ -287,9 +287,9 @@ func Test_addPvc(t *testing.T) {
 							Name:      "testPvc",
 							Namespace: "kafka",
 							Labels: map[string]string{
-								"app":      "kafka",
-								"brokerId": "0",
-								"kafka_cr": "kafka",
+								v1beta1.AppLabelKey:      "kafka",
+								v1beta1.BrokerIdLabelKey: "0",
+								v1beta1.KafkaCRLabelKey:  "kafka",
 							},
 							Annotations: map[string]string{
 								"mountPath":                          "/kafka-logs",
@@ -308,7 +308,7 @@ func Test_addPvc(t *testing.T) {
 			alertList: []model.Alert{
 				{
 					Labels: model.LabelSet{
-						"kafka_cr":              "kafka",
+						v1beta1.KafkaCRLabelKey: "kafka",
 						"namespace":             "kafka",
 						"persistentvolumeclaim": "testPvc1",
 						"node":                  "test-node",
@@ -321,7 +321,7 @@ func Test_addPvc(t *testing.T) {
 				},
 				{
 					Labels: model.LabelSet{
-						"kafka_cr":              "kafka",
+						v1beta1.KafkaCRLabelKey: "kafka",
 						"namespace":             "kafka",
 						"persistentvolumeclaim": "testPvc2",
 						"node":                  "test-node",
@@ -340,9 +340,9 @@ func Test_addPvc(t *testing.T) {
 							Name:      "testPvc1",
 							Namespace: "kafka",
 							Labels: map[string]string{
-								"app":      "kafka",
-								"brokerId": "0",
-								"kafka_cr": "kafka",
+								v1beta1.AppLabelKey:      "kafka",
+								v1beta1.BrokerIdLabelKey: "0",
+								v1beta1.KafkaCRLabelKey:  "kafka",
 							},
 							Annotations: map[string]string{
 								"mountPath":                          "/kafka-logs",
@@ -361,9 +361,9 @@ func Test_addPvc(t *testing.T) {
 							Name:      "testPvc2",
 							Namespace: "kafka",
 							Labels: map[string]string{
-								"app":      "kafka",
-								"brokerId": "0",
-								"kafka_cr": "kafka",
+								v1beta1.AppLabelKey:      "kafka",
+								v1beta1.BrokerIdLabelKey: "0",
+								v1beta1.KafkaCRLabelKey:  "kafka",
 							},
 							Annotations: map[string]string{
 								"mountPath":                          "/kafka-logs",
@@ -482,10 +482,10 @@ func Test_upScale(t *testing.T) {
 			},
 			alert: model.Alert{
 				Labels: model.LabelSet{
-					"kafka_cr":   "test-cluster",
-					"namespace":  "test-namespace",
-					"severity":   "critical",
-					"alertGroup": "test",
+					v1beta1.KafkaCRLabelKey: "test-cluster",
+					"namespace":             "test-namespace",
+					"severity":              "critical",
+					"alertGroup":            "test",
 				},
 				Annotations: map[model.LabelName]model.LabelValue{
 					"command":           "upScale",
@@ -523,10 +523,10 @@ func Test_upScale(t *testing.T) {
 			},
 			alert: model.Alert{
 				Labels: model.LabelSet{
-					"kafka_cr":   "test-cluster",
-					"namespace":  "test-namespace",
-					"severity":   "critical",
-					"alertGroup": "test",
+					v1beta1.KafkaCRLabelKey: "test-cluster",
+					"namespace":             "test-namespace",
+					"severity":              "critical",
+					"alertGroup":            "test",
 				},
 				Annotations: map[model.LabelName]model.LabelValue{
 					"command":           "upScale",
@@ -637,11 +637,11 @@ func Test_downScale(t *testing.T) {
 			// Remove broker with id 1 using alert
 			alert: model.Alert{
 				Labels: model.LabelSet{
-					"kafka_cr":   "test-cluster",
-					"namespace":  "test-namespace",
-					"severity":   "critical",
-					"alertGroup": "test",
-					"brokerId":   "1",
+					v1beta1.KafkaCRLabelKey:  "test-cluster",
+					"namespace":              "test-namespace",
+					"severity":               "critical",
+					"alertGroup":             "test",
+					v1beta1.BrokerIdLabelKey: "1",
 				},
 				Annotations: map[model.LabelName]model.LabelValue{
 					"command":           "downscale",

--- a/internal/alertmanager/currentalert/upscale_validator.go
+++ b/internal/alertmanager/currentalert/upscale_validator.go
@@ -16,6 +16,7 @@ package currentalert
 
 import (
 	emperror "emperror.dev/errors"
+	"github.com/banzaicloud/koperator/api/v1beta1"
 )
 
 type upScaleValidator struct {
@@ -29,7 +30,7 @@ func newUpScaleValidator(curerentAlert *currentAlertStruct) upScaleValidator {
 }
 
 func (a upScaleValidator) validateAlert() error {
-	if !checkLabelExists(a.Alert.Labels, "kafka_cr") {
+	if !checkLabelExists(a.Alert.Labels, v1beta1.KafkaCRLabelKey) {
 		return emperror.New("kafka_cr label doesn't exist")
 	}
 	if a.Alert.Annotations["command"] != UpScaleCommand {

--- a/internal/alertmanager/currentalert/upscale_validator.go
+++ b/internal/alertmanager/currentalert/upscale_validator.go
@@ -16,6 +16,7 @@ package currentalert
 
 import (
 	emperror "emperror.dev/errors"
+
 	"github.com/banzaicloud/koperator/api/v1beta1"
 )
 

--- a/internal/alertmanager/currentalert/upscale_validator_test.go
+++ b/internal/alertmanager/currentalert/upscale_validator_test.go
@@ -17,8 +17,9 @@ package currentalert
 import (
 	"testing"
 
-	"github.com/banzaicloud/koperator/api/v1beta1"
 	"github.com/prometheus/common/model"
+
+	"github.com/banzaicloud/koperator/api/v1beta1"
 )
 
 func TestUpScaleValidator_validateAlert(t *testing.T) {

--- a/internal/alertmanager/currentalert/upscale_validator_test.go
+++ b/internal/alertmanager/currentalert/upscale_validator_test.go
@@ -17,6 +17,7 @@ package currentalert
 import (
 	"testing"
 
+	"github.com/banzaicloud/koperator/api/v1beta1"
 	"github.com/prometheus/common/model"
 )
 
@@ -34,7 +35,7 @@ func TestUpScaleValidator_validateAlert(t *testing.T) {
 			fields: fields{
 				Alert: &currentAlertStruct{
 					Labels: model.LabelSet{
-						"kafka_cr": "kafka",
+						v1beta1.KafkaCRLabelKey: "kafka",
 					},
 					Annotations: model.LabelSet{
 						"command": UpScaleCommand,
@@ -61,7 +62,7 @@ func TestUpScaleValidator_validateAlert(t *testing.T) {
 			fields: fields{
 				Alert: &currentAlertStruct{
 					Labels: model.LabelSet{
-						"kafka_cr": "kafka",
+						v1beta1.KafkaCRLabelKey: "kafka",
 					},
 					Annotations: model.LabelSet{
 						"command": "fake-command",

--- a/pkg/k8sutil/cr.go
+++ b/pkg/k8sutil/cr.go
@@ -54,7 +54,7 @@ func rackAwarenessLabelsToReadonlyConfig(pod *corev1.Pod, cr *v1beta1.KafkaClust
 	brokerConfigs := []v1beta1.Broker{}
 	var readOnlyConfig string
 	var rackAwaranessState string
-	brokerID := pod.Labels["brokerId"]
+	brokerID := pod.Labels[v1beta1.BrokerIdLabelKey]
 	//nolint:gocritic
 	for _, broker := range cr.Spec.Brokers {
 		if strconv.Itoa(int(broker.Id)) == brokerID {

--- a/pkg/k8sutil/cr_test.go
+++ b/pkg/k8sutil/cr_test.go
@@ -42,7 +42,7 @@ func Test_rackAwarenessLabelsToReadonlyConfig(t *testing.T) {
 				pod: &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"brokerId": "0",
+							v1beta1.BrokerIdLabelKey: "0",
 						},
 					},
 				},
@@ -72,7 +72,7 @@ func Test_rackAwarenessLabelsToReadonlyConfig(t *testing.T) {
 				pod: &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"brokerId": "0",
+							v1beta1.BrokerIdLabelKey: "0",
 						},
 					},
 				},
@@ -103,7 +103,7 @@ func Test_rackAwarenessLabelsToReadonlyConfig(t *testing.T) {
 				pod: &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"brokerId": "0",
+							v1beta1.BrokerIdLabelKey: "0",
 						},
 					},
 				},
@@ -139,7 +139,7 @@ func Test_rackAwarenessLabelsToReadonlyConfig(t *testing.T) {
 				pod: &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"brokerId": "0",
+							v1beta1.BrokerIdLabelKey: "0",
 						},
 					},
 				},
@@ -176,7 +176,7 @@ func Test_rackAwarenessLabelsToReadonlyConfig(t *testing.T) {
 				pod: &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"brokerId": "0",
+							v1beta1.BrokerIdLabelKey: "0",
 						},
 					},
 				},

--- a/pkg/k8sutil/resource.go
+++ b/pkg/k8sutil/resource.go
@@ -127,15 +127,15 @@ func Reconcile(log logr.Logger, client runtimeClient.Client, desired runtime.Obj
 			}
 			if _, ok := desired.(*corev1.ConfigMap); ok {
 				// Only update status when configmap belongs to broker
-				if id, ok := desired.(*corev1.ConfigMap).Labels["brokerId"]; ok {
+				if id, ok := desired.(*corev1.ConfigMap).Labels[v1beta1.BrokerIdLabelKey]; ok {
 					currentConfigs, err := properties.NewFromString(current.(*corev1.ConfigMap).Data[kafka.ConfigPropertyName])
 					if err != nil {
-						return errors.WrapWithDetails(err, "could not parse the current configuration for broker", "brokerId", id)
+						return errors.WrapWithDetails(err, "could not parse the current configuration for broker", v1beta1.BrokerIdLabelKey, id)
 					}
 
 					desiredConfigs, err := properties.NewFromString(desired.(*corev1.ConfigMap).Data[kafka.ConfigPropertyName])
 					if err != nil {
-						return errors.WrapWithDetails(err, "could not parse the current configuration for broker", "brokerId", id)
+						return errors.WrapWithDetails(err, "could not parse the current configuration for broker", v1beta1.BrokerIdLabelKey, id)
 					}
 
 					// Check if there is drift in the configuration and return in case there is none

--- a/pkg/k8sutil/status.go
+++ b/pkg/k8sutil/status.go
@@ -80,7 +80,7 @@ func generateBrokerConfigurationBackups(cluster *banzaicloudv1beta1.KafkaCluster
 		brokerState := cluster.Status.BrokersState[fmt.Sprint(broker.Id)]
 		configurationBackup, err := util.GzipAndBase64BrokerConfiguration(&broker)
 		if err != nil {
-			return false, errors.WrapIfWithDetails(err, "could not generate broker configuration backup", "brokerId", broker.Id)
+			return false, errors.WrapIfWithDetails(err, "could not generate broker configuration backup", banzaicloudv1beta1.BrokerIdLabelKey, broker.Id)
 		}
 		if !needsUpdate && configurationBackup != brokerState.ConfigurationBackup {
 			needsUpdate = true

--- a/pkg/resources/cruisecontrol/configmap.go
+++ b/pkg/resources/cruisecontrol/configmap.go
@@ -159,7 +159,7 @@ func GenerateCapacityConfig(kafkaCluster *v1beta1.KafkaCluster, log logr.Logger,
 			if !ok {
 				continue
 			}
-			brokerId, ok, err := unstructured.NestedString(brokerCapacityMap, "brokerId")
+			brokerId, ok, err := unstructured.NestedString(brokerCapacityMap, v1beta1.BrokerIdLabelKey)
 			if err != nil {
 				return "", errors.WrapIfWithDetails(err,
 					"could retrieve broker Id from broker capacity configuration",
@@ -227,7 +227,7 @@ func appendGeneratedBrokerCapacities(kafkaCluster *v1beta1.KafkaCluster, log log
 				brokerFoundInSpec = true
 				brokerDisks, err := generateBrokerDisks(broker, kafkaCluster.Spec, log)
 				if err != nil {
-					return nil, errors.WrapIfWithDetails(err, "could not generate broker disks config for broker", "brokerID", broker.Id)
+					return nil, errors.WrapIfWithDetails(err, "could not generate broker disks config for broker", v1beta1.BrokerIdLabelKey, broker.Id)
 				}
 				brokerCapacity = BrokerCapacity{
 					BrokerID: strconv.Itoa(int(broker.Id)),
@@ -333,7 +333,7 @@ func generateBrokerDisks(brokerState v1beta1.Broker, kafkaClusterSpec v1beta1.Ka
 	logDirs := make(map[string]string, len(storageConfigs))
 	for path, conf := range storageConfigs {
 		size := parseMountPathWithSize(conf)
-		log.V(1).Info(fmt.Sprintf("broker log.dir %s size in MB: %d", path, size), "brokerId", brokerState.Id)
+		log.V(1).Info(fmt.Sprintf("broker log.dir %s size in MB: %d", path, size), v1beta1.BrokerIdLabelKey, brokerState.Id)
 
 		if size < MinLogDirSizeInMB {
 			return nil, errors.Errorf("broker log.dir %s size is %dMB which is less than the minimum %dMB",

--- a/pkg/resources/cruisecontrol/cruisecontrol.go
+++ b/pkg/resources/cruisecontrol/cruisecontrol.go
@@ -57,8 +57,8 @@ type Reconciler struct {
 
 func ccLabelSelector(kafkaCluster string) map[string]string {
 	return map[string]string{
-		"app":      "cruisecontrol",
-		"kafka_cr": kafkaCluster,
+		v1beta1.AppLabelKey:     "cruisecontrol",
+		v1beta1.KafkaCRLabelKey: kafkaCluster,
 	}
 }
 

--- a/pkg/resources/cruisecontrol/topicManager.go
+++ b/pkg/resources/cruisecontrol/topicManager.go
@@ -53,9 +53,9 @@ func newCruiseControlTopic(cluster *v1beta1.KafkaCluster) *v1alpha1.KafkaTopic {
 		ObjectMeta: templates.ObjectMeta(
 			fmt.Sprintf(cruiseControlTopicFormat, cluster.Name),
 			map[string]string{
-				"app":              "kafka",
-				"clusterName":      cluster.Name,
-				"clusterNamespace": cluster.Namespace,
+				v1beta1.AppLabelKey: "kafka",
+				"clusterName":       cluster.Name,
+				"clusterNamespace":  cluster.Namespace,
 			},
 			cluster,
 		),

--- a/pkg/resources/cruisecontrolmonitoring/cruisecontrol_monitoring.go
+++ b/pkg/resources/cruisecontrolmonitoring/cruisecontrol_monitoring.go
@@ -64,5 +64,5 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 }
 
 func labelsForJmx(name string) map[string]string {
-	return map[string]string{"app": "cruisecontrol-jmx", "kafka_cr": name}
+	return map[string]string{v1beta1.AppLabelKey: "cruisecontrol-jmx", v1beta1.KafkaCRLabelKey: name}
 }

--- a/pkg/resources/envoy/envoy.go
+++ b/pkg/resources/envoy/envoy.go
@@ -30,7 +30,7 @@ import (
 // labelsForEnvoyIngress returns the labels for selecting the resources
 // belonging to the given kafka CR name.
 func labelsForEnvoyIngress(crName, eLName string) map[string]string {
-	return map[string]string{"app": "envoyingress", "eListenerName": eLName, "kafka_cr": crName}
+	return map[string]string{v1beta1.AppLabelKey: "envoyingress", "eListenerName": eLName, v1beta1.KafkaCRLabelKey: crName}
 }
 
 // Reconciler implements the Component Reconciler

--- a/pkg/resources/istioingress/istioingress.go
+++ b/pkg/resources/istioingress/istioingress.go
@@ -44,7 +44,7 @@ const (
 // labelsForIstioIngress returns the labels for selecting the resources
 // belonging to the given kafka CR name.
 func labelsForIstioIngress(crName, eLName, istioRevision string) map[string]string {
-	labels := map[string]string{"app": "istioingress", "eListenerName": eLName, "kafka_cr": crName}
+	labels := map[string]string{v1beta1.AppLabelKey: "istioingress", "eListenerName": eLName, v1beta1.KafkaCRLabelKey: crName}
 	if istioRevision != "" {
 		labels["istio.io/rev"] = istioRevision
 	}

--- a/pkg/resources/kafka/allBrokerService.go
+++ b/pkg/resources/kafka/allBrokerService.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"emperror.dev/errors"
+
 	"github.com/banzaicloud/koperator/api/v1beta1"
 
 	"k8s.io/apimachinery/pkg/labels"

--- a/pkg/resources/kafka/allBrokerService.go
+++ b/pkg/resources/kafka/allBrokerService.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"emperror.dev/errors"
+	"github.com/banzaicloud/koperator/api/v1beta1"
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -91,7 +92,7 @@ func (r *Reconciler) deleteNonHeadlessServices() error {
 	}
 
 	// add "has label 'brokerId' to matching labels selector expression
-	req, err := labels.NewRequirement("brokerId", selection.Exists, nil)
+	req, err := labels.NewRequirement(v1beta1.BrokerIdLabelKey, selection.Exists, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/resources/kafka/configmap.go
+++ b/pkg/resources/kafka/configmap.go
@@ -122,13 +122,13 @@ func (r *Reconciler) getConfigProperties(bConfig *v1beta1.BrokerConfig, id int32
 
 	mountPathsOld, err := getMountPathsFromBrokerConfigMap(&brokerConfigMapOld)
 	if err != nil {
-		log.Error(err, "could not get mounthPaths from broker configmap", "brokerID", id)
+		log.Error(err, "could not get mounthPaths from broker configmap", v1beta1.BrokerIdLabelKey, id)
 	}
 	mountPathsNew := generateStorageConfig(bConfig.StorageConfigs)
 	mountPathsMerged, isMountPathRemoved := mergeMountPaths(mountPathsOld, mountPathsNew)
 
 	if isMountPathRemoved {
-		log.Error(errors.New("removed storage is found in the KafkaCluster CR"), "removing storage from broker is not supported", "brokerID", id, "mountPaths", mountPathsOld, "mountPaths in kafkaCluster CR ", mountPathsNew)
+		log.Error(errors.New("removed storage is found in the KafkaCluster CR"), "removing storage from broker is not supported", v1beta1.BrokerIdLabelKey, id, "mountPaths", mountPathsOld, "mountPaths in kafkaCluster CR ", mountPathsNew)
 	}
 
 	if len(mountPathsMerged) != 0 {
@@ -188,7 +188,7 @@ func (r *Reconciler) configMap(id int32, brokerConfig *v1beta1.BrokerConfig, ext
 			fmt.Sprintf(brokerConfigTemplate+"-%d", r.KafkaCluster.Name, id),
 			apiutil.MergeLabels(
 				apiutil.LabelsForKafka(r.KafkaCluster.Name),
-				map[string]string{"brokerId": fmt.Sprintf("%d", id)},
+				map[string]string{v1beta1.BrokerIdLabelKey: fmt.Sprintf("%d", id)},
 			),
 			r.KafkaCluster,
 		),

--- a/pkg/resources/kafka/kafka_test.go
+++ b/pkg/resources/kafka/kafka_test.go
@@ -320,9 +320,9 @@ func TestReorderBrokers(t *testing.T) {
 			testName: "all broker pods are up an running with no controller broker",
 			brokerPods: corev1.PodList{
 				Items: []corev1.Pod{
-					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"brokerId": "0"}}},
-					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"brokerId": "1"}}},
-					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"brokerId": "2"}}},
+					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{v1beta1.BrokerIdLabelKey: "0"}}},
+					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{v1beta1.BrokerIdLabelKey: "1"}}},
+					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{v1beta1.BrokerIdLabelKey: "2"}}},
 				},
 			},
 			desiredBrokers: []v1beta1.Broker{
@@ -346,9 +346,9 @@ func TestReorderBrokers(t *testing.T) {
 			testName: "all broker pods are up an running with controller broker",
 			brokerPods: corev1.PodList{
 				Items: []corev1.Pod{
-					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"brokerId": "0"}}},
-					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"brokerId": "1"}}},
-					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"brokerId": "2"}}},
+					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{v1beta1.BrokerIdLabelKey: "0"}}},
+					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{v1beta1.BrokerIdLabelKey: "1"}}},
+					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{v1beta1.BrokerIdLabelKey: "2"}}},
 				},
 			},
 			desiredBrokers: []v1beta1.Broker{
@@ -372,9 +372,9 @@ func TestReorderBrokers(t *testing.T) {
 			testName: "some missing broker pods",
 			brokerPods: corev1.PodList{
 				Items: []corev1.Pod{
-					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"brokerId": "0"}}},
-					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"brokerId": "1"}}},
-					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"brokerId": "2"}}},
+					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{v1beta1.BrokerIdLabelKey: "0"}}},
+					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{v1beta1.BrokerIdLabelKey: "1"}}},
+					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{v1beta1.BrokerIdLabelKey: "2"}}},
 				},
 			},
 			desiredBrokers: []v1beta1.Broker{
@@ -407,9 +407,9 @@ func TestReorderBrokers(t *testing.T) {
 			testName: "some missing broker pods and newly added brokers",
 			brokerPods: corev1.PodList{
 				Items: []corev1.Pod{
-					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"brokerId": "0"}}},
-					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"brokerId": "1"}}},
-					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"brokerId": "2"}}},
+					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{v1beta1.BrokerIdLabelKey: "0"}}},
+					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{v1beta1.BrokerIdLabelKey: "1"}}},
+					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{v1beta1.BrokerIdLabelKey: "2"}}},
 				},
 			},
 			desiredBrokers: []v1beta1.Broker{
@@ -444,16 +444,16 @@ func TestReorderBrokers(t *testing.T) {
 			testName: "some missing broker pods, newly added brokers, and missing bokers with pvc and incomplete downscale operation",
 			brokerPods: corev1.PodList{
 				Items: []corev1.Pod{
-					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"brokerId": "0"}}},
-					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"brokerId": "1"}}},
-					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"brokerId": "2"}}},
+					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{v1beta1.BrokerIdLabelKey: "0"}}},
+					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{v1beta1.BrokerIdLabelKey: "1"}}},
+					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{v1beta1.BrokerIdLabelKey: "2"}}},
 				},
 			},
 			brokersPVC: corev1.PersistentVolumeClaimList{
 				TypeMeta: metav1.TypeMeta{},
 				ListMeta: metav1.ListMeta{},
 				Items: []corev1.PersistentVolumeClaim{
-					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"brokerId": "5"}},
+					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{v1beta1.BrokerIdLabelKey: "5"}},
 						Status: corev1.PersistentVolumeClaimStatus{
 							Phase: corev1.ClaimBound,
 						},
@@ -494,9 +494,9 @@ func TestReorderBrokers(t *testing.T) {
 			testName: "some missing broker pods, newly added brokers, and missing bokers without pvc and incomplete downscale operation",
 			brokerPods: corev1.PodList{
 				Items: []corev1.Pod{
-					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"brokerId": "0"}}},
-					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"brokerId": "1"}}},
-					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"brokerId": "2"}}},
+					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{v1beta1.BrokerIdLabelKey: "0"}}},
+					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{v1beta1.BrokerIdLabelKey: "1"}}},
+					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{v1beta1.BrokerIdLabelKey: "2"}}},
 				},
 			},
 			desiredBrokers: []v1beta1.Broker{
@@ -540,12 +540,12 @@ func TestReorderBrokers(t *testing.T) {
 
 			runningBrokers := make(map[string]struct{})
 			for _, b := range test.brokerPods.Items {
-				brokerID := b.GetLabels()["brokerId"]
+				brokerID := b.GetLabels()[v1beta1.BrokerIdLabelKey]
 				runningBrokers[brokerID] = struct{}{}
 			}
 			boundPersistentVolumeClaims := make(map[string]struct{})
 			for _, pvc := range test.brokersPVC.Items {
-				brokerID := pvc.GetLabels()["brokerId"]
+				brokerID := pvc.GetLabels()[v1beta1.BrokerIdLabelKey]
 				if pvc.Status.Phase == corev1.ClaimBound {
 					boundPersistentVolumeClaims[brokerID] = struct{}{}
 				}

--- a/pkg/resources/kafka/pod_test.go
+++ b/pkg/resources/kafka/pod_test.go
@@ -33,7 +33,7 @@ func TestGetAffinity(t *testing.T) {
 			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
 				{
 					LabelSelector: &metav1.LabelSelector{
-						MatchLabels:      map[string]string{"app": "kafka", "kafka_cr": "name"},
+						MatchLabels:      map[string]string{v1beta1.AppLabelKey: "kafka", v1beta1.KafkaCRLabelKey: "name"},
 						MatchExpressions: nil,
 					},
 					Namespaces:  nil,

--- a/pkg/resources/kafka/pvc.go
+++ b/pkg/resources/kafka/pvc.go
@@ -32,7 +32,7 @@ import (
 )
 
 func (r *Reconciler) pvc(brokerId int32, storageIndex int, storage v1beta1.StorageConfig) (*corev1.PersistentVolumeClaim, error) {
-	errCtx := []interface{}{"brokerId", brokerId, "mountPath", storage.MountPath}
+	errCtx := []interface{}{v1beta1.BrokerIdLabelKey, brokerId, "mountPath", storage.MountPath}
 
 	pvcSpecYaml, err := yaml.Marshal(storage.PvcSpec)
 	if err != nil {
@@ -67,7 +67,7 @@ func (r *Reconciler) pvc(brokerId int32, storageIndex int, storage v1beta1.Stora
 			fmt.Sprintf(brokerStorageTemplate, r.KafkaCluster.Name, brokerId, storageIndex),
 			apiutil.MergeLabels(
 				apiutil.LabelsForKafka(r.KafkaCluster.Name),
-				map[string]string{"brokerId": fmt.Sprintf("%d", brokerId)},
+				map[string]string{v1beta1.BrokerIdLabelKey: fmt.Sprintf("%d", brokerId)},
 			),
 			map[string]string{"mountPath": storage.MountPath}, r.KafkaCluster),
 		Spec: pvcSpec,

--- a/pkg/resources/kafka/pvc_test.go
+++ b/pkg/resources/kafka/pvc_test.go
@@ -63,9 +63,9 @@ func TestReconciler_pvc(t *testing.T) {
 					Name:         "",
 					GenerateName: fmt.Sprintf("%s-2-storage-1-", kafkaCluster.GetName()),
 					Labels: map[string]string{
-						"app":      "kafka",
-						"kafka_cr": kafkaCluster.GetName(),
-						"brokerId": "2",
+						v1beta1.AppLabelKey:      "kafka",
+						v1beta1.KafkaCRLabelKey:  kafkaCluster.GetName(),
+						v1beta1.BrokerIdLabelKey: "2",
 					},
 					Annotations: map[string]string{
 						"mountPath": "/kafka-logs-1",
@@ -85,8 +85,8 @@ func TestReconciler_pvc(t *testing.T) {
 				PvcSpec: &corev1.PersistentVolumeClaimSpec{
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"label1":   "value1",
-							"brokerId": "{{ .BrokerId }}",
+							"label1":                 "value1",
+							v1beta1.BrokerIdLabelKey: "{{ .BrokerId }}",
 							// strip '/' from mount path as label selector values
 							// has to start with an alphanumeric character': https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
 							"mountPath": "{{ trimPrefix \"/\" .MountPath }}",
@@ -100,9 +100,9 @@ func TestReconciler_pvc(t *testing.T) {
 					Name:         "",
 					GenerateName: fmt.Sprintf("%s-2-storage-1-", kafkaCluster.GetName()),
 					Labels: map[string]string{
-						"app":      "kafka",
-						"kafka_cr": kafkaCluster.GetName(),
-						"brokerId": "2",
+						v1beta1.AppLabelKey:      "kafka",
+						v1beta1.KafkaCRLabelKey:  kafkaCluster.GetName(),
+						v1beta1.BrokerIdLabelKey: "2",
 					},
 					Annotations: map[string]string{
 						"mountPath": "/kafka-logs-1",
@@ -111,9 +111,9 @@ func TestReconciler_pvc(t *testing.T) {
 				Spec: corev1.PersistentVolumeClaimSpec{
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"label1":    "value1",
-							"brokerId":  "2",
-							"mountPath": "kafka-logs-1",
+							"label1":                 "value1",
+							v1beta1.BrokerIdLabelKey: "2",
+							"mountPath":              "kafka-logs-1",
 						},
 					},
 				},
@@ -126,9 +126,9 @@ func TestReconciler_pvc(t *testing.T) {
 				PvcSpec: &corev1.PersistentVolumeClaimSpec{
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"label1":    "value1",
-							"brokerId":  "{{ .BrokerId }}",
-							"mountPath": "{{ trimPrefix \"/\" .MountPath | sha1sum }}",
+							"label1":                 "value1",
+							v1beta1.BrokerIdLabelKey: "{{ .BrokerId }}",
+							"mountPath":              "{{ trimPrefix \"/\" .MountPath | sha1sum }}",
 						},
 					},
 				},
@@ -139,9 +139,9 @@ func TestReconciler_pvc(t *testing.T) {
 					Name:         "",
 					GenerateName: fmt.Sprintf("%s-2-storage-1-", kafkaCluster.GetName()),
 					Labels: map[string]string{
-						"app":      "kafka",
-						"kafka_cr": kafkaCluster.GetName(),
-						"brokerId": "2",
+						v1beta1.AppLabelKey:      "kafka",
+						v1beta1.KafkaCRLabelKey:  kafkaCluster.GetName(),
+						v1beta1.BrokerIdLabelKey: "2",
 					},
 					Annotations: map[string]string{
 						"mountPath": "/mountpath/that/exceeds63characters/kafka-logs-123456789123456789",
@@ -150,9 +150,9 @@ func TestReconciler_pvc(t *testing.T) {
 				Spec: corev1.PersistentVolumeClaimSpec{
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"label1":    "value1",
-							"brokerId":  "2",
-							"mountPath": "4efe1a6cf77dced13b2906585c33b0e1f615d90e",
+							"label1":                 "value1",
+							v1beta1.BrokerIdLabelKey: "2",
+							"mountPath":              "4efe1a6cf77dced13b2906585c33b0e1f615d90e",
 						},
 					},
 				},
@@ -172,9 +172,9 @@ func TestReconciler_pvc(t *testing.T) {
 					Name:         "",
 					GenerateName: fmt.Sprintf("%s-2-storage-1-", kafkaCluster.GetName()),
 					Labels: map[string]string{
-						"app":      "kafka",
-						"kafka_cr": kafkaCluster.GetName(),
-						"brokerId": "2",
+						v1beta1.AppLabelKey:      "kafka",
+						v1beta1.KafkaCRLabelKey:  kafkaCluster.GetName(),
+						v1beta1.BrokerIdLabelKey: "2",
 					},
 					Annotations: map[string]string{
 						"mountPath": "/kafka-logs-1",

--- a/pkg/resources/kafka/service.go
+++ b/pkg/resources/kafka/service.go
@@ -47,14 +47,14 @@ func (r *Reconciler) service(id int32, _ *v1beta1.BrokerConfig) runtime.Object {
 		ObjectMeta: templates.ObjectMetaWithAnnotations(fmt.Sprintf("%s-%d", r.KafkaCluster.Name, id),
 			apiutil.MergeLabels(
 				apiutil.LabelsForKafka(r.KafkaCluster.Name),
-				map[string]string{"brokerId": fmt.Sprintf("%d", id)},
+				map[string]string{v1beta1.BrokerIdLabelKey: fmt.Sprintf("%d", id)},
 			),
 			r.KafkaCluster.Spec.ListenersConfig.GetServiceAnnotations(),
 			r.KafkaCluster),
 		Spec: corev1.ServiceSpec{
 			Type:            corev1.ServiceTypeClusterIP,
 			SessionAffinity: corev1.ServiceAffinityNone,
-			Selector:        apiutil.MergeLabels(apiutil.LabelsForKafka(r.KafkaCluster.Name), map[string]string{"brokerId": fmt.Sprintf("%d", id)}),
+			Selector:        apiutil.MergeLabels(apiutil.LabelsForKafka(r.KafkaCluster.Name), map[string]string{v1beta1.BrokerIdLabelKey: fmt.Sprintf("%d", id)}),
 			Ports:           usedPorts,
 		},
 	}

--- a/pkg/resources/kafkamonitoring/kafka_monitoring.go
+++ b/pkg/resources/kafkamonitoring/kafka_monitoring.go
@@ -62,5 +62,5 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 }
 
 func labelsForJmx(name string) map[string]string {
-	return map[string]string{"app": "kafka-jmx", "kafka_cr": name}
+	return map[string]string{v1beta1.AppLabelKey: "kafka-jmx", v1beta1.KafkaCRLabelKey: name}
 }

--- a/pkg/resources/nodeportexternalaccess/service.go
+++ b/pkg/resources/nodeportexternalaccess/service.go
@@ -38,11 +38,11 @@ func (r *Reconciler) service(_ logr.Logger, id int32,
 	service := &corev1.Service{
 		ObjectMeta: templates.ObjectMetaWithAnnotations(
 			fmt.Sprintf(kafka.NodePortServiceTemplate, r.KafkaCluster.GetName(), id, extListener.Name),
-			apiutil.MergeLabels(apiutil.LabelsForKafka(r.KafkaCluster.Name), map[string]string{"brokerId": fmt.Sprintf("%d", id)}),
+			apiutil.MergeLabels(apiutil.LabelsForKafka(r.KafkaCluster.Name), map[string]string{v1beta1.BrokerIdLabelKey: fmt.Sprintf("%d", id)}),
 			extListener.GetServiceAnnotations(), r.KafkaCluster),
 		Spec: corev1.ServiceSpec{
 			Selector: apiutil.MergeLabels(apiutil.LabelsForKafka(r.KafkaCluster.Name),
-				map[string]string{"brokerId": fmt.Sprintf("%d", id)}),
+				map[string]string{v1beta1.BrokerIdLabelKey: fmt.Sprintf("%d", id)}),
 			Type: corev1.ServiceTypeNodePort,
 			Ports: []corev1.ServicePort{{
 				Name:       fmt.Sprintf("broker-%d", id),

--- a/pkg/util/pki/common.go
+++ b/pkg/util/pki/common.go
@@ -173,7 +173,7 @@ func clusterDNSNames(cluster *v1beta1.KafkaCluster) []string {
 
 // LabelsForKafkaPKI returns kubernetes labels for a PKI object
 func LabelsForKafkaPKI(name, namespace string) map[string]string {
-	return map[string]string{"app": "kafka", "kafka_issuer": fmt.Sprintf(BrokerClusterIssuerTemplate, namespace, name)}
+	return map[string]string{v1beta1.AppLabelKey: "kafka", "kafka_issuer": fmt.Sprintf(BrokerClusterIssuerTemplate, namespace, name)}
 }
 
 // BrokerUserForCluster returns a KafkaUser CR for the broker certificates in a KafkaCluster

--- a/pkg/util/pki/pki_common_test.go
+++ b/pkg/util/pki/pki_common_test.go
@@ -77,8 +77,8 @@ func TestGetCommonName(t *testing.T) {
 
 func TestLabelsForKafkaPKI(t *testing.T) {
 	expected := map[string]string{
-		"app":          "kafka",
-		"kafka_issuer": fmt.Sprintf(BrokerClusterIssuerTemplate, "kafka", "test"),
+		v1beta1.AppLabelKey: "kafka",
+		"kafka_issuer":      fmt.Sprintf(BrokerClusterIssuerTemplate, "kafka", "test"),
 	}
 	got := LabelsForKafkaPKI("test", "kafka")
 	if !reflect.DeepEqual(got, expected) {


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no|
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR refactors current implementation to replace all the hard-coded koperator reserved label keys (`"app`, `"kafka_cr"`, and `"brokerId"`)with const variables

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Using hard-coded strings for the reserved label keys comes with some drawbacks:
- Kinda bad coding style
- Hard to maintain (especially for people that are not familiar with the existing implementation)
- Increased chances of introducing careless bugs
- May introduce inconsistency between koperator and projects that have koperator as a depenency

Therefore this PR aims to replace the label keys with const variables defined along with the `kafkacluster` resource

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
