### PR TITLE
Let KafkaCluster's JKSPasswordName field to be unfilled

### DIFF
--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -463,7 +463,7 @@ func (c IngressServiceSettings) GetServiceType() corev1.ServiceType {
 // SSLSecrets defines the Kafka SSL secrets
 type SSLSecrets struct {
 	TLSSecretName   string                  `json:"tlsSecretName"`
-	JKSPasswordName string                  `json:"jksPasswordName"`
+	JKSPasswordName string                  `json:"jksPasswordName,omitempty"`
 	Create          bool                    `json:"create,omitempty"`
 	IssuerRef       *cmmeta.ObjectReference `json:"issuerRef,omitempty"`
 	// +kubebuilder:validation:Enum={"cert-manager"}

--- a/charts/kafka-operator/templates/crds.yaml
+++ b/charts/kafka-operator/templates/crds.yaml
@@ -19744,7 +19744,6 @@ spec:
                       tlsSecretName:
                         type: string
                     required:
-                    - jksPasswordName
                     - tlsSecretName
                     type: object
                 required:

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -19581,7 +19581,6 @@ spec:
                       tlsSecretName:
                         type: string
                     required:
-                    - jksPasswordName
                     - tlsSecretName
                     type: object
                 required:


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
In the KafkaCluster CR the JKSPasswordName can be empty


### Why?
JKSPasswordName is unused in the codebase

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested