### PR TITLE
Update sub-Go-module tags to valid values, remove local replacement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/banzaicloud/istio-client-go v0.0.17
 	github.com/banzaicloud/istio-operator/api/v2 v2.15.1
 	github.com/banzaicloud/k8s-objectmatcher v1.8.0
-	github.com/banzaicloud/koperator/api v0.0.0
-	github.com/banzaicloud/koperator/properties v0.0.0
+	github.com/banzaicloud/koperator/api v0.23.0
+	github.com/banzaicloud/koperator/properties v0.4.1
 	github.com/cert-manager/cert-manager v1.9.1
 	github.com/cisco-open/cluster-registry-controller/api v0.2.5
 	github.com/envoyproxy/go-control-plane v0.10.3

--- a/go.mod
+++ b/go.mod
@@ -134,8 +134,6 @@ require (
 )
 
 replace (
-	github.com/banzaicloud/koperator/api => ./api
-	github.com/banzaicloud/koperator/properties => ./properties
 	github.com/gogo/protobuf => github.com/waynz0r/protobuf v1.3.3-0.20210811122234-64636cae0910
 	github.com/golang/protobuf => github.com/luciferinlove/protobuf v0.0.0-20220913214010-c63936d75066
 )

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,10 @@ github.com/banzaicloud/istio-operator/api/v2 v2.15.1 h1:BZg8COvoOJtfx/dgN7KpoOnc
 github.com/banzaicloud/istio-operator/api/v2 v2.15.1/go.mod h1:5qCpwWlIfxiLvBfTvT2mD2wp5RlFCDEt8Xql4sYPNBc=
 github.com/banzaicloud/k8s-objectmatcher v1.8.0 h1:Nugn25elKtPMTA2br+JgHNeSQ04sc05MDPmpJnd1N2A=
 github.com/banzaicloud/k8s-objectmatcher v1.8.0/go.mod h1:p2LSNAjlECf07fbhDyebTkPUIYnU05G+WfGgkTmgeMg=
+github.com/banzaicloud/koperator/api v0.23.0 h1:WQYmDvboA6VNRSFoGJTi/fjL+hEjdM/sBtP32ymKrfg=
+github.com/banzaicloud/koperator/api v0.23.0/go.mod h1:VnxVrXvw0QdlvJzke5ZFr+x+RD4K6zhjHXUdBO+iD/Q=
+github.com/banzaicloud/koperator/properties v0.4.1 h1:SB2QgXlcK1Dc7Z1rg65PJifErDa8OQnoWCCJgmC7SGc=
+github.com/banzaicloud/koperator/properties v0.4.1/go.mod h1:TcL+llxuhW3UeQtVEDYEXGouFLF2P+LuZZVudSb6jyA=
 github.com/banzaicloud/operator-tools v0.28.0 h1:GSfc0qZr6zo7WrNxdgWZE1LcTChPU8QFYOTDirYVtIM=
 github.com/banzaicloud/operator-tools v0.28.0/go.mod h1:t0dyFGJUR9Q5CwsUcq1nDJC0wSZqeh6nzUZkUp3vCXg=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | - |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

1. Updated the Koperator submodules api and properties dependency version tags to valid values.
2. Removed the local replacements from the Go mod file.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

1. Because invalid version tag was referenced previously which made everything depending on Koperator break when trying to acquire the depended modules.
2. Because the local replacement is only needed for local development and also it is not transitive to downstream usage (packages depending on Koperator won't see them) and thus can shadow invalid tags among local dependencies.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

We intend to release a new Koperator version with this change so Koperator can be depended upon, we will immediately pull it into another project as well to test the result.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- ~Implementation tested~
- ~Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)~
- ~Logging code meets the guideline~
- ~User guide and development docs updated (if needed)~
