### PR TITLE
Add missing rbac rules for the newly created controllers

### DIFF
--- a/charts/kafka-operator/templates/operator-rbac.yaml
+++ b/charts/kafka-operator/templates/operator-rbac.yaml
@@ -240,6 +240,33 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - kafka.banzaicloud.io
+  resources:
+  - cruisecontroloperations
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kafka.banzaicloud.io
+  resources:
+  - cruisecontroloperations/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - kafka.banzaicloud.io
+  resources:
+  - cruisecontroloperations/status
+  verbs:
+  - get
+  - patch
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Add the missing RBAC to the koperator helm chart for the newly created controller for cruise control operations

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
The operator doesn't function as expected due to the missing RBAC when a user installs the operator via helm chart, for example:
```
W1012 19:19:04.011198       1 reflector.go:424] pkg/mod/k8s.io/client-go@v0.25.0/tools/cache/reflector.go:169: failed to list *v1alpha1.CruiseControlOperation: cruisecontroloperations.kafka.banzaicloud.io is forbidden: User "system:serviceaccount:kafka:kafka-operator" cannot list resource "cruisecontroloperations" in API group "kafka.banzaicloud.io" at the cluster scope
E1012 19:19:04.011232       1 reflector.go:140] pkg/mod/k8s.io/client-go@v0.25.0/tools/cache/reflector.go:169: Failed to watch *v1alpha1.CruiseControlOperation: failed to list *v1alpha1.CruiseControlOperation: cruisecontroloperations.kafka.banzaicloud.io is forbidden: User "system:serviceaccount:kafka:kafka-operator" cannot list resource "cruisecontroloperations" in API group "kafka.banzaicloud.io" at the cluster scope
W1012 19:19:06.996660       1 reflector.go:424] pkg/mod/k8s.io/client-go@v0.25.0/tools/cache/reflector.go:169: failed to list *v1alpha1.CruiseControlOperation: cruisecontroloperations.kafka.banzaicloud.io is forbidden: User "system:serviceaccount:kafka:kafka-operator" cannot list resource "cruisecontroloperations" in API group "kafka.banzaicloud.io" at the cluster scope
E1012 19:19:06.996689       1 reflector.go:140] pkg/mod/k8s.io/client-go@v0.25.0/tools/cache/reflector.go:169: Failed to watch *v1alpha1.CruiseControlOperation: failed to list *v1alpha1.CruiseControlOperation: cruisecontroloperations.kafka.banzaicloud.io is forbidden: User "system:serviceaccount:kafka:kafka-operator" cannot list resource "cruisecontroloperations" in API group "kafka.banzaicloud.io" at the cluster scope
W1012 19:19:12.772834       1 reflector.go:424] pkg/mod/k8s.io/client-go@v0.25.0/tools/cache/reflector.go:169: failed to list *v1alpha1.CruiseControlOperation: cruisecontroloperations.kafka.banzaicloud.io is forbidden: User "system:serviceaccount:kafka:kafka-operator" cannot list resource "cruisecontroloperations" in API group "kafka.banzaicloud.io" at the cluster scope
E1012 19:19:12.772862       1 reflector.go:140] pkg/mod/k8s.io/client-go@v0.25.0/tools/cache/reflector.go:169: Failed to watch *v1alpha1.CruiseControlOperation: failed to list *v1alpha1.CruiseControlOperation: cruisecontroloperations.kafka.banzaicloud.io is forbidden: User "system:serviceaccount:kafka:kafka-operator" cannot list resource "cruisecontroloperations" in API group "kafka.banzaicloud.io" at the cluster scope
W1012 19:19:25.467924       1 reflector.go:424] pkg/mod/k8s.io/client-go@v0.25.0/tools/cache/reflector.go:169: failed to list *v1alpha1.CruiseControlOperation: cruisecontroloperations.kafka.banzaicloud.io is forbidden: User "system:serviceaccount:kafka:kafka-operator" cannot list resource "cruisecontroloperations" in API group "kafka.banzaicloud.io" at the cluster scope
E1012 19:19:25.467952       1 reflector.go:140] pkg/mod/k8s.io/client-go@v0.25.0/tools/cache/reflector.go:169: Failed to watch *v1alpha1.CruiseControlOperation: failed to list *v1alpha1.CruiseControlOperation: cruisecontroloperations.kafka.banzaicloud.io is forbidden: User "system:serviceaccount:kafka:kafka-operator" cannot list resource "cruisecontroloperations" in API group "kafka.banzaicloud.io" at the cluster scope
W1012 19:19:48.829219       1 reflector.go:424] pkg/mod/k8s.io/client-go@v0.25.0/tools/cache/reflector.go:169: failed to list *v1alpha1.CruiseControlOperation: cruisecontroloperations.kafka.banzaicloud.io is forbidden: User "system:serviceaccount:kafka:kafka-operator" cannot list resource "cruisecontroloperations" in API group "kafka.banzaicloud.io" at the cluster scope
E1012 19:19:48.829247       1 reflector.go:140] pkg/mod/k8s.io/client-go@v0.25.0/tools/cache/reflector.go:169: Failed to watch *v1alpha1.CruiseControlOperation: failed to list *v1alpha1.CruiseControlOperation: cruisecontroloperations.kafka.banzaicloud.io is forbidden: User "system:serviceaccount:kafka:kafka-operator" cannot list resource "cruisecontroloperations" in API group "kafka.banzaicloud.io" at the cluster scope
```
And the manager container would end up crashing

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
The missing RBAC rules are copied from https://github.com/banzaicloud/koperator/blob/master/config/base/rbac/role.yaml, which got updated in PR #872 with the necessary access rights when the cruise control operation controllers were added

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
