### PR TITLE
Added Koperator performance test load container image building from the default branch

### DIFF
--- a/.github/workflows/docker_perf_test_load.yml
+++ b/.github/workflows/docker_perf_test_load.yml
@@ -1,0 +1,64 @@
+name: Docker / Performance test load
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "koperator-performance-test-load/v?[0-9]+.[0-9]+.[0-9]+"
+env:
+  PLATFORMS: linux/amd64
+jobs:
+  docker:
+    name: Docker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.ref }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Determine tag or commit
+        uses: haya14busa/action-cond@v1
+        id: refortag
+        with:
+          cond: ${{ startsWith(github.ref, 'refs/tags/') }}
+          if_true: ${{ github.ref }}
+          if_false: latest
+
+      - name: Determine image tag
+        id: imagetag
+        run: echo "value=${TAG_OR_BRANCH##*/}" >> $GITHUB_OUTPUT
+        env:
+          TAG_OR_BRANCH: ${{ steps.refortag.outputs.value }}
+
+      - name: Setup Docker metadata
+        id: setup-docker-metadata
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/banzaicloud/koperator-performance-test-load
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Build koperator-performance-test-load
+        uses: docker/build-push-action@v3
+        with:
+          tags: ghcr.io/banzaicloud/koperator-performance-test-load:${{ steps.imagetag.outputs.value }}
+          file: docs/benchmarks/loadgens/Dockerfile
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache

--- a/docs/benchmarks/loadgens/Dockerfile
+++ b/docs/benchmarks/loadgens/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.12
+ARG GO_VERSION=1.19
 
 FROM golang:${GO_VERSION}-alpine AS builder
 

--- a/docs/benchmarks/loadgens/Dockerfile
+++ b/docs/benchmarks/loadgens/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /build
 
 RUN git clone https://github.com/jamiealquiza/sangrenel.git
 
-WORKDIR sangrenel
+WORKDIR /build/sangrenel
 
 RUN go mod download && go build -o /sangrenel
 

--- a/docs/benchmarks/loadgens/Dockerfile
+++ b/docs/benchmarks/loadgens/Dockerfile
@@ -4,7 +4,7 @@ FROM golang:${GO_VERSION}-alpine AS builder
 
 ENV GOFLAGS="-mod=readonly"
 
-RUN apk add --update --no-cache ca-certificates make git curl mercurial bzr
+RUN apk add --update --no-cache ca-certificates make git curl mercurial
 
 RUN mkdir -p /build
 WORKDIR /build


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | - |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Added a GHA workflow for building Koperator performance test load container image from master builds and related tag builds - if we would use them in the future.
The package is available [here](https://github.com/banzaicloud/koperator/pkgs/container/koperator-performance-test-load).

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

To be able to reference the built image publicly, the source Dockerfile is available in this repository.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Haven't tested the image itself, only the build process.

Also the package enablement needed organization level access to packages before the repo would have been connected to the new package. I'm now administrator of the new package, but I'm still not an organization admin.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- ~Implementation tested~
- ~Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)~
- ~Logging code meets the guideline~
- ~User guide and development docs updated (if needed)~
