### PR TITLE
Fix Kafka super.users override

### DIFF
--- a/pkg/resources/kafka/configmap.go
+++ b/pkg/resources/kafka/configmap.go
@@ -378,6 +378,8 @@ func mergeSuperUsersPropertyValue(source *properties.Properties, target *propert
 
 	if inserted {
 		mergedSuperUsers := strings.Join(targetSuperUsers, ";")
+		// Setting string value for a property is not going to run into error, also we don't have error handling at upper levels
+		//nolint:errcheck
 		target.Set("super.users", mergedSuperUsers)
 	}
 }

--- a/pkg/resources/kafka/configmap.go
+++ b/pkg/resources/kafka/configmap.go
@@ -392,8 +392,8 @@ func (r Reconciler) generateBrokerConfig(id int32, brokerConfig *v1beta1.BrokerC
 
 	// Merge operator generated configuration to the final one
 	if opGenConf != nil {
-		// When there is super.users configuration in the readOnly config we merge its value into the Koperator generated one.
-		// thus finalBrokerConfig contains the merged super.user value.
+		// When there is custom super.users configuration we merge its value into the Koperator generated one
+		// thus finalBrokerConfig contains merged super.users value.
 		mergeSuperUsersPropertyValue(finalBrokerConfig, opGenConf)
 		finalBrokerConfig.Merge(opGenConf)
 	}

--- a/pkg/resources/kafka/configmap.go
+++ b/pkg/resources/kafka/configmap.go
@@ -347,7 +347,7 @@ func generateListenerSSLConfig(config *properties.Properties, name string, sslCl
 }
 
 // mergeSuperUsersPropertyValue merges the target and source super.users property value, and returns it as string.
-// It returns empty string when there were no updates or any  of the super.users property value was empty.
+// It returns empty string when there were no updates or any of the super.users property value was empty.
 func mergeSuperUsersPropertyValue(source *properties.Properties, target *properties.Properties) string {
 	sourceVal, foundSource := source.Get("super.users")
 	if !foundSource || sourceVal.IsEmpty() {

--- a/pkg/resources/kafka/configmap_test.go
+++ b/pkg/resources/kafka/configmap_test.go
@@ -16,13 +16,13 @@ package kafka
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/banzaicloud/koperator/pkg/util"
 	kafkautils "github.com/banzaicloud/koperator/pkg/util/kafka"
 
 	"github.com/stretchr/testify/mock"
@@ -466,6 +466,146 @@ metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlM
 super.users=User:CN=kafka-headless.kafka.svc.cluster.local
 zookeeper.connect=example.zk:2181/`,
 		},
+		{
+			testName:                  "configWithSSL_with_readOnly-superUsers1",
+			readOnlyConfig:            `super.users=User:CN=custom-superuser1;User:CN=custom-superuser2`,
+			zkAddresses:               []string{"example.zk:2181"},
+			zkPath:                    ``,
+			kubernetesClusterDomain:   ``,
+			clusterWideConfig:         ``,
+			perBrokerConfig:           ``,
+			perBrokerReadOnlyConfig:   ``,
+			advertisedListenerAddress: `kafka-0.kafka.svc.cluster.local:9092`,
+			listenerType:              "ssl",
+			sslClientAuth:             "none",
+			expectedConfig: `advertised.listeners=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
+broker.id=0
+cruise.control.metrics.reporter.bootstrap.servers=kafka-all-broker.kafka.svc.cluster.local:9092
+cruise.control.metrics.reporter.kubernetes.mode=true
+cruise.control.metrics.reporter.security.protocol=SSL
+cruise.control.metrics.reporter.ssl.keystore.location=/var/run/secrets/java.io/keystores/client/keystore.jks
+cruise.control.metrics.reporter.ssl.keystore.password=keystore_clientpassword123
+cruise.control.metrics.reporter.ssl.truststore.location=/var/run/secrets/java.io/keystores/client/truststore.jks
+cruise.control.metrics.reporter.ssl.truststore.password=keystore_clientpassword123
+inter.broker.listener.name=INTERNAL
+listener.name.internal.ssl.client.auth=none
+listener.name.internal.ssl.keystore.location=/var/run/secrets/java.io/keystores/server/internal/keystore.jks
+listener.name.internal.ssl.keystore.password=keystore_serverpassword123
+listener.name.internal.ssl.keystore.type=JKS
+listener.name.internal.ssl.truststore.location=/var/run/secrets/java.io/keystores/server/internal/truststore.jks
+listener.name.internal.ssl.truststore.password=keystore_serverpassword123
+listener.name.internal.ssl.truststore.type=JKS
+listener.security.protocol.map=INTERNAL:SSL
+listeners=INTERNAL://:9092
+metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter
+super.users=User:CN=kafka-headless.kafka.svc.cluster.local;User:CN=custom-superuser1;User:CN=custom-superuser2
+zookeeper.connect=example.zk:2181/`,
+		},
+		{
+			testName:                  "configWithSSL_with_readOnly-superUsers2",
+			readOnlyConfig:            `super.users=User:CN=kafka-headless.kafka.svc.cluster.local`,
+			zkAddresses:               []string{"example.zk:2181"},
+			zkPath:                    ``,
+			kubernetesClusterDomain:   ``,
+			clusterWideConfig:         ``,
+			perBrokerConfig:           ``,
+			perBrokerReadOnlyConfig:   ``,
+			advertisedListenerAddress: `kafka-0.kafka.svc.cluster.local:9092`,
+			listenerType:              "ssl",
+			sslClientAuth:             "none",
+			expectedConfig: `advertised.listeners=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
+broker.id=0
+cruise.control.metrics.reporter.bootstrap.servers=kafka-all-broker.kafka.svc.cluster.local:9092
+cruise.control.metrics.reporter.kubernetes.mode=true
+cruise.control.metrics.reporter.security.protocol=SSL
+cruise.control.metrics.reporter.ssl.keystore.location=/var/run/secrets/java.io/keystores/client/keystore.jks
+cruise.control.metrics.reporter.ssl.keystore.password=keystore_clientpassword123
+cruise.control.metrics.reporter.ssl.truststore.location=/var/run/secrets/java.io/keystores/client/truststore.jks
+cruise.control.metrics.reporter.ssl.truststore.password=keystore_clientpassword123
+inter.broker.listener.name=INTERNAL
+listener.name.internal.ssl.client.auth=none
+listener.name.internal.ssl.keystore.location=/var/run/secrets/java.io/keystores/server/internal/keystore.jks
+listener.name.internal.ssl.keystore.password=keystore_serverpassword123
+listener.name.internal.ssl.keystore.type=JKS
+listener.name.internal.ssl.truststore.location=/var/run/secrets/java.io/keystores/server/internal/truststore.jks
+listener.name.internal.ssl.truststore.password=keystore_serverpassword123
+listener.name.internal.ssl.truststore.type=JKS
+listener.security.protocol.map=INTERNAL:SSL
+listeners=INTERNAL://:9092
+metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter
+super.users=User:CN=kafka-headless.kafka.svc.cluster.local
+zookeeper.connect=example.zk:2181/`,
+		},
+		{
+			testName:                  "configWithSSL_with_readOnly-superUsers3",
+			readOnlyConfig:            `super.users=User:CN=custom-superuser1;User:CN=custom-superuser2;User:CN=kafka-headless.kafka.svc.cluster.local`,
+			zkAddresses:               []string{"example.zk:2181"},
+			zkPath:                    ``,
+			kubernetesClusterDomain:   ``,
+			clusterWideConfig:         ``,
+			perBrokerConfig:           ``,
+			perBrokerReadOnlyConfig:   ``,
+			advertisedListenerAddress: `kafka-0.kafka.svc.cluster.local:9092`,
+			listenerType:              "ssl",
+			sslClientAuth:             "none",
+			expectedConfig: `advertised.listeners=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
+broker.id=0
+cruise.control.metrics.reporter.bootstrap.servers=kafka-all-broker.kafka.svc.cluster.local:9092
+cruise.control.metrics.reporter.kubernetes.mode=true
+cruise.control.metrics.reporter.security.protocol=SSL
+cruise.control.metrics.reporter.ssl.keystore.location=/var/run/secrets/java.io/keystores/client/keystore.jks
+cruise.control.metrics.reporter.ssl.keystore.password=keystore_clientpassword123
+cruise.control.metrics.reporter.ssl.truststore.location=/var/run/secrets/java.io/keystores/client/truststore.jks
+cruise.control.metrics.reporter.ssl.truststore.password=keystore_clientpassword123
+inter.broker.listener.name=INTERNAL
+listener.name.internal.ssl.client.auth=none
+listener.name.internal.ssl.keystore.location=/var/run/secrets/java.io/keystores/server/internal/keystore.jks
+listener.name.internal.ssl.keystore.password=keystore_serverpassword123
+listener.name.internal.ssl.keystore.type=JKS
+listener.name.internal.ssl.truststore.location=/var/run/secrets/java.io/keystores/server/internal/truststore.jks
+listener.name.internal.ssl.truststore.password=keystore_serverpassword123
+listener.name.internal.ssl.truststore.type=JKS
+listener.security.protocol.map=INTERNAL:SSL
+listeners=INTERNAL://:9092
+metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter
+super.users=User:CN=kafka-headless.kafka.svc.cluster.local;User:CN=custom-superuser1;User:CN=custom-superuser2
+zookeeper.connect=example.zk:2181/`,
+		},
+		{
+			testName:                  "configWithSSL_with_readOnly-superUsers4",
+			readOnlyConfig:            `super.users=`,
+			zkAddresses:               []string{"example.zk:2181"},
+			zkPath:                    ``,
+			kubernetesClusterDomain:   ``,
+			clusterWideConfig:         ``,
+			perBrokerConfig:           ``,
+			perBrokerReadOnlyConfig:   ``,
+			advertisedListenerAddress: `kafka-0.kafka.svc.cluster.local:9092`,
+			listenerType:              "ssl",
+			sslClientAuth:             "none",
+			expectedConfig: `advertised.listeners=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
+broker.id=0
+cruise.control.metrics.reporter.bootstrap.servers=kafka-all-broker.kafka.svc.cluster.local:9092
+cruise.control.metrics.reporter.kubernetes.mode=true
+cruise.control.metrics.reporter.security.protocol=SSL
+cruise.control.metrics.reporter.ssl.keystore.location=/var/run/secrets/java.io/keystores/client/keystore.jks
+cruise.control.metrics.reporter.ssl.keystore.password=keystore_clientpassword123
+cruise.control.metrics.reporter.ssl.truststore.location=/var/run/secrets/java.io/keystores/client/truststore.jks
+cruise.control.metrics.reporter.ssl.truststore.password=keystore_clientpassword123
+inter.broker.listener.name=INTERNAL
+listener.name.internal.ssl.client.auth=none
+listener.name.internal.ssl.keystore.location=/var/run/secrets/java.io/keystores/server/internal/keystore.jks
+listener.name.internal.ssl.keystore.password=keystore_serverpassword123
+listener.name.internal.ssl.keystore.type=JKS
+listener.name.internal.ssl.truststore.location=/var/run/secrets/java.io/keystores/server/internal/truststore.jks
+listener.name.internal.ssl.truststore.password=keystore_serverpassword123
+listener.name.internal.ssl.truststore.type=JKS
+listener.security.protocol.map=INTERNAL:SSL
+listeners=INTERNAL://:9092
+metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter
+super.users=User:CN=kafka-headless.kafka.svc.cluster.local
+zookeeper.connect=example.zk:2181/`,
+		},
 	}
 
 	t.Parallel()
@@ -537,9 +677,7 @@ zookeeper.connect=example.zk:2181/`,
 				superUsers   []string
 			)
 
-			sslConfigTestNames := []string{"configWithSSL_SSLClientAuth_not_provided", "configWithSSL_SSLClientAuth_required", "configWithSSL_SSLClientAuth_requested",
-				"configWithSSL_SSLClientAuth_none"}
-			if util.StringSliceContains(sslConfigTestNames, test.testName) {
+			if strings.Contains(test.testName, "configWithSSL") {
 				serverPasses = map[string]string{"internal": "keystore_serverpassword123"}
 				clientPass = "keystore_clientpassword123"
 				superUsers = []string{"CN=kafka-headless.kafka.svc.cluster.local"}


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Merges custom super.users configuration with the Koperator auto generated one.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
When there is custom super.users configuration in the KafkaCluster CR and there is SSL listener, Koperator generated super.user configuration overrides the custom one. 


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
