### PR TITLE
Fix KafkaCluster's status update at CruiseControlTask controller

### DIFF
--- a/controllers/cruisecontroltask_controller.go
+++ b/controllers/cruisecontroltask_controller.go
@@ -105,7 +105,7 @@ func (r *CruiseControlTaskReconciler) Reconcile(ctx context.Context, request ctr
 	updateActiveTasks(tasksAndStates, ccOperations)
 
 	if err = r.UpdateStatus(ctx, instance, tasksAndStates); err != nil {
-		requeueWithError(log, "failed to update Kafka Cluster status", err)
+		return requeueWithError(log, "failed to update Kafka Cluster status", err)
 	}
 
 	scaler, err := r.ScaleFactory(ctx, instance)
@@ -210,7 +210,7 @@ func (r *CruiseControlTaskReconciler) Reconcile(ctx context.Context, request ctr
 	}
 
 	if err = r.UpdateStatus(ctx, instance, tasksAndStates); err != nil {
-		requeueWithError(log, "failed to update Kafka Cluster status", err)
+		return requeueWithError(log, "failed to update Kafka Cluster status", err)
 	}
 
 	return reconciled()


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
KafkaCluster status update happens only when it is necessary.
KafkaCluster status update happens more frequently to avoid an edge case at the CruiseControlTask controller when the code execution exits sooner then the status update


### Why?
KafkaCluster status update happened always because a wrong check.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)