### PR TITLE
Added imagePullSecrets to deployment template

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,11 @@
-name: CI test
+name: Release
 
 on:
   push:
     tags:
       - 'v?[0-9]+.[0-9]+.[0-9]+'
       - "v?[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
-      - "v?[0-9]+.[0-9]+.[0-9]+-dev.[0-9]+"
+      #- "v?[0-9]+.[0-9]+.[0-9]+-dev.[0-9]+" Disabled for now for dev tags
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/charts/kafka-operator/Chart.yaml
+++ b/charts/kafka-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kafka-operator
-version: 0.22.0
+version: 0.23.0-dev.0
 description: kafka-operator manages Kafka deployments on Kubernetes
 sources:
   - https://github.com/banzaicloud/koperator
-appVersion: v0.22.0
+appVersion: v0.23.0-dev.0

--- a/charts/kafka-operator/templates/operator-deployment-with-webhook.yaml
+++ b/charts/kafka-operator/templates/operator-deployment-with-webhook.yaml
@@ -135,6 +135,10 @@ spec:
         app: prometheus
         component: alertmanager
     spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       serviceAccountName: {{ include "operator.serviceAccountName" .}}
       volumes:
       {{- if .Values.webhook.enabled }}

--- a/charts/kafka-operator/templates/operator-rbac.yaml
+++ b/charts/kafka-operator/templates/operator-rbac.yaml
@@ -1,12 +1,6 @@
 {{- if .Values.operator.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
-{{- if .Values.imagePullSecrets }}
-imagePullSecrets:
-{{- range .Values.imagePullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- end }}
 metadata:
   name: {{ include "operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace | quote }}


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
I added imagePullSecrets to the deployment template and updated the chart version. Also updated release.yml to not include dev tags for now in releases.

### Why?
Not sure when there would be a need for this as the images are publicly accessible but just in case it doesn't hurt if it's there.

### Checklist
- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
