### PR TITLE
Add check to ensure all kafka brokers are available before updating K…

### DIFF
--- a/charts/kafka-operator/Chart.yaml
+++ b/charts/kafka-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kafka-operator
-version: 0.22.0-dev.6
+version: 0.22.0-dev.7
 description: kafka-operator manages Kafka deployments on Kubernetes
 sources:
   - https://github.com/banzaicloud/koperator
-appVersion: v0.22.0-dev.6
+appVersion: v0.22.0-dev.7

--- a/charts/kafka-operator/README.md
+++ b/charts/kafka-operator/README.md
@@ -53,7 +53,7 @@ The following table lists the configurable parameters of the Banzaicloud Kafka O
 Parameter | Description | Default
 --------- | ----------- | -------
 `operator.image.repository` | Operator container image repository | `ghcr.io/banzaicloud/kafka-operator`
-`operator.image.tag` | Operator container image tag | `v0.22.0-dev.6`
+`operator.image.tag` | Operator container image tag | `v0.22.0-dev.7`
 `operator.image.pullPolicy` | Operator container image pull policy | `IfNotPresent`
 `operator.serviceAccount.name` | ServiceAccount used by the operator pod | `kafka-operator`
 `operator.serviceAccount.create` | If true, create the `operator.serviceAccount.name` service account | `true`


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Before updating the KafkaCluster CR status to be `v1beta1.KafkaClusterRunning`, use Kafka client to check if all the brokers are available

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
While doing steps the following in script / code:
1. Apply KafkaCluster CR with 2 brokers
2. Wait for KafkaCluster CR status to be `v1beta1.KafkaClusterRunning`
3. Apply a test KafkaTopic with `replicationFactor` of 2

Occasionally the webhook would reject the KafkaTopic creation with the following error:
```
failed to create resource: creating resource failed: admission webhook "kafkatopics.kafka.banzaicloud.io" denied the request: KafkaTopic.kafka.banzaicloud.io "test-topic" is invalid: spec.replicationFactor: Invalid value: 2: replication factor is larger than the number of nodes in the kafka cluster (available brokers: 1)
```

So it looks like the Reconcile logic for KafkaCluster doesn't really make sure all the brokers are available to the Kafka client before updating the KafkaCluster CR status to be `v1beta1.KafkaClusterRunning`

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
Using KafkaClient to ensure all the brokers are available before updating the KafkaCluster CR status would allow users to use the `v1beta1.KafkaClusterRunning` to check if all the brokers within the Kafka cluster are running fine, which indicates the Kafka cluster is indeed in `ClusterRunning` state


I've tested the changes with a script that does the following steps for 100 times:
1. Create a sample KafkaCluster CR with 2 brokers
2. Wait until KafkaCluster CR status becomes `ClusterRunning`
3. Create a sample KafkaTopic with `replicationFactor` of 2
4. Uninstall both the KafkaTopic and KafkaCluster
5. Repeat

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
