### PR TITLE
Add description in helm chart about cert-manager namespace

### DIFF
--- a/charts/kafka-operator/values.yaml
+++ b/charts/kafka-operator/values.yaml
@@ -14,6 +14,15 @@ operator:
     repository: ghcr.io/banzaicloud/kafka-operator
     tag: ""
     pullPolicy: IfNotPresent
+  # In constrained environments where operator cannot
+  # be granted cluster level roles, users can configure
+  # the Koperator to watch CRs only in specific set of
+  # configurable Kubernetes namespaces.
+  # In this scenario, users can replace the default
+  # ClusterRole and ClusterRoleBinding to Role and RoleBinding respectively.
+  # When this field is not empty and Cert-manager is used, 
+  # the Cert-manager's Custom Resource Namespace must be included in the comma separated list.
+  # When it is empty, all namespaces will be watched. 
   namespaces: ""
   verboseLogging: false
   developmentLogging: false
@@ -38,8 +47,10 @@ webhook:
     secret: "kafka-operator-serving-cert"
 
 certManager:
+  enabled: true
+  # namespace field specifies the Cert-manager's Cluster Resource Namespace.
+  # https://cert-manager.io/docs/configuration/
   namespace: "cert-manager"
-  enabled: false
 
 certSigning:
   enabled: true

--- a/charts/kafka-operator/values.yaml
+++ b/charts/kafka-operator/values.yaml
@@ -47,7 +47,7 @@ webhook:
     secret: "kafka-operator-serving-cert"
 
 certManager:
-  enabled: true
+  enabled: false
   # namespace field specifies the Cert-manager's Cluster Resource Namespace.
   # https://cert-manager.io/docs/configuration/
   namespace: "cert-manager"

--- a/controllers/kafkauser_controller.go
+++ b/controllers/kafkauser_controller.go
@@ -55,7 +55,7 @@ import (
 var userFinalizer = "finalizer.kafkausers.kafka.banzaicloud.io"
 
 // SetupKafkaUserWithManager registers KafkaUser controller to the manager
-func SetupKafkaUserWithManager(mgr ctrl.Manager, certSigningEnabled bool, certManagerNamespace bool) *ctrl.Builder {
+func SetupKafkaUserWithManager(mgr ctrl.Manager, certSigningEnabled bool, certManagerEnabled bool) *ctrl.Builder {
 	log := mgr.GetLogger()
 	builder := ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.KafkaUser{}).
@@ -71,7 +71,7 @@ func SetupKafkaUserWithManager(mgr ctrl.Manager, certSigningEnabled bool, certMa
 			handler.EnqueueRequestsFromMapFunc(csrMapper.mapToKafkaUser),
 			ctrlBuilder.WithPredicates(certificateSigningRequestFilter(log)))
 	}
-	if certManagerNamespace {
+	if certManagerEnabled {
 		builder.Owns(&certv1.Certificate{})
 	}
 	return builder


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
Cert-manager related comments are added to the helm chart.
Rename a variable from certManagerNamespace to certManagerEnabled



### Why?
- The cert manager namespace should point to the Cert manager's Cluster Resource Namespace for the proper working of the ClusterIssuer
-  When cert manager is used, Its Cluster Resource Namespace is needed to be watched by Koeprator.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
