### PR TITLE
Min and Max validation for KafkaCluster.spec.Brokers.[].Id

### DIFF
--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -153,6 +153,9 @@ type DisruptionBudgetWithStrategy struct {
 
 // Broker defines the broker basic configuration
 type Broker struct {
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=65535
+	// +kubebuilder:validation:ExclusiveMaximum=true
 	Id                int32         `json:"id"`
 	BrokerConfigGroup string        `json:"brokerConfigGroup,omitempty"`
 	ReadOnlyConfig    string        `json:"readOnlyConfig,omitempty"`

--- a/charts/kafka-operator/templates/crds.yaml
+++ b/charts/kafka-operator/templates/crds.yaml
@@ -12456,7 +12456,10 @@ spec:
                     brokerConfigGroup:
                       type: string
                     id:
+                      exclusiveMaximum: true
                       format: int32
+                      maximum: 65535
+                      minimum: 0
                       type: integer
                     readOnlyConfig:
                       type: string

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -12293,7 +12293,10 @@ spec:
                     brokerConfigGroup:
                       type: string
                     id:
+                      exclusiveMaximum: true
                       format: int32
+                      maximum: 65535
+                      minimum: 0
                       type: integer
                     readOnlyConfig:
                       type: string


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| Related tickets | partially https://github.com/banzaicloud/koperator/issues/913 |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR adds kubebuilder markers to implement a minimal validation of the `KafkaCluster.spec.Brokers.[].Id` field according to https://github.com/banzaicloud/koperator/issues/913.

The updates to the CRD are generated with `make manifests`.


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
I chose the `Maximum` + `ExclusiveMaximum` combination of settings because `65535` is a more recognisable number than 65534.

