### PR TITLE
Update benchmark kafka yaml

### DIFF
--- a/docs/benchmarks/infrastructure/kafka.yaml
+++ b/docs/benchmarks/infrastructure/kafka.yaml
@@ -24,21 +24,13 @@ spec:
         num.io.threads=16
         num.network.threads=6
       kafkaHeapOpts: "-Xmx10G -Xms10G"
-      resourceReqs:
+      resourceRequirements:
         limits:
           memory: "16Gi"
           cpu: "7500m"
         requests:
           memory: "12Gi"
           cpu: "4000m"
-      nodeAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          nodeSelectorTerms:
-            - matchExpressions:
-                - key: nodepool.banzaicloud.io/name
-                  operator: In
-                  values:
-                    - pool2
       storageConfigs:
         - mountPath: "/kafka-logs"
           pvcSpec:
@@ -106,6 +98,7 @@ spec:
       metric.sampler.partition.assignor.class=com.linkedin.kafka.cruisecontrol.monitor.sampling.DefaultMetricSamplerPartitionAssignor
       # The metric sampling interval in milliseconds
       metric.sampling.interval.ms=120000
+      metric.anomaly.detection.interval.ms=180000
       # The partition metrics window size in milliseconds
       partition.metrics.window.ms=300000
       # The number of partition metric windows to keep in memory
@@ -264,7 +257,7 @@ spec:
           }
         ]
       }
-    clusterConfigs: |
+    clusterConfig: |
       {
         "min.insync.replicas": 3
       }


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no|
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Update Kafka configurations for performance test

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Configurations are outdated, and step 3 of the section https://docs.calisti.app/sdm/koperator/benchmarks/#install-other-required-components uses this sample yaml for configuring example Kafka cluster

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

- `resourceReqs` had been changed to `resourceRequirements`: https://github.com/banzaicloud/koperator/commit/c57e0b7e51de88f1c48c7eb42fcb97fd85ed8657
- `clusterConfigs` had been changed to `clusterConfig`: https://github.com/banzaicloud/koperator/commit/4d6e7a44465f764d8bb01595c998606aad10baaf
- The entire `nodeAffinity` section was tied to the `nodepool.banzaicloud.io/name` label, which would not be valid for regular users
- The `metric.anomaly.detection.interval.ms=180000` is also needed for CruiseControl to be properly configured with existing configurations

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] User guide and development docs updated (if needed)
