### PR TITLE
Allow creating KafkaTopic CR for topic that already present on the Kafka cluster

### DIFF
--- a/pkg/webhooks/kafkatopic_validator_test.go
+++ b/pkg/webhooks/kafkatopic_validator_test.go
@@ -75,7 +75,7 @@ func newMockClients(cluster *v1beta1.KafkaCluster) (runtimeClient.WithWatch, kaf
 func TestValidateTopic(t *testing.T) {
 	topic := newMockTopic()
 	cluster := newMockCluster()
-	client, kafkaClient, returnMockedKafkaClient := newMockClients(cluster)
+	client, _, returnMockedKafkaClient := newMockClients(cluster)
 
 	kafkaTopicValidator := KafkaTopicValidator{
 		Client:              client,
@@ -167,22 +167,6 @@ func TestValidateTopic(t *testing.T) {
 	}
 
 	topic.Spec.ReplicationFactor = 1
-
-	// Test overwrite attempt
-	err = kafkaClient.CreateTopic(&kafkaclient.CreateTopicOptions{Name: "test-topic", ReplicationFactor: 1, Partitions: 2})
-	if err != nil {
-		t.Error("creation of topic should have been successful")
-	}
-	topic.Name = "test-topic"
-	fieldErrorList, err = kafkaTopicValidator.validateKafkaTopic(context.Background(), topic, logr.Discard())
-	if err != nil {
-		t.Errorf("err should be nil, got: %s", err)
-	}
-	if len(fieldErrorList) != 1 {
-		t.Error("Expected not allowed due to existing topic with same name, got allowed")
-	} else if !strings.Contains(fieldErrorList.ToAggregate().Error(), "topic already exists on kafka cluster") {
-		t.Error("Expected not allowed for reason: already exists")
-	}
 
 	// Add topic and test existing topic reason
 	if err := kafkaTopicValidator.Client.Create(context.TODO(), topic); err != nil {


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no |
| New feature?    | yes |
| API breaks?     | no  |
| Deprecations?   | no  |
| License         | Apache 2.0 |


### What's in this PR?
It allows to create a KafkaTopic CR when the referenced topic is already present on the Kafka cluster.


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Let the user create KafkaTopic resources for that topic which is already on the Kafka cluster 
Users can modify the topic configuration and partition number for that topic through the created KafkaTopic CR


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
