### PR TITLE
Configurable webhook target port

### DIFF
--- a/charts/kafka-operator/templates/operator-service.yaml
+++ b/charts/kafka-operator/templates/operator-service.yaml
@@ -28,8 +28,9 @@ spec:
   ports:
   - name: https
     port: 443
-    targetPort: {{ default 443 .Values.webhook.serverPort }}
+    targetPort: {{ (.Values.webhook).serverPort | default 443 }}
   {{- if and .Values.prometheusMetrics.enabled (not .Values.prometheusMetrics.authProxy.enabled) }}
   - name: metrics
     port: 8080
+    targetPort: {{ (.Values.metricEndpoint).port | default 8080 }}
   {{- end }}

--- a/charts/kafka-operator/templates/operator-service.yaml
+++ b/charts/kafka-operator/templates/operator-service.yaml
@@ -28,6 +28,7 @@ spec:
   ports:
   - name: https
     port: 443
+    targetPort: {{ default 443 .Values.webhook.serverPort }}
   {{- if and .Values.prometheusMetrics.enabled (not .Values.prometheusMetrics.authProxy.enabled) }}
   - name: metrics
     port: 8080


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | #895 |
| License         | Apache 2.0 |


### What's in this PR?
Set the configured webhook port from the values.yaml explicitly on the operator's service.

### Why?
When the user wants to use custom webhook port and change the KafkaCluster resource the ValidatingWebhookConfiguration call fails.

### Checklist
- [x] Implementation tested
