### PR TITLE
Envoy and Cruisecontrol custom label addition

### DIFF
--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -265,6 +265,9 @@ type CruiseControlConfig struct {
 	//  Annotations to be applied to CruiseControl pod
 	// +optional
 	CruiseControlAnnotations map[string]string `json:"cruiseControlAnnotations,omitempty"`
+	//  Labels to be applied to CruiseControl pod
+	// +optional
+	CruiseControlLabels map[string]string `json:"cruiseControlLabels,omitempty"`
 	// InitContainers add extra initContainers to CruiseControl pod
 	InitContainers []corev1.Container `json:"initContainers,omitempty"`
 	// Volumes define some extra Kubernetes Volumes for the CruiseControl Pods.
@@ -330,6 +333,8 @@ type EnvoyConfig struct {
 	Tolerations  []corev1.Toleration `json:"tolerations,omitempty"`
 	// Annotations defines the annotations placed on the envoy ingress controller deployment
 	Annotations map[string]string `json:"annotations,omitempty"`
+	// Labels defines the labels placed on the envoy ingress controller deployment
+	Labels map[string]string `json:"labels,omitempty"`
 	// If specified and supported by the platform, traffic through the
 	// cloud-provider load-balancer will be restricted to the specified client
 	// IPs. This field will be ignored if the

--- a/charts/kafka-operator/templates/crds.yaml
+++ b/charts/kafka-operator/templates/crds.yaml
@@ -12537,6 +12537,11 @@ spec:
                     type: object
                   cruiseControlEndpoint:
                     type: string
+                  cruiseControlLabels:
+                    additionalProperties:
+                      type: string
+                    description: Labels to be applied to CruiseControl pod
+                    type: object
                   cruiseControlOperationSpec:
                     description: CruiseControlOperationSpec specifies the configuration
                       of the CruiseControlOperation handling
@@ -16832,6 +16837,12 @@ spec:
                       type: object
                       x-kubernetes-map-type: atomic
                     type: array
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels defines the labels placed on the
+                      envoy ingress controller deployment
+                    type: object
                   loadBalancerIP:
                     description: LoadBalancerIP can be used to specify an exact IP
                       for the LoadBalancer service


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no |
| New feature?    | yes |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | fixes #945 , partially #Y, mentioned in #Z |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Envoy and Cruisecontrol pods are not accepting customized labels. So added them and updated CRD to accept the labels for the pods.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
This will enable the custom labels addition support on envoy and cruisecontrol pods.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Implementation tested
- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [ ] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
