### PR TITLE
Allow creating KafkaTopic CR for topic that already present on the Kafka cluster

### DIFF
--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -58,8 +58,6 @@ const (
 	KafkaPatternTypeDefault  KafkaPatternType = "literal"
 	// TopicStateCreated describes the status of a KafkaTopic as created
 	TopicStateCreated TopicState = "created"
-	// // TopicStateUnmanaged describes the status of a KafkaTopic as not managed by Koperator
-	// TopicStateUnmanaged TopicState = "unmanaged"
 	// UserStateCreated describes the status of a KafkaUser as created
 	UserStateCreated UserState = "created"
 	// TLSJKSKeyStore is where a JKS keystore is stored in a user secret when requested

--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -58,6 +58,8 @@ const (
 	KafkaPatternTypeDefault  KafkaPatternType = "literal"
 	// TopicStateCreated describes the status of a KafkaTopic as created
 	TopicStateCreated TopicState = "created"
+	// // TopicStateUnmanaged describes the status of a KafkaTopic as not managed by Koperator
+	// TopicStateUnmanaged TopicState = "unmanaged"
 	// UserStateCreated describes the status of a KafkaUser as created
 	UserStateCreated UserState = "created"
 	// TLSJKSKeyStore is where a JKS keystore is stored in a user secret when requested

--- a/charts/kafka-operator/templates/crds.yaml
+++ b/charts/kafka-operator/templates/crds.yaml
@@ -20101,10 +20101,10 @@ spec:
             properties:
               managedBy:
                 description: 'ManagedBy describes who is the manager of the Kafka
-                  topic. When its value is not ''koperator'' then modifications to
-                  the KafkaTopic CR''s topic configurations will be unaffected on
+                  topic. When its value is not "koperator" then modifications to the
+                  topic configurations of the KafkaTopic CR will be unaffected on
                   the Kafka topic. Manager of the Kafka topic can be changed by adding
-                  the ''managedBy: <manager>'' annotation to the KafkaTopic CR.'
+                  the "managedBy: <manager>" annotation to the KafkaTopic CR.'
                 type: string
               state:
                 description: TopicState defines the state of a KafkaTopic

--- a/charts/kafka-operator/templates/crds.yaml
+++ b/charts/kafka-operator/templates/crds.yaml
@@ -3907,6 +3907,21 @@ spec:
                         external listener advertise address according to the description
                         of the "hostnameOverride" field.
                       type: object
+                    nodePortNodeAddressType:
+                      description: When "hostNameOverride" and brokerConfig.nodePortExternalIP
+                        are empty and NodePort access method is selected for an external
+                        listener the NodePortNodeAdddressType defines the Kafka broker's
+                        Kubernetes node's address type that shall be used in the advertised.listeners
+                        property. https://kubernetes.io/docs/concepts/architecture/nodes/#addresses
+                        The NodePortNodeAddressType's possible values can be Hostname,
+                        ExternalIP, InternalIP, InternalDNS,ExternalDNS
+                      enum:
+                      - Hostname
+                      - ExternalIP
+                      - InternalIP
+                      - InternalDNS
+                      - ExternalDNS
+                      type: string
                     nodeSelector:
                       additionalProperties:
                         type: string
@@ -10034,6 +10049,21 @@ spec:
                             the broker's external listener advertise address according
                             to the description of the "hostnameOverride" field.
                           type: object
+                        nodePortNodeAddressType:
+                          description: When "hostNameOverride" and brokerConfig.nodePortExternalIP
+                            are empty and NodePort access method is selected for an
+                            external listener the NodePortNodeAdddressType defines
+                            the Kafka broker's Kubernetes node's address type that
+                            shall be used in the advertised.listeners property. https://kubernetes.io/docs/concepts/architecture/nodes/#addresses
+                            The NodePortNodeAddressType's possible values can be Hostname,
+                            ExternalIP, InternalIP, InternalDNS,ExternalDNS
+                          enum:
+                          - Hostname
+                          - ExternalIP
+                          - InternalIP
+                          - InternalDNS
+                          - ExternalDNS
+                          type: string
                         nodeSelector:
                           additionalProperties:
                             type: string
@@ -20102,9 +20132,9 @@ spec:
               managedBy:
                 description: 'ManagedBy describes who is the manager of the Kafka
                   topic. When its value is not "koperator" then modifications to the
-                  topic configurations of the KafkaTopic CR will be unaffected on
-                  the Kafka topic. Manager of the Kafka topic can be changed by adding
-                  the "managedBy: <manager>" annotation to the KafkaTopic CR.'
+                  topic configurations of the KafkaTopic CR will not be propagated
+                  to the Kafka topic. Manager of the Kafka topic can be changed by
+                  adding the "managedBy: <manager>" annotation to the KafkaTopic CR.'
                 type: string
               state:
                 description: TopicState defines the state of a KafkaTopic

--- a/charts/kafka-operator/templates/crds.yaml
+++ b/charts/kafka-operator/templates/crds.yaml
@@ -20100,6 +20100,11 @@ spec:
             description: KafkaTopicStatus defines the observed state of KafkaTopic
             properties:
               managedBy:
+                description: 'ManagedBy describes who is the manager of the Kafka
+                  topic. When its value is not ''koperator'' then modifications to
+                  the KafkaTopic CR''s topic configurations will be unaffected on
+                  the Kafka topic. Manager of the Kafka topic can be changed by adding
+                  the ''managedBy: <manager>'' annotation to the KafkaTopic CR.'
                 type: string
               state:
                 description: TopicState defines the state of a KafkaTopic

--- a/charts/kafka-operator/templates/crds.yaml
+++ b/charts/kafka-operator/templates/crds.yaml
@@ -20099,10 +20099,13 @@ spec:
           status:
             description: KafkaTopicStatus defines the observed state of KafkaTopic
             properties:
+              managedBy:
+                type: string
               state:
                 description: TopicState defines the state of a KafkaTopic
                 type: string
             required:
+            - managedBy
             - state
             type: object
         type: object

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -3744,6 +3744,21 @@ spec:
                         external listener advertise address according to the description
                         of the "hostnameOverride" field.
                       type: object
+                    nodePortNodeAddressType:
+                      description: When "hostNameOverride" and brokerConfig.nodePortExternalIP
+                        are empty and NodePort access method is selected for an external
+                        listener the NodePortNodeAdddressType defines the Kafka broker's
+                        Kubernetes node's address type that shall be used in the advertised.listeners
+                        property. https://kubernetes.io/docs/concepts/architecture/nodes/#addresses
+                        The NodePortNodeAddressType's possible values can be Hostname,
+                        ExternalIP, InternalIP, InternalDNS,ExternalDNS
+                      enum:
+                      - Hostname
+                      - ExternalIP
+                      - InternalIP
+                      - InternalDNS
+                      - ExternalDNS
+                      type: string
                     nodeSelector:
                       additionalProperties:
                         type: string
@@ -9871,6 +9886,21 @@ spec:
                             the broker's external listener advertise address according
                             to the description of the "hostnameOverride" field.
                           type: object
+                        nodePortNodeAddressType:
+                          description: When "hostNameOverride" and brokerConfig.nodePortExternalIP
+                            are empty and NodePort access method is selected for an
+                            external listener the NodePortNodeAdddressType defines
+                            the Kafka broker's Kubernetes node's address type that
+                            shall be used in the advertised.listeners property. https://kubernetes.io/docs/concepts/architecture/nodes/#addresses
+                            The NodePortNodeAddressType's possible values can be Hostname,
+                            ExternalIP, InternalIP, InternalDNS,ExternalDNS
+                          enum:
+                          - Hostname
+                          - ExternalIP
+                          - InternalIP
+                          - InternalDNS
+                          - ExternalDNS
+                          type: string
                         nodeSelector:
                           additionalProperties:
                             type: string

--- a/config/base/crds/kafka.banzaicloud.io_kafkatopics.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkatopics.yaml
@@ -75,10 +75,10 @@ spec:
             properties:
               managedBy:
                 description: 'ManagedBy describes who is the manager of the Kafka
-                  topic. When its value is not ''koperator'' then modifications to
-                  the KafkaTopic CR''s topic configurations will be unaffected on
+                  topic. When its value is not "koperator" then modifications to the
+                  topic configurations of the KafkaTopic CR will be unaffected on
                   the Kafka topic. Manager of the Kafka topic can be changed by adding
-                  the ''managedBy: <manager>'' annotation to the KafkaTopic CR.'
+                  the "managedBy: <manager>" annotation to the KafkaTopic CR.'
                 type: string
               state:
                 description: TopicState defines the state of a KafkaTopic

--- a/config/base/crds/kafka.banzaicloud.io_kafkatopics.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkatopics.yaml
@@ -73,10 +73,13 @@ spec:
           status:
             description: KafkaTopicStatus defines the observed state of KafkaTopic
             properties:
+              managedBy:
+                type: string
               state:
                 description: TopicState defines the state of a KafkaTopic
                 type: string
             required:
+            - managedBy
             - state
             type: object
         type: object

--- a/config/base/crds/kafka.banzaicloud.io_kafkatopics.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkatopics.yaml
@@ -76,9 +76,9 @@ spec:
               managedBy:
                 description: 'ManagedBy describes who is the manager of the Kafka
                   topic. When its value is not "koperator" then modifications to the
-                  topic configurations of the KafkaTopic CR will be unaffected on
-                  the Kafka topic. Manager of the Kafka topic can be changed by adding
-                  the "managedBy: <manager>" annotation to the KafkaTopic CR.'
+                  topic configurations of the KafkaTopic CR will not be propagated
+                  to the Kafka topic. Manager of the Kafka topic can be changed by
+                  adding the "managedBy: <manager>" annotation to the KafkaTopic CR.'
                 type: string
               state:
                 description: TopicState defines the state of a KafkaTopic

--- a/config/base/crds/kafka.banzaicloud.io_kafkatopics.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkatopics.yaml
@@ -74,6 +74,11 @@ spec:
             description: KafkaTopicStatus defines the observed state of KafkaTopic
             properties:
               managedBy:
+                description: 'ManagedBy describes who is the manager of the Kafka
+                  topic. When its value is not ''koperator'' then modifications to
+                  the KafkaTopic CR''s topic configurations will be unaffected on
+                  the Kafka topic. Manager of the Kafka topic can be changed by adding
+                  the ''managedBy: <manager>'' annotation to the KafkaTopic CR.'
                 type: string
               state:
                 description: TopicState defines the state of a KafkaTopic

--- a/controllers/kafkatopic_controller.go
+++ b/controllers/kafkatopic_controller.go
@@ -41,8 +41,8 @@ import (
 var topicFinalizer = "finalizer.kafkatopics.kafka.banzaicloud.io"
 
 func isTopicManagedByKoperator(topic metav1.Object) bool {
-	if manager, ok := topic.GetAnnotations()[webhooks.TopicManagedByAnnotationKey]; !ok || strings.ToLower(manager) == webhooks.TopicManagedByKoperatorAnnotationValue {
-		return true
+	if managedByAnnotation, ok := topic.GetAnnotations()[webhooks.TopicManagedByAnnotationKey]; !ok {
+		return strings.ToLower(managedByAnnotation) == webhooks.TopicManagedByKoperatorAnnotationValue
 	}
 	return false
 }
@@ -133,7 +133,7 @@ func (r *KafkaTopicReconciler) Reconcile(ctx context.Context, request reconcile.
 
 	// No need to do anything when the kafka topic is not managed by Koperator
 	if !isTopicManagedByKoperator(instance) {
-		reqLogger.Info(fmt.Sprintf("topic '%s' is not managed by %s it is managed by '%s' ==> reconciled", instance.Spec.Name, webhooks.TopicManagedByKoperatorAnnotationValue, instance.GetAnnotations()[webhooks.TopicManagedByAnnotationKey]))
+		reqLogger.Info(fmt.Sprintf("topic '%s' is not managed by %s it is managed by '%s' ==> nothing to reconcile here", instance.Spec.Name, webhooks.TopicManagedByKoperatorAnnotationValue, instance.GetAnnotations()[webhooks.TopicManagedByAnnotationKey]))
 		return reconciled()
 	}
 

--- a/controllers/kafkatopic_controller.go
+++ b/controllers/kafkatopic_controller.go
@@ -32,6 +32,7 @@ import (
 	"github.com/banzaicloud/koperator/pkg/k8sutil"
 	"github.com/banzaicloud/koperator/pkg/kafkaclient"
 	"github.com/banzaicloud/koperator/pkg/util"
+	"github.com/banzaicloud/koperator/pkg/webhooks"
 )
 
 var topicFinalizer = "finalizer.kafkatopics.kafka.banzaicloud.io"
@@ -216,6 +217,10 @@ func (r *KafkaTopicReconciler) finalizeKafkaTopic(reqLogger logr.Logger, broker 
 		return err
 	}
 	if exists != nil {
+		// When the topic is not managed by the Koperator, it is not our responsibility to delete it.
+		if val, ok := topic.GetAnnotations()[webhooks.ManagedByAnnotationKey]; ok && val != webhooks.ManagedByAnnotationValue {
+			return nil
+		}
 		// DeleteTopic with wait to make sure it goes down fully in case of cluster
 		// deletion.
 		// TODO (tinyzimmer): Perhaps this should only wait when it's the cluster

--- a/controllers/kafkatopic_controller.go
+++ b/controllers/kafkatopic_controller.go
@@ -41,10 +41,10 @@ import (
 var topicFinalizer = "finalizer.kafkatopics.kafka.banzaicloud.io"
 
 func isTopicManagedByKoperator(topic metav1.Object) bool {
-	if managedByAnnotation, ok := topic.GetAnnotations()[webhooks.TopicManagedByAnnotationKey]; !ok {
+	if managedByAnnotation, hasManagedByAnnotation := topic.GetAnnotations()[webhooks.TopicManagedByAnnotationKey]; hasManagedByAnnotation {
 		return strings.ToLower(managedByAnnotation) == webhooks.TopicManagedByKoperatorAnnotationValue
 	}
-	return false
+	return true
 }
 
 // SetupKafkaTopicWithManager registers kafka topic controller with manager
@@ -133,7 +133,7 @@ func (r *KafkaTopicReconciler) Reconcile(ctx context.Context, request reconcile.
 
 	// No need to do anything when the kafka topic is not managed by Koperator
 	if !isTopicManagedByKoperator(instance) {
-		reqLogger.Info(fmt.Sprintf("topic '%s' is not managed by %s it is managed by '%s' ==> nothing to reconcile here", instance.Spec.Name, webhooks.TopicManagedByKoperatorAnnotationValue, instance.GetAnnotations()[webhooks.TopicManagedByAnnotationKey]))
+		reqLogger.Info(fmt.Sprintf("topic '%s' is not managed by %s it is managed by '%s' ==> nothing to reconcile here", instance.Spec.Name, webhooks.TopicManagedByKoperatorAnnotationValue, managedByStatus))
 		return reconciled()
 	}
 

--- a/controllers/kafkatopic_controller_kafka_test.go
+++ b/controllers/kafkatopic_controller_kafka_test.go
@@ -1,0 +1,69 @@
+// Copyright © 2023 Cisco Systems, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/banzaicloud/koperator/api/v1alpha1"
+	"github.com/banzaicloud/koperator/pkg/webhooks"
+)
+
+func TestIsTopicManagedByKoperator(t *testing.T) {
+	testCases := []struct {
+		testName   string
+		kafkaTopic v1alpha1.KafkaTopic
+		expected   bool
+	}{
+		{
+			testName: "no managedBy annotation",
+			kafkaTopic: v1alpha1.KafkaTopic{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			expected: true,
+		},
+		{
+			testName: "has managedBy annotation with koperator value",
+			kafkaTopic: v1alpha1.KafkaTopic{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{webhooks.TopicManagedByAnnotationKey: webhooks.TopicManagedByKoperatorAnnotationValue},
+				},
+			},
+			expected: true,
+		},
+		{
+			testName: "has managedBy annotation with not koperator value",
+			kafkaTopic: v1alpha1.KafkaTopic{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{webhooks.TopicManagedByAnnotationKey: "other"},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.testName, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, testCase.expected, isTopicManagedByKoperator(&testCase.kafkaTopic))
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/banzaicloud/istio-client-go v0.0.17
 	github.com/banzaicloud/istio-operator/api/v2 v2.15.1
 	github.com/banzaicloud/k8s-objectmatcher v1.8.0
-	github.com/banzaicloud/koperator/api v0.23.0
+	github.com/banzaicloud/koperator/api v0.23.2
 	github.com/banzaicloud/koperator/properties v0.4.1
 	github.com/cert-manager/cert-manager v1.9.1
 	github.com/cisco-open/cluster-registry-controller/api v0.2.5

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/banzaicloud/istio-operator/api/v2 v2.15.1 h1:BZg8COvoOJtfx/dgN7KpoOnc
 github.com/banzaicloud/istio-operator/api/v2 v2.15.1/go.mod h1:5qCpwWlIfxiLvBfTvT2mD2wp5RlFCDEt8Xql4sYPNBc=
 github.com/banzaicloud/k8s-objectmatcher v1.8.0 h1:Nugn25elKtPMTA2br+JgHNeSQ04sc05MDPmpJnd1N2A=
 github.com/banzaicloud/k8s-objectmatcher v1.8.0/go.mod h1:p2LSNAjlECf07fbhDyebTkPUIYnU05G+WfGgkTmgeMg=
-github.com/banzaicloud/koperator/api v0.23.0 h1:WQYmDvboA6VNRSFoGJTi/fjL+hEjdM/sBtP32ymKrfg=
-github.com/banzaicloud/koperator/api v0.23.0/go.mod h1:VnxVrXvw0QdlvJzke5ZFr+x+RD4K6zhjHXUdBO+iD/Q=
+github.com/banzaicloud/koperator/api v0.23.2 h1:4K0FbGaefM3673GptjYO0XuthECu0S7zn389IAF5VLU=
+github.com/banzaicloud/koperator/api v0.23.2/go.mod h1:qvpewvjdELAnfO70vg9397CXZ4K4uHxpiWtf5fhKSrQ=
 github.com/banzaicloud/koperator/properties v0.4.1 h1:SB2QgXlcK1Dc7Z1rg65PJifErDa8OQnoWCCJgmC7SGc=
 github.com/banzaicloud/koperator/properties v0.4.1/go.mod h1:TcL+llxuhW3UeQtVEDYEXGouFLF2P+LuZZVudSb6jyA=
 github.com/banzaicloud/operator-tools v0.28.0 h1:GSfc0qZr6zo7WrNxdgWZE1LcTChPU8QFYOTDirYVtIM=

--- a/pkg/webhooks/kafkatopic_validator.go
+++ b/pkg/webhooks/kafkatopic_validator.go
@@ -173,22 +173,22 @@ func (s *KafkaTopicValidator) checkKafka(ctx context.Context, topic *banzaicloud
 				if manager, ok := topic.GetAnnotations()[TopicManagedByAnnotationKey]; !ok || strings.ToLower(manager) != TopicManagedByKoperatorAnnotationValue {
 					allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("name"), topic.Spec.Name,
 						fmt.Sprintf(`topic "%s" already exists on kafka cluster and it is not managed by Koperator,
-					if you want it to be managed by Koperator making you able to modify its configuration through a KafkaTopic CR,
+					if you want it to be managed by Koperator so you can modify its configurations through a KafkaTopic CR,,
 					add this "%s: %s" annotation to this KafkaTopic CR`, topic.Spec.Name, TopicManagedByAnnotationKey, TopicManagedByKoperatorAnnotationValue)))
 				}
 				// Comparing KafkaTopic configuration with the existing
 				if existing.NumPartitions != topic.Spec.Partitions {
 					allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("partitions"), topic.Spec.Partitions,
-						fmt.Sprintf(`initial KafkaTopic partition number must be the same as what the existing kafka topic has  (given: %v present: %v)`, topic.Spec.Partitions, existing.NumPartitions)))
+						fmt.Sprintf(`When creating KafkaTopic CR for existing topic, initially its partition number must be the same as what the existing kafka topic has (given: %v present: %v)`, topic.Spec.Partitions, existing.NumPartitions)))
 				}
 				if existing.ReplicationFactor != int16(topic.Spec.ReplicationFactor) {
 					allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("replicationfactor"), topic.Spec.ReplicationFactor,
-						fmt.Sprintf(`initial KafkaTopic replication factor must be the same as what the existing kafka topic has (given: %v present: %v)`, topic.Spec.ReplicationFactor, existing.ReplicationFactor)))
+						fmt.Sprintf(`When creating KafkaTopic CR for existing topic, initially its replication factor must be the same as what the existing kafka topic has (given: %v present: %v)`, topic.Spec.ReplicationFactor, existing.ReplicationFactor)))
 				}
 
 				if diff := cmp.Diff(existing.ConfigEntries, util.MapStringStringPointer(topic.Spec.Config), cmpopts.EquateEmpty()); diff != "" {
 					allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("config"), topic.Spec.Partitions,
-						fmt.Sprintf(`initial KafkaTopic configuration must be the same as what the existing kafka topic configuration.
+						fmt.Sprintf(`When creating KafkaTopic CR for existing topic, initially its configuration must be the same as the existing kafka topic configuration.
 						Difference: %s`, diff)))
 				}
 

--- a/pkg/webhooks/kafkatopic_validator.go
+++ b/pkg/webhooks/kafkatopic_validator.go
@@ -173,7 +173,7 @@ func (s *KafkaTopicValidator) checkKafka(ctx context.Context, topic *banzaicloud
 				if manager, ok := topic.GetAnnotations()[TopicManagedByAnnotationKey]; !ok || strings.ToLower(manager) != TopicManagedByKoperatorAnnotationValue {
 					allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("name"), topic.Spec.Name,
 						fmt.Sprintf(`topic "%s" already exists on kafka cluster and it is not managed by Koperator,
-					if you want it to be managed by Koperator so you can modify its configurations through a KafkaTopic CR,,
+					if you want it to be managed by Koperator so you can modify its configurations through a KafkaTopic CR,
 					add this "%s: %s" annotation to this KafkaTopic CR`, topic.Spec.Name, TopicManagedByAnnotationKey, TopicManagedByKoperatorAnnotationValue)))
 				}
 				// Comparing KafkaTopic configuration with the existing

--- a/pkg/webhooks/kafkatopic_validator.go
+++ b/pkg/webhooks/kafkatopic_validator.go
@@ -39,8 +39,8 @@ import (
 )
 
 const (
-	ManagedByAnnotationKey   = "managedBy"
-	ManagedByAnnotationValue = "koperator"
+	TopicManagedByKoperatorAnnotationKey   = "managedBy"
+	TopicManagedByKoperatorAnnotationValue = "koperator"
 )
 
 type KafkaTopicValidator struct {
@@ -169,11 +169,11 @@ func (s *KafkaTopicValidator) checkKafka(ctx context.Context, topic *banzaicloud
 		if err := s.Client.Get(ctx, types.NamespacedName{Name: topic.Name, Namespace: topic.Namespace}, topicCR); err != nil {
 			// Checking that the validation request is update
 			if apierrors.IsNotFound(err) {
-				if manager, ok := topic.GetAnnotations()[ManagedByAnnotationKey]; !ok || strings.ToLower(manager) != ManagedByAnnotationValue {
+				if manager, ok := topic.GetAnnotations()[TopicManagedByKoperatorAnnotationKey]; !ok || strings.ToLower(manager) != TopicManagedByKoperatorAnnotationValue {
 					allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("name"), topic.Spec.Name,
 						fmt.Sprintf(`topic "%s" already exists on kafka cluster and it is not managed by Koperator,
 					when you want to be managed by Koperator to be able to modify its configuration through KafkaTopic CR,
-					add this "%s: %s" annotation for this KafkaTopic CR`, topic.Spec.Name, ManagedByAnnotationKey, ManagedByAnnotationValue)))
+					add this "%s: %s" annotation for this KafkaTopic CR`, topic.Spec.Name, TopicManagedByKoperatorAnnotationKey, TopicManagedByKoperatorAnnotationValue)))
 				}
 				// Comparing KafkaTopic configuration with the Kafka topic
 				if existing.NumPartitions != topic.Spec.Partitions {
@@ -187,7 +187,7 @@ func (s *KafkaTopicValidator) checkKafka(ctx context.Context, topic *banzaicloud
 
 				if diff := cmp.Diff(existing.ConfigEntries, util.MapStringStringPointer(topic.Spec.Config), cmpopts.EquateEmpty()); diff != "" {
 					allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("config"), topic.Spec.Partitions,
-						fmt.Sprintf(`initial KafkaTopic configuration must be the same as the already exist kafka topic configuration (difference: %s`, diff)))
+						fmt.Sprintf(`initial KafkaTopic configuration must be the same as the already exist kafka topic configuration difference: %s`, diff)))
 				}
 
 				if len(allErrs) > 0 {

--- a/pkg/webhooks/kafkatopic_validator.go
+++ b/pkg/webhooks/kafkatopic_validator.go
@@ -178,16 +178,16 @@ func (s *KafkaTopicValidator) checkKafka(ctx context.Context, topic *banzaicloud
 				// Comparing KafkaTopic configuration with the Kafka topic
 				if existing.NumPartitions != topic.Spec.Partitions {
 					allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("partitions"), topic.Spec.Partitions,
-						fmt.Sprintf(`initial KafkaTopic configuration must be the same as the already exist kafka topic configuration (partitions: given: %v present: %v)`, topic.Spec.Partitions, existing.NumPartitions)))
+						fmt.Sprintf(`initial KafkaTopic partition number must be the same as the already exist kafka topic has  (given: %v present: %v)`, topic.Spec.Partitions, existing.NumPartitions)))
 				}
 				if existing.ReplicationFactor != int16(topic.Spec.ReplicationFactor) {
-					allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("partitions"), topic.Spec.Partitions,
-						fmt.Sprintf(`initial KafkaTopic configuration must be the same as the already exist kafka topic configuration (replication factor: given: %v present: %v)`, topic.Spec.Partitions, existing.NumPartitions)))
+					allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("replicationfactor"), topic.Spec.ReplicationFactor,
+						fmt.Sprintf(`initial KafkaTopic replication factor must be the same as the already exist kafka topic has (given: %v present: %v)`, topic.Spec.ReplicationFactor, existing.ReplicationFactor)))
 				}
 
 				if diff := cmp.Diff(existing.ConfigEntries, util.MapStringStringPointer(topic.Spec.Config), cmpopts.EquateEmpty()); diff != "" {
 					allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("config"), topic.Spec.Partitions,
-						fmt.Sprintf(`initial KafkaTopic configuration must be the same as the already exist kafka topic configuration (topic configuration differs from the present topic: %s`, diff)))
+						fmt.Sprintf(`initial KafkaTopic configuration must be the same as the already exist kafka topic configuration (difference: %s`, diff)))
 				}
 
 				if len(allErrs) > 0 {

--- a/pkg/webhooks/kafkatopic_validator.go
+++ b/pkg/webhooks/kafkatopic_validator.go
@@ -39,7 +39,7 @@ import (
 )
 
 const (
-	TopicManagedByKoperatorAnnotationKey   = "managedBy"
+	TopicManagedByAnnotationKey            = "managedBy"
 	TopicManagedByKoperatorAnnotationValue = "koperator"
 )
 
@@ -169,11 +169,11 @@ func (s *KafkaTopicValidator) checkKafka(ctx context.Context, topic *banzaicloud
 		if err := s.Client.Get(ctx, types.NamespacedName{Name: topic.Name, Namespace: topic.Namespace}, topicCR); err != nil {
 			// Checking that the validation request is update
 			if apierrors.IsNotFound(err) {
-				if manager, ok := topic.GetAnnotations()[TopicManagedByKoperatorAnnotationKey]; !ok || strings.ToLower(manager) != TopicManagedByKoperatorAnnotationValue {
+				if manager, ok := topic.GetAnnotations()[TopicManagedByAnnotationKey]; !ok || strings.ToLower(manager) != TopicManagedByKoperatorAnnotationValue {
 					allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("name"), topic.Spec.Name,
 						fmt.Sprintf(`topic "%s" already exists on kafka cluster and it is not managed by Koperator,
 					when you want to be managed by Koperator to be able to modify its configuration through KafkaTopic CR,
-					add this "%s: %s" annotation for this KafkaTopic CR`, topic.Spec.Name, TopicManagedByKoperatorAnnotationKey, TopicManagedByKoperatorAnnotationValue)))
+					add this "%s: %s" annotation for this KafkaTopic CR`, topic.Spec.Name, TopicManagedByAnnotationKey, TopicManagedByKoperatorAnnotationValue)))
 				}
 				// Comparing KafkaTopic configuration with the Kafka topic
 				if existing.NumPartitions != topic.Spec.Partitions {

--- a/pkg/webhooks/kafkatopic_validator_test.go
+++ b/pkg/webhooks/kafkatopic_validator_test.go
@@ -203,7 +203,6 @@ func TestCheckKafkaTopicExist(t *testing.T) {
 					t.Errorf("missing error: %s from: %s", err, fieldErrorList.ToAggregate().Error())
 				}
 			}
-
 		})
 	}
 }

--- a/pkg/webhooks/kafkatopic_validator_test.go
+++ b/pkg/webhooks/kafkatopic_validator_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/banzaicloud/koperator/api/v1beta1"
 	"github.com/banzaicloud/koperator/pkg/kafkaclient"
 	"github.com/banzaicloud/koperator/pkg/util"
+	"github.com/go-logr/logr"
 )
 
 func newMockCluster() *v1beta1.KafkaCluster {
@@ -218,7 +219,7 @@ func TestValidateTopic(t *testing.T) {
 	}
 
 	// Test non-existent kafka cluster
-	fieldErrorList, err := kafkaTopicValidator.validateKafkaTopic(context.Background(), topic)
+	fieldErrorList, err := kafkaTopicValidator.validateKafkaTopic(context.Background(), logr.Discard(), topic)
 	if err != nil {
 		t.Errorf("err should be nil, got: %s", err)
 	}
@@ -239,7 +240,7 @@ func TestValidateTopic(t *testing.T) {
 	topic.Spec.Partitions = 2
 
 	// Test kafka topic with invalid replication factor
-	fieldErrorList, err = kafkaTopicValidator.validateKafkaTopic(context.Background(), topic)
+	fieldErrorList, err = kafkaTopicValidator.validateKafkaTopic(context.Background(), logr.Discard(), topic)
 	if err != nil {
 		t.Errorf("err should be nil, got: %s", err)
 	}
@@ -253,7 +254,7 @@ func TestValidateTopic(t *testing.T) {
 	// test topic marked for deletion
 	now := metav1.Now()
 	topic.SetDeletionTimestamp(&now)
-	fieldErrorList, err = kafkaTopicValidator.validateKafkaTopic(context.Background(), topic)
+	fieldErrorList, err = kafkaTopicValidator.validateKafkaTopic(context.Background(), logr.Discard(), topic)
 	if err != nil {
 		t.Errorf("err should be nil, got: %s", err)
 	}
@@ -266,7 +267,7 @@ func TestValidateTopic(t *testing.T) {
 	// test cluster marked for deletion
 	cluster.SetDeletionTimestamp(&now)
 
-	fieldErrorList, err = kafkaTopicValidator.validateKafkaTopic(context.Background(), topic)
+	fieldErrorList, err = kafkaTopicValidator.validateKafkaTopic(context.Background(), logr.Discard(), topic)
 	if err != nil {
 		t.Errorf("err should be nil, got: %s", err)
 	}
@@ -281,7 +282,7 @@ func TestValidateTopic(t *testing.T) {
 	}
 
 	// test no rejection reasons
-	fieldErrorList, err = kafkaTopicValidator.validateKafkaTopic(context.Background(), topic)
+	fieldErrorList, err = kafkaTopicValidator.validateKafkaTopic(context.Background(), logr.Discard(), topic)
 	if err != nil {
 		t.Errorf("err should be nil, got: %s", err)
 	}
@@ -293,7 +294,7 @@ func TestValidateTopic(t *testing.T) {
 
 	// Replication factor larger than num brokers
 	topic.Spec.ReplicationFactor = 2
-	fieldErrorList, err = kafkaTopicValidator.validateKafkaTopic(context.Background(), topic)
+	fieldErrorList, err = kafkaTopicValidator.validateKafkaTopic(context.Background(), logr.Discard(), topic)
 	if err != nil {
 		t.Errorf("err should be nil, got: %s", err)
 	}
@@ -316,11 +317,11 @@ func TestValidateTopic(t *testing.T) {
 
 	// partition decrease attempt
 	topic.Spec.Partitions = 1
-	fieldErrorList, err = kafkaTopicValidator.validateKafkaTopic(context.Background(), topic)
+	fieldErrorList, err = kafkaTopicValidator.validateKafkaTopic(context.Background(), logr.Discard(), topic)
 	if err != nil {
 		t.Errorf("err should be nil, got: %s", err)
 	}
-	// TODO BUG
+
 	if len(fieldErrorList) != 1 {
 		t.Error("Expected not allowed due to partition decrease, got allowed")
 	} else if !strings.Contains(fieldErrorList.ToAggregate().Error(), "kafka does not support decreasing partition count on an existing") {
@@ -330,7 +331,7 @@ func TestValidateTopic(t *testing.T) {
 	// replication factor change attempt
 	topic.Spec.Partitions = 2
 	topic.Spec.ReplicationFactor = 2
-	fieldErrorList, err = kafkaTopicValidator.validateKafkaTopic(context.Background(), topic)
+	fieldErrorList, err = kafkaTopicValidator.validateKafkaTopic(context.Background(), logr.Discard(), topic)
 	if err != nil {
 		t.Errorf("err should be nil, got: %s", err)
 	}

--- a/pkg/webhooks/kafkatopic_validator_test.go
+++ b/pkg/webhooks/kafkatopic_validator_test.go
@@ -188,7 +188,7 @@ func TestCheckKafkaTopicExist(t *testing.T) {
 					ClusterRef:        v1alpha1.ClusterReference{},
 				},
 			},
-			expectedErrors: []string{"configuration difference"},
+			expectedErrors: []string{"its configuration must be"},
 		},
 	}
 

--- a/pkg/webhooks/kafkatopic_validator_test.go
+++ b/pkg/webhooks/kafkatopic_validator_test.go
@@ -28,11 +28,12 @@ import (
 
 	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/go-logr/logr"
+
 	"github.com/banzaicloud/koperator/api/v1alpha1"
 	"github.com/banzaicloud/koperator/api/v1beta1"
 	"github.com/banzaicloud/koperator/pkg/kafkaclient"
 	"github.com/banzaicloud/koperator/pkg/util"
-	"github.com/go-logr/logr"
 )
 
 func newMockCluster() *v1beta1.KafkaCluster {

--- a/pkg/webhooks/kafkatopic_validator_test.go
+++ b/pkg/webhooks/kafkatopic_validator_test.go
@@ -95,7 +95,7 @@ func TestCheckKafkaTopicExist(t *testing.T) {
 			testName: "topic configuration is same and managedBy koperator",
 			kafkaTopic: v1alpha1.KafkaTopic{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{TopicManagedByKoperatorAnnotationKey: TopicManagedByKoperatorAnnotationValue},
+					Annotations: map[string]string{TopicManagedByAnnotationKey: TopicManagedByKoperatorAnnotationValue},
 				},
 				Spec: v1alpha1.KafkaTopicSpec{
 					Name:              "test-topic",
@@ -121,13 +121,13 @@ func TestCheckKafkaTopicExist(t *testing.T) {
 					ClusterRef:        v1alpha1.ClusterReference{},
 				},
 			},
-			expectedErrors: []string{TopicManagedByKoperatorAnnotationKey},
+			expectedErrors: []string{TopicManagedByAnnotationKey},
 		},
 		{
 			testName: "topic replication factor is different and managedBy koperator",
 			kafkaTopic: v1alpha1.KafkaTopic{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{TopicManagedByKoperatorAnnotationKey: TopicManagedByKoperatorAnnotationValue},
+					Annotations: map[string]string{TopicManagedByAnnotationKey: TopicManagedByKoperatorAnnotationValue},
 				},
 				Spec: v1alpha1.KafkaTopicSpec{
 					Name:              "test-topic",
@@ -143,7 +143,7 @@ func TestCheckKafkaTopicExist(t *testing.T) {
 			testName: "topic partition is different and managedBy koperator",
 			kafkaTopic: v1alpha1.KafkaTopic{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{TopicManagedByKoperatorAnnotationKey: TopicManagedByKoperatorAnnotationValue},
+					Annotations: map[string]string{TopicManagedByAnnotationKey: TopicManagedByKoperatorAnnotationValue},
 				},
 				Spec: v1alpha1.KafkaTopicSpec{
 					Name:              "test-topic",
@@ -160,7 +160,7 @@ func TestCheckKafkaTopicExist(t *testing.T) {
 			testName: "topic partition and replication is different and not managedBy koperator",
 			kafkaTopic: v1alpha1.KafkaTopic{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{TopicManagedByKoperatorAnnotationKey: TopicManagedByKoperatorAnnotationValue},
+					Annotations: map[string]string{TopicManagedByAnnotationKey: TopicManagedByKoperatorAnnotationValue},
 				},
 				Spec: v1alpha1.KafkaTopicSpec{
 					Name:              "test-topic",
@@ -170,13 +170,13 @@ func TestCheckKafkaTopicExist(t *testing.T) {
 					ClusterRef:        v1alpha1.ClusterReference{},
 				},
 			},
-			expectedErrors: []string{"replication", "partition", TopicManagedByKoperatorAnnotationKey},
+			expectedErrors: []string{"replication", "partition", TopicManagedByAnnotationKey},
 		},
 		{
 			testName: "topic configuration is different and managedBy koperator",
 			kafkaTopic: v1alpha1.KafkaTopic{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{TopicManagedByKoperatorAnnotationKey: TopicManagedByKoperatorAnnotationValue},
+					Annotations: map[string]string{TopicManagedByAnnotationKey: TopicManagedByKoperatorAnnotationValue},
 				},
 				Spec: v1alpha1.KafkaTopicSpec{
 					Name:              "test-topic",


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no |
| New feature?    | yes |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
It allows to create a KafkaTopic CR when the referenced topic is already present on the Kafka cluster. 
It allows when KafkaTopic CR:
-  has managedBy: koperator annotation 
-  configuration is the same as the present kafka topic configuration
otherwise the KafkaTopic CR will be rejected by validation webhook.
There is a new status field "managedBy" which value is the manager of the kafka topic

When the KafkaTopic CR has "managedBy" annotation with not "koperator" value and the KafkaTopic CR is deleted or modified then the present kafka topic will not be affected in the kafka cluster. 


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Let the user create KafkaTopic resources for that topic which is already on the Kafka cluster
Users can modify the topic configuration and partition number for that topic through the created KafkaTopic CR

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)

### More details
When the KafkaTopic rejected the above error message is an example:
```code
The KafkaTopic "ccmetrics" is invalid:
* spec.name: Invalid value: "__CruiseControlMetrics": topic "__CruiseControlMetrics" already exists on kafka cluster and it is not managed by Koperator,
					when you want to be managed by Koperator to be able to modify its configuration through KafkaTopic CR,
					add this "managedBy: koperator" annotation for this KafkaTopic CR
* spec.partitions: Invalid value: 3: initial KafkaTopic partition number must be the same as the already exist kafka topic has  (given: 3 present: 12)
* spec.replicationfactor: Invalid value: 3: initial KafkaTopic replication factor must be the same as the already exist kafka topic has (given: 3 present: 2)
* spec.config: Invalid value: 3: initial KafkaTopic configuration must be the same as the already exist kafka topic configuration (difference:   map[string]*string{
  	"cleanup.policy":      &"delete",
- 	"min.insync.replicas": &"1",
- 	"retention.ms":        &"18000000",
+ 	"retention.ms":        &"604800000",
  }
```