### PR TITLE
Augment error behaviour

### DIFF
--- a/controllers/controller_common.go
+++ b/controllers/controller_common.go
@@ -81,18 +81,18 @@ func clusterLabelString(cluster *v1beta1.KafkaCluster) string {
 // checkBrokerConnectionError is a convenience wrapper for returning from common
 // broker connection errors
 func checkBrokerConnectionError(logger logr.Logger, err error) (ctrl.Result, error) {
-	switch errors.Cause(err).(type) {
-	case errorfactory.BrokersUnreachable:
+	switch {
+	case errors.As(err, &errorfactory.BrokersUnreachable{}):
 		return ctrl.Result{
 			Requeue:      true,
 			RequeueAfter: time.Duration(15) * time.Second,
 		}, nil
-	case errorfactory.BrokersNotReady:
+	case errors.As(err, &errorfactory.BrokersNotReady{}):
 		return ctrl.Result{
 			Requeue:      true,
 			RequeueAfter: time.Duration(15) * time.Second,
 		}, nil
-	case errorfactory.ResourceNotReady:
+	case errors.As(err, &errorfactory.ResourceNotReady{}):
 		logger.Info("Needed resource for broker connection not found, may not be ready")
 		return ctrl.Result{
 			Requeue:      true,

--- a/controllers/kafkauser_controller.go
+++ b/controllers/kafkauser_controller.go
@@ -211,14 +211,14 @@ func (r *KafkaUserReconciler) Reconcile(ctx context.Context, request reconcile.R
 
 		user, err := pkiManager.ReconcileUserCertificate(ctx, instance, r.Scheme, cluster.Spec.GetKubernetesClusterDomain())
 		if err != nil {
-			switch errors.Cause(err).(type) {
-			case errorfactory.ResourceNotReady:
+			switch {
+			case errors.As(err, &errorfactory.ResourceNotReady{}):
 				reqLogger.Info("generated secret not found, may not be ready")
 				return ctrl.Result{
 					Requeue:      true,
 					RequeueAfter: time.Duration(5) * time.Second,
 				}, nil
-			case errorfactory.FatalReconcileError:
+			case errors.As(err, &errorfactory.FatalReconcileError{}):
 				// TODO: (tinyzimmer) - Sleep for longer for now to give user time to see the error
 				// But really we should catch these kinds of issues in a pre-admission hook in a future PR
 				// The user can fix while this is looping and it will pick it up next reconcile attempt

--- a/pkg/errorfactory/errorfactory.go
+++ b/pkg/errorfactory/errorfactory.go
@@ -19,6 +19,7 @@ import "emperror.dev/errors"
 // ResourceNotReady states that resource is not ready
 type ResourceNotReady struct{ error }
 
+// Unwrap() allows compliance with Go1.13+ error chaining behavior
 func (e ResourceNotReady) Unwrap() error { return e.error }
 
 // APIFailure states that something went wrong with the api

--- a/pkg/errorfactory/errorfactory.go
+++ b/pkg/errorfactory/errorfactory.go
@@ -19,59 +19,97 @@ import "emperror.dev/errors"
 // ResourceNotReady states that resource is not ready
 type ResourceNotReady struct{ error }
 
+func (e ResourceNotReady) Unwrap() error { return e.error }
+
 // APIFailure states that something went wrong with the api
 type APIFailure struct{ error }
+
+func (e APIFailure) Unwrap() error { return e.error }
 
 // StatusUpdateError states that the operator failed to update the Status
 type StatusUpdateError struct{ error }
 
+func (e StatusUpdateError) Unwrap() error { return e.error }
+
 // BrokersUnreachable states that the given broker is unreachable
 type BrokersUnreachable struct{ error }
+
+func (e BrokersUnreachable) Unwrap() error { return e.error }
 
 // BrokersNotReady states that the broker is not ready
 type BrokersNotReady struct{ error }
 
+func (e BrokersNotReady) Unwrap() error { return e.error }
+
 // BrokersRequestError states that the broker could not understand the request
 type BrokersRequestError struct{ error }
+
+func (e BrokersRequestError) Unwrap() error { return e.error }
 
 // CreateTopicError states that the operator could not create the topic
 type CreateTopicError struct{ error }
 
+func (e CreateTopicError) Unwrap() error { return e.error }
+
 // TopicNotFound states that the given topic is not found
 type TopicNotFound struct{ error }
+
+func (e TopicNotFound) Unwrap() error { return e.error }
 
 // GracefulUpscaleFailed states that the operator failed to update the cluster gracefully
 type GracefulUpscaleFailed struct{ error }
 
+func (e GracefulUpscaleFailed) Unwrap() error { return e.error }
+
 // TooManyResources states that too many resource found
 type TooManyResources struct{ error }
+
+func (e TooManyResources) Unwrap() error { return e.error }
 
 // InternalError states that internal error happened
 type InternalError struct{ error }
 
+func (e InternalError) Unwrap() error { return e.error }
+
 // FatalReconcileError states that a fatal error happened
 type FatalReconcileError struct{ error }
+
+func (e FatalReconcileError) Unwrap() error { return e.error }
 
 // ReconcileRollingUpgrade states that rolling upgrade is reconciling
 type ReconcileRollingUpgrade struct{ error }
 
+func (e ReconcileRollingUpgrade) Unwrap() error { return e.error }
+
 // CruiseControlNotReady states that CC is not ready to receive connection
 type CruiseControlNotReady struct{ error }
+
+func (e CruiseControlNotReady) Unwrap() error { return e.error }
 
 // CruiseControlTaskRunning states that CC task is still running
 type CruiseControlTaskRunning struct{ error }
 
+func (e CruiseControlTaskRunning) Unwrap() error { return e.error }
+
 // CruiseControlTaskRunning states that CC task timed out
 type CruiseControlTaskTimeout struct{ error }
+
+func (e CruiseControlTaskTimeout) Unwrap() error { return e.error }
 
 // CruiseControlTaskFailure states that CC task was not found (CC restart?) or failed
 type CruiseControlTaskFailure struct{ error }
 
+func (e CruiseControlTaskFailure) Unwrap() error { return e.error }
+
 // PerBrokerConfigNotReady states that per-broker configurations has been updated for a broker
 type PerBrokerConfigNotReady struct{ error }
 
+func (e PerBrokerConfigNotReady) Unwrap() error { return e.error }
+
 // LoadBalancerIPNotReady states that the LoadBalancer IP is not yet created
 type LoadBalancerIPNotReady struct{ error }
+
+func (e LoadBalancerIPNotReady) Unwrap() error { return e.error }
 
 // New creates a new error factory error
 func New(t interface{}, err error, msg string, wrapArgs ...interface{}) error {

--- a/pkg/errorfactory/errorfactory_test.go
+++ b/pkg/errorfactory/errorfactory_test.go
@@ -53,3 +53,29 @@ func TestNew(t *testing.T) {
 		}
 	}
 }
+
+func TestUnwrapMethod(t *testing.T) {
+	// testError is a custom error type used to test the features of unwrapping errors using errors.Is() and errors.As()
+	type testError struct{ error }
+	var tstErr = testError{errors.New("inner-error")}
+
+	for _, errType := range errorTypes {
+		errType := errType
+		err := New(errType, tstErr, "test-message")
+
+		// This tests the use of errors.Is() using the Unwrap() method
+		if ok := errors.Is(err, tstErr); !ok {
+			t.Errorf("Type %T does not Unwrap() correctly using errors.Is(). Expected: %t ; Got: %t", errType, true, ok)
+		}
+
+		var c testError
+		// This tests the use of errors.As() using the Unwrap() method
+		if ok := errors.As(err, &c); !ok {
+			t.Errorf("Type %T does not Unwrap() correctly using errors.As(). Expected: %t ; Got: %t", errType, true, ok)
+			// This tests whether errors.As() succeeded in extracting the correct wrapped error into the given variable, not just the boolean return value
+			if c != tstErr {
+				t.Errorf("Type %T does not extract correctly the wrapped error using errors.As(). Expected: %v ; Got: %v", errType, tstErr, c)
+			}
+		}
+	}
+}

--- a/pkg/webhooks/errors.go
+++ b/pkg/webhooks/errors.go
@@ -39,15 +39,15 @@ func IsAdmissionCantConnect(err error) bool {
 	return false
 }
 
-func IsInvalidReplicationFactor(err error) bool {
-	if apierrors.IsInvalid(err) && strings.Contains(err.Error(), invalidReplicationFactorErrMsg) {
+func IsCantConnectAPIServer(err error) bool {
+	if apierrors.IsInternalError(err) && strings.Contains(err.Error(), cantConnectAPIServerMsg) {
 		return true
 	}
 	return false
 }
 
-func IsCantConnectAPIServer(err error) bool {
-	if apierrors.IsInternalError(err) && strings.Contains(err.Error(), cantConnectAPIServerMsg) {
+func IsInvalidReplicationFactor(err error) bool {
+	if apierrors.IsInvalid(err) && strings.Contains(err.Error(), invalidReplicationFactorErrMsg) {
 		return true
 	}
 	return false

--- a/pkg/webhooks/errors.go
+++ b/pkg/webhooks/errors.go
@@ -26,8 +26,10 @@ const (
 	invalidReplicationFactorErrMsg    = "replication factor is larger than the number of nodes in the kafka cluster"
 	outOfRangeReplicationFactorErrMsg = "replication factor must be larger than 0 (or set it to be -1 to use the broker's default)"
 	outOfRangePartitionsErrMsg        = "number of partitions must be larger than 0 (or set it to be -1 to use the broker's default)"
-	removingStorageMsg                = "removing storage from a broker is not supported"
-	errorDuringValidationMsg          = "error during validation"
+	unsupportedRemovingStorageMsg     = "removing storage from a broker is not supported"
+
+	// errorDuringValidationMsg is added to infrastructure errors (e.g. failed to connect), but not to field validation errors
+	errorDuringValidationMsg = "error during validation"
 )
 
 func IsAdmissionCantConnect(err error) bool {
@@ -66,7 +68,7 @@ func IsOutOfRangePartitions(err error) bool {
 }
 
 func IsInvalidRemovingStorage(err error) bool {
-	if apierrors.IsInvalid(err) && strings.Contains(err.Error(), removingStorageMsg) {
+	if apierrors.IsInvalid(err) && strings.Contains(err.Error(), unsupportedRemovingStorageMsg) {
 		return true
 	}
 	return false

--- a/pkg/webhooks/errors.go
+++ b/pkg/webhooks/errors.go
@@ -33,50 +33,29 @@ const (
 )
 
 func IsAdmissionCantConnect(err error) bool {
-	if apierrors.IsInternalError(err) && strings.Contains(err.Error(), cantConnectErrorMsg) {
-		return true
-	}
-	return false
+	return apierrors.IsInternalError(err) && strings.Contains(err.Error(), cantConnectErrorMsg)
 }
 
 func IsCantConnectAPIServer(err error) bool {
-	if apierrors.IsInternalError(err) && strings.Contains(err.Error(), cantConnectAPIServerMsg) {
-		return true
-	}
-	return false
+	return apierrors.IsInternalError(err) && strings.Contains(err.Error(), cantConnectAPIServerMsg)
 }
 
 func IsInvalidReplicationFactor(err error) bool {
-	if apierrors.IsInvalid(err) && strings.Contains(err.Error(), invalidReplicationFactorErrMsg) {
-		return true
-	}
-	return false
+	return apierrors.IsInvalid(err) && strings.Contains(err.Error(), invalidReplicationFactorErrMsg)
 }
 
 func IsOutOfRangeReplicationFactor(err error) bool {
-	if apierrors.IsInvalid(err) && strings.Contains(err.Error(), outOfRangeReplicationFactorErrMsg) {
-		return true
-	}
-	return false
+	return apierrors.IsInvalid(err) && strings.Contains(err.Error(), outOfRangeReplicationFactorErrMsg)
 }
 
 func IsOutOfRangePartitions(err error) bool {
-	if apierrors.IsInvalid(err) && strings.Contains(err.Error(), outOfRangePartitionsErrMsg) {
-		return true
-	}
-	return false
+	return apierrors.IsInvalid(err) && strings.Contains(err.Error(), outOfRangePartitionsErrMsg)
 }
 
 func IsInvalidRemovingStorage(err error) bool {
-	if apierrors.IsInvalid(err) && strings.Contains(err.Error(), unsupportedRemovingStorageMsg) {
-		return true
-	}
-	return false
+	return apierrors.IsInvalid(err) && strings.Contains(err.Error(), unsupportedRemovingStorageMsg)
 }
 
 func IsErrorDuringValidation(err error) bool {
-	if apierrors.IsInternalError(err) && strings.Contains(err.Error(), errorDuringValidationMsg) {
-		return true
-	}
-	return false
+	return apierrors.IsInternalError(err) && strings.Contains(err.Error(), errorDuringValidationMsg)
 }

--- a/pkg/webhooks/errors.go
+++ b/pkg/webhooks/errors.go
@@ -43,3 +43,38 @@ func IsInvalidReplicationFactor(err error) bool {
 	}
 	return false
 }
+
+func IsCantConnectAPIServer(err error) bool {
+	if apierrors.IsInternalError(err) && strings.Contains(err.Error(), cantConnectAPIServerMsg) {
+		return true
+	}
+	return false
+}
+
+func IsOutOfRangeReplicationFactor(err error) bool {
+	if apierrors.IsInvalid(err) && strings.Contains(err.Error(), outOfRangeReplicationFactorErrMsg) {
+		return true
+	}
+	return false
+}
+
+func IsOutOfRangePartitions(err error) bool {
+	if apierrors.IsInvalid(err) && strings.Contains(err.Error(), outOfRangePartitionsErrMsg) {
+		return true
+	}
+	return false
+}
+
+func IsInvalidRemovingStorage(err error) bool {
+	if apierrors.IsInvalid(err) && strings.Contains(err.Error(), removingStorageMsg) {
+		return true
+	}
+	return false
+}
+
+func IsErrorDuringValidation(err error) bool {
+	if apierrors.IsInternalError(err) && strings.Contains(err.Error(), errorDuringValidationMsg) {
+		return true
+	}
+	return false
+}

--- a/pkg/webhooks/errors_test.go
+++ b/pkg/webhooks/errors_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 
 	"emperror.dev/errors"
-	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	banzaicloudv1alpha1 "github.com/banzaicloud/koperator/api/v1alpha1"
@@ -29,18 +29,18 @@ import (
 )
 
 func TestIsAdmissionConnectionError(t *testing.T) {
-	err := apiErrors.NewInternalError(errors.Wrap(errors.New("..."), cantConnectErrorMsg))
+	err := apierrors.NewInternalError(errors.Wrap(errors.New("..."), cantConnectErrorMsg))
 
 	if !IsAdmissionCantConnect(err) {
 		t.Error("Expected is connection error to be true, got false")
 	}
 
-	err = apiErrors.NewServiceUnavailable("some other reason")
+	err = apierrors.NewServiceUnavailable("some other reason")
 	if IsAdmissionCantConnect(err) {
 		t.Error("Expected is connection error to be false, got true")
 	}
 
-	err = apiErrors.NewBadRequest(cantConnectErrorMsg)
+	err = apierrors.NewBadRequest(cantConnectErrorMsg)
 	if IsAdmissionCantConnect(err) {
 		t.Error("Expected is connection error to be false, got true")
 	}
@@ -51,7 +51,7 @@ func TestIsInvalidReplicationFactor(t *testing.T) {
 	var fieldErrs field.ErrorList
 	logMsg := fmt.Sprintf("%s (available brokers: 2)", invalidReplicationFactorErrMsg)
 	fieldErrs = append(fieldErrs, field.Invalid(field.NewPath("spec").Child("replicationFactor"), "4", logMsg))
-	err := apiErrors.NewInvalid(
+	err := apierrors.NewInvalid(
 		kafkaTopic.GetObjectKind().GroupVersionKind().GroupKind(),
 		kafkaTopic.Name, fieldErrs)
 
@@ -59,12 +59,12 @@ func TestIsInvalidReplicationFactor(t *testing.T) {
 		t.Error("Expected is invalid replication error to be true, got false")
 	}
 
-	err = apiErrors.NewServiceUnavailable("some other reason")
+	err = apierrors.NewServiceUnavailable("some other reason")
 	if IsInvalidReplicationFactor(err) {
 		t.Error("Expected is invalid replication error to be false, got true")
 	}
 
-	err = apiErrors.NewServiceUnavailable(invalidReplicationFactorErrMsg)
+	err = apierrors.NewServiceUnavailable(invalidReplicationFactorErrMsg)
 	if IsInvalidReplicationFactor(err) {
 		t.Error("Expected is invalid replication error to be false, got true")
 	}
@@ -78,12 +78,12 @@ func TestIsCantConnectAPIServer(t *testing.T) {
 	}{
 		{
 			testname: "cantConnectAPIServer",
-			err:      apiErrors.NewInternalError(errors.Wrap(errors.New("..."), cantConnectAPIServerMsg)),
+			err:      apierrors.NewInternalError(errors.Wrap(errors.New("..."), cantConnectAPIServerMsg)),
 			want:     true,
 		},
 		{
 			testname: "wrong-error-message",
-			err:      apiErrors.NewInternalError(errors.Wrap(errors.New("..."), "wrong-error-message")),
+			err:      apierrors.NewInternalError(errors.Wrap(errors.New("..."), "wrong-error-message")),
 			want:     false,
 		},
 	}
@@ -101,7 +101,7 @@ func TestIsOutOfRangeReplicationFactor(t *testing.T) {
 	kafkaTopic := banzaicloudv1alpha1.KafkaTopic{ObjectMeta: metav1.ObjectMeta{Name: "test-KafkaTopic"}}
 	var fieldErrs field.ErrorList
 	fieldErrs = append(fieldErrs, field.Invalid(field.NewPath("spec").Child("replicationFactor"), "-2", outOfRangeReplicationFactorErrMsg))
-	err := apiErrors.NewInvalid(
+	err := apierrors.NewInvalid(
 		kafkaTopic.GetObjectKind().GroupVersionKind().GroupKind(),
 		kafkaTopic.Name, fieldErrs)
 
@@ -114,7 +114,7 @@ func TestIsOutOfRangePartitions(t *testing.T) {
 	kafkaTopic := banzaicloudv1alpha1.KafkaTopic{ObjectMeta: metav1.ObjectMeta{Name: "test-KafkaTopic"}}
 	var fieldErrs field.ErrorList
 	fieldErrs = append(fieldErrs, field.Invalid(field.NewPath("spec").Child("partitions"), "-2", outOfRangePartitionsErrMsg))
-	err := apiErrors.NewInvalid(
+	err := apierrors.NewInvalid(
 		kafkaTopic.GetObjectKind().GroupVersionKind().GroupKind(),
 		kafkaTopic.Name, fieldErrs)
 
@@ -155,7 +155,7 @@ func TestIsInvalidRemovingStorage(t *testing.T) {
 		t.Run(tc.testname, func(t *testing.T) {
 			kafkaCluster := banzaicloudv1beta1.KafkaCluster{ObjectMeta: metav1.ObjectMeta{Name: "test-KafkaCluster"}}
 
-			err := apiErrors.NewInvalid(
+			err := apierrors.NewInvalid(
 				kafkaCluster.GetObjectKind().GroupVersionKind().GroupKind(),
 				kafkaCluster.Name, tc.fieldErrs)
 
@@ -174,12 +174,12 @@ func TestIsErrorDuringValidation(t *testing.T) {
 	}{
 		{
 			testname: "errorDuringValidation",
-			err:      apiErrors.NewInternalError(errors.WithMessage(errors.New("..."), errorDuringValidationMsg)),
+			err:      apierrors.NewInternalError(errors.WithMessage(errors.New("..."), errorDuringValidationMsg)),
 			want:     true,
 		},
 		{
 			testname: "wrong-error-message",
-			err:      apiErrors.NewInternalError(errors.WithMessage(errors.New("..."), "wrong-error-message")),
+			err:      apierrors.NewInternalError(errors.WithMessage(errors.New("..."), "wrong-error-message")),
 			want:     false,
 		},
 	}

--- a/pkg/webhooks/errors_test.go
+++ b/pkg/webhooks/errors_test.go
@@ -115,11 +115,11 @@ func Test_IsInvalidRemovingStorage(t *testing.T) {
 	}{
 		{
 			testname:  "field.Invalid",
-			fieldErrs: append(field.ErrorList{}, field.Invalid(field.NewPath("spec").Child("brokers").Index(0).Child("brokerConfigGroup"), "test-broker-config-group", removingStorageMsg+", provided brokerConfigGroup not found")),
+			fieldErrs: append(field.ErrorList{}, field.Invalid(field.NewPath("spec").Child("brokers").Index(0).Child("brokerConfigGroup"), "test-broker-config-group", unsupportedRemovingStorageMsg+", provided brokerConfigGroup not found")),
 		},
 		{
 			testname:  "field.NotFound",
-			fieldErrs: append(field.ErrorList{}, field.NotFound(field.NewPath("spec").Child("brokers").Index(0).Child("storageConfig").Index(0), "/test/storageConfig/mount/path"+", "+removingStorageMsg)),
+			fieldErrs: append(field.ErrorList{}, field.NotFound(field.NewPath("spec").Child("brokers").Index(0).Child("storageConfig").Index(0), "/test/storageConfig/mount/path"+", "+unsupportedRemovingStorageMsg)),
 		},
 		//		{
 		//			testname:  "field.Invalid_wrong",

--- a/pkg/webhooks/errors_test.go
+++ b/pkg/webhooks/errors_test.go
@@ -71,25 +71,25 @@ func TestIsInvalidReplicationFactor(t *testing.T) {
 }
 
 func TestIsCantConnectAPIServer(t *testing.T) {
-	testcases := []struct {
-		testname string
+	testCases := []struct {
+		testName string
 		err      error
 		want     bool
 	}{
 		{
-			testname: "cantConnectAPIServer",
+			testName: "cantConnectAPIServer",
 			err:      apierrors.NewInternalError(errors.Wrap(errors.New("..."), cantConnectAPIServerMsg)),
 			want:     true,
 		},
 		{
-			testname: "wrong-error-message",
+			testName: "wrong-error-message",
 			err:      apierrors.NewInternalError(errors.Wrap(errors.New("..."), "wrong-error-message")),
 			want:     false,
 		},
 	}
 
-	for _, tc := range testcases {
-		t.Run(tc.testname, func(t *testing.T) {
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
 			if got := IsCantConnectAPIServer(tc.err); got != tc.want {
 				t.Errorf("Check connection to API Server error message. Expected: %t ; Got: %t", tc.want, got)
 			}
@@ -124,35 +124,35 @@ func TestIsOutOfRangePartitions(t *testing.T) {
 }
 
 func TestIsInvalidRemovingStorage(t *testing.T) {
-	testcases := []struct {
-		testname  string
+	testCases := []struct {
+		testName  string
 		fieldErrs field.ErrorList
 		want      bool
 	}{
 		{
-			testname:  "field.Invalid_removingStorage",
+			testName:  "field.Invalid_removingStorage",
 			fieldErrs: append(field.ErrorList{}, field.Invalid(field.NewPath("spec").Child("brokers").Index(0).Child("brokerConfigGroup"), "test-broker-config-group", unsupportedRemovingStorageMsg+", provided brokerConfigGroup not found")),
 			want:      true,
 		},
 		{
-			testname:  "field.NotFound_removingStorage",
+			testName:  "field.NotFound_removingStorage",
 			fieldErrs: append(field.ErrorList{}, field.NotFound(field.NewPath("spec").Child("brokers").Index(0).Child("storageConfig").Index(0), "/test/storageConfig/mount/path"+", "+unsupportedRemovingStorageMsg)),
 			want:      true,
 		},
 		{
-			testname:  "field.Invalid_wrong-error-message",
+			testName:  "field.Invalid_wrong-error-message",
 			fieldErrs: append(field.ErrorList{}, field.Invalid(field.NewPath("spec").Child("brokers").Index(0).Child("brokerConfigGroup"), "test-broker-config-group", "wrong-error-message"+", provided brokerConfigGroup not found")),
 			want:      false,
 		},
 		{
-			testname:  "field.NotFound_wrong-error-message",
+			testName:  "field.NotFound_wrong-error-message",
 			fieldErrs: append(field.ErrorList{}, field.NotFound(field.NewPath("spec").Child("brokers").Index(0).Child("storageConfig").Index(0), "/test/storageConfig/mount/path"+", "+"wrong-error-message")),
 			want:      false,
 		},
 	}
 
-	for _, tc := range testcases {
-		t.Run(tc.testname, func(t *testing.T) {
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
 			kafkaCluster := banzaicloudv1beta1.KafkaCluster{ObjectMeta: metav1.ObjectMeta{Name: "test-KafkaCluster"}}
 
 			err := apierrors.NewInvalid(
@@ -167,25 +167,25 @@ func TestIsInvalidRemovingStorage(t *testing.T) {
 }
 
 func TestIsErrorDuringValidation(t *testing.T) {
-	testcases := []struct {
-		testname string
+	testCases := []struct {
+		testName string
 		err      error
 		want     bool
 	}{
 		{
-			testname: "errorDuringValidation",
+			testName: "errorDuringValidation",
 			err:      apierrors.NewInternalError(errors.WithMessage(errors.New("..."), errorDuringValidationMsg)),
 			want:     true,
 		},
 		{
-			testname: "wrong-error-message",
+			testName: "wrong-error-message",
 			err:      apierrors.NewInternalError(errors.WithMessage(errors.New("..."), "wrong-error-message")),
 			want:     false,
 		},
 	}
 
-	for _, tc := range testcases {
-		t.Run(tc.testname, func(t *testing.T) {
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
 			if got := IsErrorDuringValidation(tc.err); got != tc.want {
 				t.Errorf("Check overall Error During Validation error message. Expected: %t ; Got: %t", tc.want, got)
 			}

--- a/pkg/webhooks/kafkacluster_validator.go
+++ b/pkg/webhooks/kafkacluster_validator.go
@@ -78,7 +78,7 @@ func checkBrokerStorageRemoval(kafkaClusterSpecOld, kafkaClusterSpecNew *banzaic
 				// checking broukerConfigGroup existence
 				if brokerNew.BrokerConfigGroup != "" {
 					if _, exists := kafkaClusterSpecNew.BrokerConfigGroups[brokerNew.BrokerConfigGroup]; !exists {
-						return field.Invalid(field.NewPath("spec").Child("brokers").Index(int(brokerNew.Id)).Child("brokerConfigGroup"), brokerNew.BrokerConfigGroup, removingStorageMsg+", provided brokerConfigGroup not found"), nil
+						return field.Invalid(field.NewPath("spec").Child("brokers").Index(int(brokerNew.Id)).Child("brokerConfigGroup"), brokerNew.BrokerConfigGroup, unsupportedRemovingStorageMsg+", provided brokerConfigGroup not found"), nil
 					}
 				}
 				brokerConfigsNew, err := brokerNew.GetBrokerConfig(*kafkaClusterSpecNew)
@@ -99,9 +99,9 @@ func checkBrokerStorageRemoval(kafkaClusterSpecOld, kafkaClusterSpecNew *banzaic
 					if !isStorageFound {
 						fromConfigGroup := getMissingMounthPathLocation(storageConfigOld.MountPath, kafkaClusterSpecOld, int32(k))
 						if fromConfigGroup != nil && *fromConfigGroup {
-							return field.Invalid(field.NewPath("spec").Child("brokers").Index(k).Child("brokerConfigGroup"), brokerNew.BrokerConfigGroup, fmt.Sprintf("%s, missing storageConfig mounthPath: %s", removingStorageMsg, storageConfigOld.MountPath)), nil
+							return field.Invalid(field.NewPath("spec").Child("brokers").Index(k).Child("brokerConfigGroup"), brokerNew.BrokerConfigGroup, fmt.Sprintf("%s, missing storageConfig mounthPath: %s", unsupportedRemovingStorageMsg, storageConfigOld.MountPath)), nil
 						}
-						return field.NotFound(field.NewPath("spec").Child("brokers").Index(k).Child("storageConfig").Index(e), storageConfigOld.MountPath+", "+removingStorageMsg), nil
+						return field.NotFound(field.NewPath("spec").Child("brokers").Index(k).Child("storageConfig").Index(e), storageConfigOld.MountPath+", "+unsupportedRemovingStorageMsg), nil
 					}
 				}
 			}

--- a/pkg/webhooks/kafkacluster_validator.go
+++ b/pkg/webhooks/kafkacluster_validator.go
@@ -20,7 +20,7 @@ import (
 
 	"emperror.dev/errors"
 	"golang.org/x/exp/slices"
-	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
@@ -42,7 +42,7 @@ func (s KafkaClusterValidator) ValidateUpdate(ctx context.Context, oldObj, newOb
 	fieldErr, err := checkBrokerStorageRemoval(&kafkaClusterOld.Spec, &kafkaClusterNew.Spec)
 	if err != nil {
 		log.Error(err, errorDuringValidationMsg)
-		return apiErrors.NewInternalError(errors.WithMessage(err, errorDuringValidationMsg))
+		return apierrors.NewInternalError(errors.WithMessage(err, errorDuringValidationMsg))
 	}
 	if fieldErr != nil {
 		allErrs = append(allErrs, fieldErr)
@@ -51,7 +51,7 @@ func (s KafkaClusterValidator) ValidateUpdate(ctx context.Context, oldObj, newOb
 		return nil
 	}
 	log.Info("rejected", "invalid field(s)", allErrs.ToAggregate().Error())
-	return apiErrors.NewInvalid(
+	return apierrors.NewInvalid(
 		kafkaClusterNew.GroupVersionKind().GroupKind(),
 		kafkaClusterNew.Name, allErrs)
 }

--- a/pkg/webhooks/kafkatopic_validator.go
+++ b/pkg/webhooks/kafkatopic_validator.go
@@ -20,7 +20,7 @@ import (
 
 	"emperror.dev/errors"
 
-	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -59,13 +59,13 @@ func (s *KafkaTopicValidator) validate(ctx context.Context, obj runtime.Object) 
 	fieldErrs, err := s.validateKafkaTopic(ctx, kafkaTopic, log)
 	if err != nil {
 		log.Error(err, errorDuringValidationMsg)
-		return apiErrors.NewInternalError(errors.WithMessage(err, errorDuringValidationMsg))
+		return apierrors.NewInternalError(errors.WithMessage(err, errorDuringValidationMsg))
 	}
 	if len(fieldErrs) == 0 {
 		return nil
 	}
 	log.Info("rejected", "invalid field(s)", fieldErrs.ToAggregate().Error())
-	return apiErrors.NewInvalid(
+	return apierrors.NewInvalid(
 		kafkaTopic.GetObjectKind().GroupVersionKind().GroupKind(),
 		kafkaTopic.Name, fieldErrs)
 }
@@ -94,7 +94,7 @@ func (s *KafkaTopicValidator) validateKafkaTopic(ctx context.Context, topic *ban
 
 	// Check if the cluster being referenced actually exists
 	if cluster, err = k8sutil.LookupKafkaCluster(ctx, s.Client, clusterName, clusterNamespace); err != nil {
-		if !apiErrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return nil, errors.Wrap(err, cantConnectAPIServerMsg)
 		}
 		if k8sutil.IsMarkedForDeletion(topic.ObjectMeta) {
@@ -159,7 +159,7 @@ func (s *KafkaTopicValidator) checkKafka(ctx context.Context, topic *banzaicloud
 		// Check if this is the correct CR for this topic
 		topicCR := &banzaicloudv1alpha1.KafkaTopic{}
 		if err := s.Client.Get(ctx, types.NamespacedName{Name: topic.Name, Namespace: topic.Namespace}, topicCR); err != nil {
-			if apiErrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				// User is trying to overwrite an existing topic - bad user
 				logMsg := fmt.Sprintf("topic already exists on kafka cluster '%s'", topic.Spec.ClusterRef.Name)
 				return field.Invalid(field.NewPath("spec").Child("name"), topic.Spec.Name, logMsg), nil


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no|
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets |  |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR aims to improve the errors implementations (in the **errorfactory** and **webhooks** packages).  
Along the way, I'm also renaming a couple of variables and functions to better reflect their usage.

The custom error types from the **errorfactory** package can be improved and brought up to date (to Go > 1.13 recommendations) by adding an `Unwrap()` method for each one of these types returning the **embedded** `error` so that errors that could be wrapped inside can be inspected and matched on with all of their details, not just the string representation, with `errors.Is()` and `errors.As()`.  
I'm also adding a unit test for the `Unwrap()` behaviour.

The constant error message strings from the **webhooks** package don't need to be exported, but, because we still have to do some string matching, we can add exported matching functions for all them much like we have right now for 2 of them (`IsAdmissionCantConnect(error) bool`  and  `IsInvalidReplicationFactor(error) bool`). This will facilitate and hide the details of the string matching that we need to do.  
I'm also adding unit tests for these new functions.

The changes made to the `controllers` package reflect the updated usage pattern of the errors from the `errorfactory` package. Without these, that code no longer works correctly.    
The previous model that performed a `type switch` on the error returned by `emperror/errors.Cause(err)` no longer works because the error types from the `errorfactory` package can now Unwrap() and return the errors inside, not just stopping the unwrap immediately and returning the outer type. Because we no longer break the error chain, the "last" error in the chain (deemed as "Cause") is no longer the type from the `errorfactory` package but whatever it wraps or further.  
Now, we can and should use the standard `errors.As(...)` function instead which doesn't require the type we seek to be at the very end of the chain but anywhere inside the chain of wrapped errors. Yes, we currently use the `As(...)` function from the emperror/errors package but that translates directly to the `errors.As(...)` from the **standard library**.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
Currently, in koperator we have 2 patterns for our own errors:

1. Custom error types in koperator/pkg/errorfactory/errorfactory.go

These embed the builtin "error" type and wrap external errors passed in to the errorfactory.New function alongside lists of "details". We make use of the `emperror/errors` module which returns error types that can be chained (have both Error() and Unwrap() methods).  
Right now errors like APIFailure (used like in koperator/pkg/k8sutil/resource.go) can be inspected or matched on for type but we lose the details of the error(s) wrapped inside. This can be improved by adding an `Unwrap()` method for each one of these types returning the embedded error.

2. The error strings in koperator/pkg/webhooks/errors.go

These are unexported constant strings used during the validating webhook functions. These are used as parts of the strings of some log and error messages.

These end up used to create either an `error` or a `field.Error` (k8s.io/apimachinery/pkg/util/validation/field). In both situations, the ValidateCreate and ValidateUpdate sets of methods return errors that, underneath, are of `StatusError` type (apimachinery/pkg/api/errors/errors.go) from `apimachinery`. This type hides all other details from the wrapped errors except for the accumulated string. Sometimes the error chain is broken even earlier by other error types from apimachinery.   
The downside to the error types we end up returning from the webhook functions is that we don't have a reasonable solution to avoid doing string matching to discriminate between errors.



