### PR TITLE
Fix TestCheckKafkaTopicExist

### DIFF
--- a/pkg/webhooks/kafkatopic_validator_test.go
+++ b/pkg/webhooks/kafkatopic_validator_test.go
@@ -162,7 +162,7 @@ func TestCheckKafkaTopicExist(t *testing.T) {
 			testName: "topic partition and replication is different and not managedBy koperator",
 			kafkaTopic: v1alpha1.KafkaTopic{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{TopicManagedByAnnotationKey: TopicManagedByKoperatorAnnotationValue},
+					Annotations: map[string]string{TopicManagedByAnnotationKey: "other"},
 				},
 				Spec: v1alpha1.KafkaTopicSpec{
 					Name:              "test-topic",
@@ -193,6 +193,7 @@ func TestCheckKafkaTopicExist(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
+		testCase := testCase
 		t.Run(testCase.testName, func(t *testing.T) {
 			t.Parallel()
 			fieldErrorList, err := kafkaTopicValidator.checkKafka(context.Background(), &testCase.kafkaTopic, cluster)


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Fix test for that case when the Kafka topic exist on the Kafka cluster and we want to create KafkaTopic Cr for that.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
The current implementation only checks the last case from the test cases and there is  a wrong test.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Implementation tested