### PR TITLE
Add mechnism to create permissive peerauthenticaion for koperator's default alert manager

### DIFF
--- a/charts/kafka-operator/templates/alertmanager-peerauthentication.yaml
+++ b/charts/kafka-operator/templates/alertmanager-peerauthentication.yaml
@@ -1,0 +1,24 @@
+{{- if and (.Values.alertManager.enable) (.Values.alertManager.permissivePeerAuthentication.create) (.Capabilities.APIVersions.Has "security.istio.io/v1beta1") -}}
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: "{{ include "kafka-operator.fullname" . }}-alertmanager-peerauthenticaiton"
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+    app.kubernetes.io/name: {{ include "kafka-operator.name" . }}
+    helm.sh/chart: {{ include "kafka-operator.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/component: alertmanager
+spec:
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+      component: alertmanager
+  portLevelMtls:
+    {{ .Values.alertManager.port | quote }}:
+      mode: PERMISSIVE
+{{- end -}}

--- a/charts/kafka-operator/templates/alertmanager-service.yaml
+++ b/charts/kafka-operator/templates/alertmanager-service.yaml
@@ -25,5 +25,5 @@ spec:
     app.kubernetes.io/component: operator
   ports:
   - name: http-alerts
-    port: 9001
+    port: {{ .Values.alertManager.port }}
 {{- end -}}

--- a/charts/kafka-operator/templates/operator-deployment-with-webhook.yaml
+++ b/charts/kafka-operator/templates/operator-deployment-with-webhook.yaml
@@ -215,7 +215,7 @@ spec:
             - containerPort: {{ (.Values.metricEndpoint).port | default 8080 }}
               name: metrics
               protocol: TCP
-            - containerPort: 9001
+            - containerPort: {{ .Values.alertManager.port }}
               name: alerts
               protocol: TCP
           volumeMounts:

--- a/charts/kafka-operator/values.yaml
+++ b/charts/kafka-operator/values.yaml
@@ -46,6 +46,9 @@ certSigning:
 
 alertManager:
   enable: true
+  port: 9001
+  permissivePeerAuthentication:
+    create: false
 
 prometheusMetrics:
   enabled: true


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no |
| New feature?    | yes |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Add mechnism to create permissive peerauthenticaion for koperator's default alert manager while using the helm chart to install koperator

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
The users might need this to allow plaintext traffic to go into the default alert manager port for certain applications that do no support mTLS or not easy to configure to support mTLS (e.g. prometheus)

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
To deploy koperator along with the default peerauthentication CR to set alert manager's port to be PERMISSIVE:
```
helm install koperator charts/kafka-operator --set alertManager.permissivePeerAuthentication.create=true
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] User guide and development docs updated (if needed)
