### PR TITLE
Koperator can handle intermediate and leaf certificates in generated kafkaUser's TLS certificate

### DIFF
--- a/controllers/kafkauser_controller.go
+++ b/controllers/kafkauser_controller.go
@@ -240,7 +240,7 @@ func (r *KafkaUserReconciler) Reconcile(ctx context.Context, request reconcile.R
 		}
 		kafkaUser, err = user.DN()
 		if err != nil {
-			reqLogger.Error(err, "Could not get Distinguished Name from the generated TLS certificate")
+			reqLogger.Error(err, "could not get Distinguished Name from the generated TLS certificate")
 			return ctrl.Result{
 				Requeue: false,
 			}, err

--- a/controllers/kafkauser_controller.go
+++ b/controllers/kafkauser_controller.go
@@ -238,7 +238,13 @@ func (r *KafkaUserReconciler) Reconcile(ctx context.Context, request reconcile.R
 				return requeueWithError(reqLogger, "failed to reconcile user secret", err)
 			}
 		}
-		kafkaUser = user.DN()
+		kafkaUser, err = user.DN()
+		if err != nil {
+			reqLogger.Error(err, "Could not get Distinguished Name from the generated TLS certificate")
+			return ctrl.Result{
+				Requeue: false,
+			}, err
+		}
 		// check if marked for deletion and remove created certs
 		if k8sutil.IsMarkedForDeletion(instance.ObjectMeta) {
 			reqLogger.Info("Kafka user is marked for deletion, revoking certificates")

--- a/controllers/kafkauser_controller.go
+++ b/controllers/kafkauser_controller.go
@@ -238,9 +238,9 @@ func (r *KafkaUserReconciler) Reconcile(ctx context.Context, request reconcile.R
 				return requeueWithError(reqLogger, "failed to reconcile user secret", err)
 			}
 		}
-		kafkaUser, err = user.DN()
+		kafkaUser, err = user.GetDistinguishedName()
 		if err != nil {
-			reqLogger.Error(err, "could not get Distinguished Name from the generated TLS certificate")
+			reqLogger.Error(err, "could not get Distinguished Name from the generated TLS certificate", "cert", string(user.Certificate))
 			return ctrl.Result{
 				Requeue: false,
 			}, err

--- a/pkg/util/cert/certutil.go
+++ b/pkg/util/cert/certutil.go
@@ -132,9 +132,7 @@ func DecodeCertificate(raw []byte) (cert *x509.Certificate, err error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(certs) != 1 {
-		return nil, errors.New("only one certificate should be present, more found")
-	}
+
 	return certs[0].Certificate, nil
 }
 

--- a/pkg/util/pki/common.go
+++ b/pkg/util/pki/common.go
@@ -94,10 +94,13 @@ type UserCertificate struct {
 }
 
 // DN returns the Distinguished Name of a TLS certificate
-func (u *UserCertificate) DN() string {
+func (u *UserCertificate) DN() (string, error) {
 	// cert has already been validated so we can assume no error
-	cert, _ := certutil.DecodeCertificate(u.Certificate)
-	return cert.Subject.String()
+	cert, err := certutil.DecodeCertificate(u.Certificate)
+	if err != nil {
+		return "", err
+	}
+	return cert.Subject.String(), nil
 }
 
 // GetInternalDNSNames returns all potential DNS names for a kafka cluster - including brokers

--- a/pkg/util/pki/common.go
+++ b/pkg/util/pki/common.go
@@ -93,8 +93,8 @@ type UserCertificate struct {
 	Password    []byte
 }
 
-// DN returns the Distinguished Name of a TLS certificate
-func (u *UserCertificate) DN() (string, error) {
+//  GetDistinguishedName returns the Distinguished Name of a TLS certificate
+func (u *UserCertificate) GetDistinguishedName() (string, error) {
 	// cert has already been validated so we can assume no error
 	cert, err := certutil.DecodeCertificate(u.Certificate)
 	if err != nil {

--- a/pkg/util/pki/pki_common_test.go
+++ b/pkg/util/pki/pki_common_test.go
@@ -42,7 +42,10 @@ func TestDN(t *testing.T) {
 	userCert := &UserCertificate{
 		Certificate: cert,
 	}
-	dn := userCert.DN()
+	dn, err := userCert.DN()
+	if err != nil {
+		t.Errorf("error should be nil, got: %s", err)
+	}
 	if dn != expected {
 		t.Error("Expected:", expected, "got:", dn)
 	}

--- a/pkg/util/pki/pki_common_test.go
+++ b/pkg/util/pki/pki_common_test.go
@@ -42,7 +42,7 @@ func TestDN(t *testing.T) {
 	userCert := &UserCertificate{
 		Certificate: cert,
 	}
-	dn, err := userCert.DN()
+	dn, err := userCert.GetDistinguishedName()
 	if err != nil {
 		t.Errorf("error should be nil, got: %s", err)
 	}


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | fixes #834 |
| License         | Apache 2.0 |


### What's in this PR?
It fixes bug in the kafkaUser reconcile when trying to get Distinguish Name from the generated TLS certificate.

### Why?
When the generated TLS certificate contains intermediate certificates, not only the leaf certificate, the Koperator gets panic because of nil pointer dereference.

### Checklist

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
