### PR TITLE
Fix for checking CRD existance on the cluster when installing CRDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,11 +104,7 @@ run: generate fmt vet manifests
 # Install CRDs into a cluster by manually creating or replacing the CRD depending on whether is currently existing
 # Apply is not applicable as the last-applied-configuration annotation would exceed the size limit enforced by the api server
 install: manifests
-ifeq ($(shell kubectl get -f config/base/crds >/dev/null 2>&1; echo $$?), 1)
-	kubectl create -f config/base/crds
-else
-	kubectl replace -f config/base/crds
-endif
+	kubectl create -f config/base/crds || kubectl replace -f config/base/crds
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: install-kustomize install


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
It fixes the Kubernetes CRD installation through Makefile in case when there are no Koperator CRDs on the cluster

### Why?
When "make install" (or deploy) is used the current check for CRD existence does not work.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Implementation tested
