### PR TITLE
Use node IP in advertised.listeners

### DIFF
--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -191,6 +191,13 @@ type BrokerConfig struct {
 	// type service to expose the broker outside the Kubernetes cluster. Also, when "hostnameOverride" field of the external listener is set
 	// it will override the broker's external listener advertise address according to the description of the "hostnameOverride" field.
 	NodePortExternalIP map[string]string `json:"nodePortExternalIP,omitempty"`
+	// When "hostNameOverride" and brokerConfig.nodePortExternalIP are empty and NodePort access method is selected
+	// the NodePortNodeAdddressType defines the external listener Address that shall be used in the advertised.listeners property.
+	// https://kubernetes.io/docs/concepts/architecture/nodes/#addresses
+	// If NodePortNodeAddressType is not provided the first non empty address is used in the following order:
+	// 1. ExternalIP
+	// 2. InternalIP
+	NodePortNodeAddressType corev1.NodeAddressType `json:"nodePortNodeAddressType,omitempty"`
 	// Any definition received through this field will override the default behaviour of OneBrokerPerNode flag
 	// and the operator supposes that the user is aware of how scheduling is done by kubernetes
 	// Affinity could be set through brokerConfigGroups definitions and can be set for individual brokers as well

--- a/charts/kafka-operator/templates/crds.yaml
+++ b/charts/kafka-operator/templates/crds.yaml
@@ -3907,6 +3907,14 @@ spec:
                         external listener advertise address according to the description
                         of the "hostnameOverride" field.
                       type: object
+                    nodePortNodeAddressType:
+                      description: 'When "hostNameOverride" and brokerConfig.nodePortExternalIP
+                        are empty and NodePort access method is selected the NodePortNodeAdddressType
+                        defines the external listener Address that shall be used in
+                        the advertised.listeners property. https://kubernetes.io/docs/concepts/architecture/nodes/#addresses
+                        If NodePortNodeAddressType is not provided the first non empty
+                        address is used in the following order: 1. ExternalIP 2. InternalIP'
+                      type: string
                     nodeSelector:
                       additionalProperties:
                         type: string
@@ -10034,6 +10042,15 @@ spec:
                             the broker's external listener advertise address according
                             to the description of the "hostnameOverride" field.
                           type: object
+                        nodePortNodeAddressType:
+                          description: 'When "hostNameOverride" and brokerConfig.nodePortExternalIP
+                            are empty and NodePort access method is selected the NodePortNodeAdddressType
+                            defines the external listener Address that shall be used
+                            in the advertised.listeners property. https://kubernetes.io/docs/concepts/architecture/nodes/#addresses
+                            If NodePortNodeAddressType is not provided the first non
+                            empty address is used in the following order: 1. ExternalIP
+                            2. InternalIP'
+                          type: string
                         nodeSelector:
                           additionalProperties:
                             type: string

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -3744,6 +3744,14 @@ spec:
                         external listener advertise address according to the description
                         of the "hostnameOverride" field.
                       type: object
+                    nodePortNodeAddressType:
+                      description: 'When "hostNameOverride" and brokerConfig.nodePortExternalIP
+                        are empty and NodePort access method is selected the NodePortNodeAdddressType
+                        defines the external listener Address that shall be used in
+                        the advertised.listeners property. https://kubernetes.io/docs/concepts/architecture/nodes/#addresses
+                        If NodePortNodeAddressType is not provided the first non empty
+                        address is used in the following order: 1. ExternalIP 2. InternalIP'
+                      type: string
                     nodeSelector:
                       additionalProperties:
                         type: string
@@ -9871,6 +9879,15 @@ spec:
                             the broker's external listener advertise address according
                             to the description of the "hostnameOverride" field.
                           type: object
+                        nodePortNodeAddressType:
+                          description: 'When "hostNameOverride" and brokerConfig.nodePortExternalIP
+                            are empty and NodePort access method is selected the NodePortNodeAdddressType
+                            defines the external listener Address that shall be used
+                            in the advertised.listeners property. https://kubernetes.io/docs/concepts/architecture/nodes/#addresses
+                            If NodePortNodeAddressType is not provided the first non
+                            empty address is used in the following order: 1. ExternalIP
+                            2. InternalIP'
+                          type: string
                         nodeSelector:
                           additionalProperties:
                             type: string

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -1162,7 +1162,14 @@ func (r *Reconciler) createExternalListenerStatuses(log logr.Logger) (map[string
 						portNumber = eListener.ContainerPort
 					}
 					if brokerHost == "" {
-						brokerHost = bConfig.NodePortExternalIP[eListener.Name]
+						if bConfig.NodePortExternalIP[eListener.Name] == "" {
+							brokerHost, err = r.getK8sAssignedNode(log, broker.Id, string(bConfig.NodePortNodeAddressType))
+							if err != nil {
+								log.Error(err, "Could not get the address of broker's node.")
+							}
+						} else {
+							brokerHost = bConfig.NodePortExternalIP[eListener.Name]
+						}
 					} else {
 						brokerHost = fmt.Sprintf("%s-%d-%s.%s%s", r.KafkaCluster.Name, broker.Id, eListener.Name, r.KafkaCluster.Namespace, brokerHost)
 					}
@@ -1216,6 +1223,48 @@ func (r *Reconciler) getK8sAssignedNodeport(log logr.Logger, eListenerName strin
 			errors.New("nodeport port number is not allocated"), "nodeport number is still 0")
 	}
 	return nodePort, nil
+}
+
+func (r *Reconciler) getK8sAssignedNode(log logr.Logger, brokerId int32, nodeAddressType string) (string, error) {
+	podList := &corev1.PodList{}
+	err := r.Client.List(context.TODO(), podList,
+		client.InNamespace(r.KafkaCluster.Namespace),
+		client.MatchingLabels(apiutil.LabelsForKafka(r.KafkaCluster.Name)),
+	)
+	if err != nil {
+		return "", err
+	}
+	for _, pod := range podList.Items {
+		id, ok := pod.Labels[v1beta1.BrokerIdLabelKey]
+		if !ok {
+			continue
+		}
+		if id == strconv.Itoa(int(brokerId)) {
+			return r.getK8sNodeIp(log, pod.Spec.NodeName, nodeAddressType)
+		}
+	}
+	return "", errors.New("Could not find matching brokerId")
+}
+
+func (r *Reconciler) getK8sNodeIp(log logr.Logger, nodeName string, nodeAddressType string) (string, error) {
+	node := &corev1.Node{}
+	clientNamespacedName := types.NamespacedName{Name: nodeName, Namespace: r.KafkaCluster.Namespace}
+	if err := r.Client.Get(context.TODO(), clientNamespacedName, node); err != nil {
+		return "", err
+	}
+	addressMap := make(map[string]string)
+	for _, address := range node.Status.Addresses {
+		addressMap[string(address.Type)] = address.Address
+	}
+	if val, ok := addressMap[nodeAddressType]; ok && val != "" {
+		return val, nil
+	} else if val, ok := addressMap[string(corev1.NodeExternalIP)]; ok && val != "" {
+		return val, nil
+	} else if val, ok := addressMap[string(corev1.NodeInternalIP)]; ok && val != "" {
+		return val, nil
+	}
+	log.Info("Could not detect IP address of node", "node", nodeName)
+	return "", errors.New("Could not detect IP address of node.")
 }
 
 // determineControllerId returns the ID of the controller broker of the current cluster


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no|
| New feature?    | yes |
| API breaks?     | no|
| Deprecations?   | no|
| Related tickets | fixes #900  |
| License         | Apache 2.0 |


### What's in this PR?
Use node IP in advertised.listeners when hostnameOverride and nodePortExternalIP are not set


### Additional context
When "hostNameOverride" and brokerConfig.nodePortExternalIP are empty and NodePort access method is selected the NodePortNodeAdddressType defines the external listener Address that shall be used in the advertised.listeners property. 
If NodePortNodeAddressType is not provided the first non empty address is used in the following order:
1. ExternalIP
2. InternalIP

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ x] Implementation tested
- [x ] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x ] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)

