### PR TITLE
Add more memory to CC pod

### DIFF
--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -915,11 +915,11 @@ func (cConfig *CruiseControlConfig) GetResources() *corev1.ResourceRequirements 
 	return &corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
 			"cpu":    resource.MustParse("200m"),
-			"memory": resource.MustParse("512Mi"),
+			"memory": resource.MustParse("768Mi"),
 		},
 		Requests: corev1.ResourceList{
 			"cpu":    resource.MustParse("200m"),
-			"memory": resource.MustParse("512Mi"),
+			"memory": resource.MustParse("768Mi"),
 		},
 	}
 }

--- a/controllers/tests/kafkacluster_controller_cruisecontrol_test.go
+++ b/controllers/tests/kafkacluster_controller_cruisecontrol_test.go
@@ -278,11 +278,11 @@ func expectCruiseControlDeployment(kafkaCluster *v1beta1.KafkaCluster) {
 	Expect(container.Resources).To(Equal(corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
 			"cpu":    resource.MustParse("200m"),
-			"memory": resource.MustParse("512Mi"),
+			"memory": resource.MustParse("768Mi"),
 		},
 		Requests: corev1.ResourceList{
 			"cpu":    resource.MustParse("200m"),
-			"memory": resource.MustParse("512Mi"),
+			"memory": resource.MustParse("768Mi"),
 		},
 	}))
 	Expect(container.ReadinessProbe).NotTo(BeNil())


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
Increase CC pod memory request and limit to 768MB


### Why?
CC pod uses around 512 memory and sometimes it gets OOMKilled.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
