### PR TITLE
Fix: unused ingress resources cleanup for external listeners

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/banzaicloud/istio-client-go v0.0.17
 	github.com/banzaicloud/istio-operator/api/v2 v2.15.1
 	github.com/banzaicloud/k8s-objectmatcher v1.8.0
-	github.com/banzaicloud/koperator/api v0.23.2
+	github.com/banzaicloud/koperator/api v0.24.0
 	github.com/banzaicloud/koperator/properties v0.4.1
 	github.com/cert-manager/cert-manager v1.9.1
 	github.com/cisco-open/cluster-registry-controller/api v0.2.5
@@ -47,7 +47,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
-	github.com/banzaicloud/operator-tools v0.28.0 // indirect
+	github.com/banzaicloud/operator-tools v0.28.0
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/briandowns/spinner v1.12.0 // indirect
 	github.com/census-instrumentation/opencensus-proto v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/banzaicloud/istio-operator/api/v2 v2.15.1 h1:BZg8COvoOJtfx/dgN7KpoOnc
 github.com/banzaicloud/istio-operator/api/v2 v2.15.1/go.mod h1:5qCpwWlIfxiLvBfTvT2mD2wp5RlFCDEt8Xql4sYPNBc=
 github.com/banzaicloud/k8s-objectmatcher v1.8.0 h1:Nugn25elKtPMTA2br+JgHNeSQ04sc05MDPmpJnd1N2A=
 github.com/banzaicloud/k8s-objectmatcher v1.8.0/go.mod h1:p2LSNAjlECf07fbhDyebTkPUIYnU05G+WfGgkTmgeMg=
-github.com/banzaicloud/koperator/api v0.23.2 h1:4K0FbGaefM3673GptjYO0XuthECu0S7zn389IAF5VLU=
-github.com/banzaicloud/koperator/api v0.23.2/go.mod h1:qvpewvjdELAnfO70vg9397CXZ4K4uHxpiWtf5fhKSrQ=
+github.com/banzaicloud/koperator/api v0.24.0 h1:RwhKWy8umzpKhKEa0J6xgvv5wOU37ti3A9JqIjCHrDk=
+github.com/banzaicloud/koperator/api v0.24.0/go.mod h1:qvpewvjdELAnfO70vg9397CXZ4K4uHxpiWtf5fhKSrQ=
 github.com/banzaicloud/koperator/properties v0.4.1 h1:SB2QgXlcK1Dc7Z1rg65PJifErDa8OQnoWCCJgmC7SGc=
 github.com/banzaicloud/koperator/properties v0.4.1/go.mod h1:TcL+llxuhW3UeQtVEDYEXGouFLF2P+LuZZVudSb6jyA=
 github.com/banzaicloud/operator-tools v0.28.0 h1:GSfc0qZr6zo7WrNxdgWZE1LcTChPU8QFYOTDirYVtIM=

--- a/pkg/resources/envoy/envoy.go
+++ b/pkg/resources/envoy/envoy.go
@@ -97,55 +97,57 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 				}
 			}
 		} else {
-			// Cleaning up unused envoy resources when ingress controller is not envoy or externalListener access method is not LoadBalancer
-			deletionCounter := 0
-			ctx := context.Background()
-			envoyResourcesGVK := []schema.GroupVersionKind{
-				{
-					Version: corev1.SchemeGroupVersion.Version,
-					Group:   corev1.SchemeGroupVersion.Group,
-					Kind:    reflect.TypeOf(corev1.Service{}).Name(),
-				},
-				{
-					Version: corev1.SchemeGroupVersion.Version,
-					Group:   corev1.SchemeGroupVersion.Group,
-					Kind:    reflect.TypeOf(corev1.ConfigMap{}).Name(),
-				},
-				{
-					Version: appsv1.SchemeGroupVersion.Version,
-					Group:   appsv1.SchemeGroupVersion.Group,
-					Kind:    reflect.TypeOf(appsv1.Deployment{}).Name(),
-				},
-				{
-					Version: policyv1.SchemeGroupVersion.Version,
-					Group:   policyv1.SchemeGroupVersion.Group,
-					Kind:    reflect.TypeOf(policyv1.PodDisruptionBudget{}).Name(),
-				},
-			}
-			var envoyResources unstructured.UnstructuredList
-			for _, gvk := range envoyResourcesGVK {
-				envoyResources.SetGroupVersionKind(gvk)
-
-				if err := r.List(ctx, &envoyResources, client.InNamespace(r.KafkaCluster.GetNamespace()),
-					client.MatchingLabels(labelsForEnvoyIngressWithoutEListenerName(r.KafkaCluster.Name))); err != nil {
-					return errors.Wrap(err, "error when getting list of envoy ingress resources for deletion")
+			if r.KafkaCluster.Spec.RemoveUnusedIngressResources {
+				// Cleaning up unused envoy resources when ingress controller is not envoy or externalListener access method is not LoadBalancer
+				deletionCounter := 0
+				ctx := context.Background()
+				envoyResourcesGVK := []schema.GroupVersionKind{
+					{
+						Version: corev1.SchemeGroupVersion.Version,
+						Group:   corev1.SchemeGroupVersion.Group,
+						Kind:    reflect.TypeOf(corev1.Service{}).Name(),
+					},
+					{
+						Version: corev1.SchemeGroupVersion.Version,
+						Group:   corev1.SchemeGroupVersion.Group,
+						Kind:    reflect.TypeOf(corev1.ConfigMap{}).Name(),
+					},
+					{
+						Version: appsv1.SchemeGroupVersion.Version,
+						Group:   appsv1.SchemeGroupVersion.Group,
+						Kind:    reflect.TypeOf(appsv1.Deployment{}).Name(),
+					},
+					{
+						Version: policyv1.SchemeGroupVersion.Version,
+						Group:   policyv1.SchemeGroupVersion.Group,
+						Kind:    reflect.TypeOf(policyv1.PodDisruptionBudget{}).Name(),
+					},
 				}
+				var envoyResources unstructured.UnstructuredList
+				for _, gvk := range envoyResourcesGVK {
+					envoyResources.SetGroupVersionKind(gvk)
 
-				for _, removeObject := range envoyResources.Items {
-					if !strings.Contains(removeObject.GetLabels()[util.ExternalListenerLabelNameKey], eListener.Name) ||
-						util.ObjectManagedByClusterRegistry(&removeObject) ||
-						!removeObject.GetDeletionTimestamp().IsZero() {
-						continue
+					if err := r.List(ctx, &envoyResources, client.InNamespace(r.KafkaCluster.GetNamespace()),
+						client.MatchingLabels(labelsForEnvoyIngressWithoutEListenerName(r.KafkaCluster.Name))); err != nil {
+						return errors.Wrap(err, "error when getting list of envoy ingress resources for deletion")
 					}
-					if err := r.Delete(ctx, &removeObject); client.IgnoreNotFound(err) != nil {
-						return errors.Wrap(err, "error when removing envoy ingress resources")
+
+					for _, removeObject := range envoyResources.Items {
+						if !strings.Contains(removeObject.GetLabels()[util.ExternalListenerLabelNameKey], eListener.Name) ||
+							util.ObjectManagedByClusterRegistry(&removeObject) ||
+							!removeObject.GetDeletionTimestamp().IsZero() {
+							continue
+						}
+						if err := r.Delete(ctx, &removeObject); client.IgnoreNotFound(err) != nil {
+							return errors.Wrap(err, "error when removing envoy ingress resources")
+						}
+						log.V(1).Info(fmt.Sprintf("Deleted envoy ingress '%s' resource '%s' for externalListener '%s'", gvk.Kind, removeObject.GetName(), eListener.Name))
+						deletionCounter++
 					}
-					log.V(1).Info(fmt.Sprintf("Deleted envoy ingress '%s' resource '%s' for externalListener '%s'", gvk.Kind, removeObject.GetName(), eListener.Name))
-					deletionCounter++
 				}
-			}
-			if deletionCounter > 0 {
-				log.Info(fmt.Sprintf("Removed '%d' resources for envoy ingress", deletionCounter))
+				if deletionCounter > 0 {
+					log.Info(fmt.Sprintf("Removed '%d' resources for envoy ingress", deletionCounter))
+				}
 			}
 		}
 	}

--- a/pkg/resources/envoy/envoy.go
+++ b/pkg/resources/envoy/envoy.go
@@ -37,14 +37,10 @@ import (
 	envoyutils "github.com/banzaicloud/koperator/pkg/util/envoy"
 )
 
-const (
-	eListenerLabelNameKey = "eListenerName"
-)
-
 // labelsForEnvoyIngress returns the labels for selecting the resources
 // belonging to the given kafka CR name.
 func labelsForEnvoyIngress(crName, eLName string) map[string]string {
-	return apiutil.MergeLabels(labelsForEnvoyIngressWithoutEListenerName(crName), map[string]string{eListenerLabelNameKey: eLName})
+	return apiutil.MergeLabels(labelsForEnvoyIngressWithoutEListenerName(crName), map[string]string{util.ExternalListenerLabelNameKey: eLName})
 }
 
 func labelsForEnvoyIngressWithoutEListenerName(crName string) map[string]string {
@@ -136,7 +132,7 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 				}
 
 				for _, removeObject := range envoyResources.Items {
-					if !strings.Contains(removeObject.GetLabels()[eListenerLabelNameKey], eListener.Name) ||
+					if !strings.Contains(removeObject.GetLabels()[util.ExternalListenerLabelNameKey], eListener.Name) ||
 						util.ObjectManagedByClusterRegistry(&removeObject) ||
 						!removeObject.GetDeletionTimestamp().IsZero() {
 						continue

--- a/pkg/resources/envoy/envoy.go
+++ b/pkg/resources/envoy/envoy.go
@@ -15,22 +15,39 @@
 package envoy
 
 import (
-	corev1 "k8s.io/api/core/v1"
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
 
+	"emperror.dev/errors"
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiutil "github.com/banzaicloud/koperator/api/util"
 	"github.com/banzaicloud/koperator/api/v1beta1"
 	"github.com/banzaicloud/koperator/pkg/k8sutil"
 	"github.com/banzaicloud/koperator/pkg/resources"
 	"github.com/banzaicloud/koperator/pkg/util"
 	envoyutils "github.com/banzaicloud/koperator/pkg/util/envoy"
+)
 
-	"github.com/go-logr/logr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+const (
+	eListenerLabelNameKey = "eListenerName"
 )
 
 // labelsForEnvoyIngress returns the labels for selecting the resources
 // belonging to the given kafka CR name.
 func labelsForEnvoyIngress(crName, eLName string) map[string]string {
-	return map[string]string{v1beta1.AppLabelKey: "envoyingress", "eListenerName": eLName, v1beta1.KafkaCRLabelKey: crName}
+	return apiutil.MergeLabels(labelsForEnvoyIngressWithoutEListenerName(crName), map[string]string{eListenerLabelNameKey: eLName})
+}
+
+func labelsForEnvoyIngressWithoutEListenerName(crName string) map[string]string {
+	return map[string]string{v1beta1.AppLabelKey: "envoyingress", v1beta1.KafkaCRLabelKey: crName}
 }
 
 // Reconciler implements the Component Reconciler
@@ -53,41 +70,82 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 	log = log.WithValues("component", envoyutils.ComponentName)
 
 	log.V(1).Info("Reconciling")
+	for _, eListener := range r.KafkaCluster.Spec.ListenersConfig.ExternalListeners {
+		if r.KafkaCluster.Spec.GetIngressController() == envoyutils.IngressControllerName && eListener.GetAccessMethod() == corev1.ServiceTypeLoadBalancer {
+			ingressConfigs, defaultControllerName, err := util.GetIngressConfigs(r.KafkaCluster.Spec, eListener)
+			if err != nil {
+				return err
+			}
+			var externalListenerResources []resources.ResourceWithLogAndExternalListenerSpecificInfos
+			externalListenerResources = append(externalListenerResources,
+				r.service,
+				r.configMap,
+				r.deployment,
+			)
 
-	if r.KafkaCluster.Spec.GetIngressController() == envoyutils.IngressControllerName {
-		for _, eListener := range r.KafkaCluster.Spec.ListenersConfig.ExternalListeners {
-			if eListener.GetAccessMethod() == corev1.ServiceTypeLoadBalancer {
-				ingressConfigs, defaultControllerName, err := util.GetIngressConfigs(r.KafkaCluster.Spec, eListener)
-				if err != nil {
-					return err
+			if r.KafkaCluster.Spec.EnvoyConfig.GetDistruptionBudget().DisruptionBudget.Create {
+				externalListenerResources = append(externalListenerResources, r.podDisruptionBudget)
+			}
+			for name, ingressConfig := range ingressConfigs {
+				if !util.IsIngressConfigInUse(name, defaultControllerName, r.KafkaCluster, log) {
+					continue
 				}
-				var externalListenerResources []resources.ResourceWithLogAndExternalListenerSpecificInfos
-				externalListenerResources = append(externalListenerResources,
-					r.service,
-					r.configMap,
-					r.deployment,
-				)
 
-				if r.KafkaCluster.Spec.EnvoyConfig.GetDistruptionBudget().DisruptionBudget.Create {
-					externalListenerResources = append(externalListenerResources, r.podDisruptionBudget)
-				}
-				for name, ingressConfig := range ingressConfigs {
-					if !util.IsIngressConfigInUse(name, defaultControllerName, r.KafkaCluster, log) {
-						continue
-					}
-
-					for _, res := range externalListenerResources {
-						o := res(log, eListener, ingressConfig, name, defaultControllerName)
-						err := k8sutil.Reconcile(log, r.Client, o, r.KafkaCluster)
-						if err != nil {
-							return err
-						}
+				for _, res := range externalListenerResources {
+					o := res(log, eListener, ingressConfig, name, defaultControllerName)
+					err := k8sutil.Reconcile(log, r.Client, o, r.KafkaCluster)
+					if err != nil {
+						return err
 					}
 				}
 			}
+		} else {
+			// Cleaning up unused envoy resources when ingress controller is not envoy or eListener access method is not LoadBalancer
+			deletionCounter := 0
+			ctx := context.Background()
+			envoyResourcesGVK := []schema.GroupVersionKind{
+				{
+					Version: corev1.SchemeGroupVersion.Version,
+					Group:   corev1.SchemeGroupVersion.Group,
+					Kind:    reflect.TypeOf(corev1.Service{}).Name(),
+				},
+				{
+					Version: corev1.SchemeGroupVersion.Version,
+					Group:   corev1.SchemeGroupVersion.Group,
+					Kind:    reflect.TypeOf(corev1.ConfigMap{}).Name(),
+				},
+				{
+					Version: appsv1.SchemeGroupVersion.Version,
+					Group:   appsv1.SchemeGroupVersion.Group,
+					Kind:    reflect.TypeOf(appsv1.Deployment{}).Name(),
+				},
+			}
+			var envoyResources unstructured.UnstructuredList
+			for _, gvk := range envoyResourcesGVK {
+				envoyResources.SetGroupVersionKind(gvk)
+
+				if err := r.List(ctx, &envoyResources, client.InNamespace(r.KafkaCluster.GetNamespace()),
+					client.MatchingLabels(labelsForEnvoyIngressWithoutEListenerName(r.KafkaCluster.Name))); err != nil {
+					return errors.Wrap(err, "error happened when getting list of envoy ingress resources for deletion")
+				}
+
+				for _, removeObject := range envoyResources.Items {
+					if !strings.Contains(removeObject.GetLabels()[eListenerLabelNameKey], eListener.Name) ||
+						util.ObjectManagedByClusterRegistry(&removeObject) ||
+						!removeObject.GetDeletionTimestamp().IsZero() {
+						continue
+					}
+					if err := r.Delete(ctx, &removeObject); client.IgnoreNotFound(err) != nil {
+						return errors.Wrap(err, "error happened when removing envoy ingress resources")
+					}
+					deletionCounter++
+				}
+			}
+			if deletionCounter > 0 {
+				log.Info(fmt.Sprintf("Removed '%d' resources for envoy ingress", deletionCounter))
+			}
 		}
 	}
-
 	log.V(1).Info("Reconciled")
 
 	return nil

--- a/pkg/resources/envoy/envoy.go
+++ b/pkg/resources/envoy/envoy.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -118,6 +119,11 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 					Version: appsv1.SchemeGroupVersion.Version,
 					Group:   appsv1.SchemeGroupVersion.Group,
 					Kind:    reflect.TypeOf(appsv1.Deployment{}).Name(),
+				},
+				{
+					Version: policyv1.SchemeGroupVersion.Version,
+					Group:   policyv1.SchemeGroupVersion.Group,
+					Kind:    reflect.TypeOf(policyv1.PodDisruptionBudget{}).Name(),
 				},
 			}
 			var envoyResources unstructured.UnstructuredList

--- a/pkg/resources/envoy/envoy.go
+++ b/pkg/resources/envoy/envoy.go
@@ -101,7 +101,7 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 				}
 			}
 		} else {
-			// Cleaning up unused envoy resources when ingress controller is not envoy or eListener access method is not LoadBalancer
+			// Cleaning up unused envoy resources when ingress controller is not envoy or externalListener access method is not LoadBalancer
 			deletionCounter := 0
 			ctx := context.Background()
 			envoyResourcesGVK := []schema.GroupVersionKind{
@@ -132,7 +132,7 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 
 				if err := r.List(ctx, &envoyResources, client.InNamespace(r.KafkaCluster.GetNamespace()),
 					client.MatchingLabels(labelsForEnvoyIngressWithoutEListenerName(r.KafkaCluster.Name))); err != nil {
-					return errors.Wrap(err, "error happened when getting list of envoy ingress resources for deletion")
+					return errors.Wrap(err, "error when getting list of envoy ingress resources for deletion")
 				}
 
 				for _, removeObject := range envoyResources.Items {
@@ -142,7 +142,7 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 						continue
 					}
 					if err := r.Delete(ctx, &removeObject); client.IgnoreNotFound(err) != nil {
-						return errors.Wrap(err, "error happened when removing envoy ingress resources")
+						return errors.Wrap(err, "error when removing envoy ingress resources")
 					}
 					deletionCounter++
 				}

--- a/pkg/resources/envoy/envoy.go
+++ b/pkg/resources/envoy/envoy.go
@@ -140,6 +140,7 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 					if err := r.Delete(ctx, &removeObject); client.IgnoreNotFound(err) != nil {
 						return errors.Wrap(err, "error when removing envoy ingress resources")
 					}
+					log.V(1).Info(fmt.Sprintf("Deleted envoy ingress '%s' resource '%s' for externalListener '%s'", gvk.Kind, removeObject.GetName(), eListener.Name))
 					deletionCounter++
 				}
 			}

--- a/pkg/resources/istioingress/istioingress.go
+++ b/pkg/resources/istioingress/istioingress.go
@@ -152,6 +152,7 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 					if err := r.Delete(ctx, &removeObject); client.IgnoreNotFound(err) != nil {
 						return errors.Wrap(err, "error when removing istio ingress resources")
 					}
+					log.V(1).Info(fmt.Sprintf("Deleted istio ingress '%s' resource '%s' for externalListener '%s'", gvk.Kind, removeObject.GetName(), eListener.Name))
 					deletionCounter++
 				}
 			}

--- a/pkg/resources/istioingress/istioingress.go
+++ b/pkg/resources/istioingress/istioingress.go
@@ -47,13 +47,12 @@ const (
 	gatewayNameTemplateWithScope    = "%s-%s-%s-gateway"
 	virtualServiceTemplate          = "%s-%s-virtualservice"
 	virtualServiceTemplateWithScope = "%s-%s-%s-virtualservice"
-	externalListenerLabelNameKey    = "eListenerName"
 )
 
 // labelsForIstioIngress returns the labels for selecting the resources
 // belonging to the given kafka CR name.
 func labelsForIstioIngress(crName, eLName, istioRevision string) map[string]string {
-	return utils.MergeLabels(labelsForIstioIngressWithoutEListenerName(crName, istioRevision), map[string]string{externalListenerLabelNameKey: eLName})
+	return utils.MergeLabels(labelsForIstioIngressWithoutEListenerName(crName, istioRevision), map[string]string{util.ExternalListenerLabelNameKey: eLName})
 }
 
 func labelsForIstioIngressWithoutEListenerName(crName, istioRevision string) map[string]string {
@@ -145,7 +144,7 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 				}
 
 				for _, removeObject := range istioResources.Items {
-					if !strings.Contains(removeObject.GetLabels()[externalListenerLabelNameKey], eListener.Name) ||
+					if !strings.Contains(removeObject.GetLabels()[util.ExternalListenerLabelNameKey], eListener.Name) ||
 						util.ObjectManagedByClusterRegistry(&removeObject) ||
 						!removeObject.GetDeletionTimestamp().IsZero() {
 						continue

--- a/pkg/resources/istioingress/istioingress.go
+++ b/pkg/resources/istioingress/istioingress.go
@@ -113,53 +113,51 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 					}
 				}
 			}
-		} else {
-			if r.KafkaCluster.Spec.RemoveUnusedIngressResources {
-				// Cleaning up unused istio resources when ingress controller is not istioingress or externalListener access method is not LoadBalancer
-				deletionCounter := 0
-				ctx := context.Background()
-				istioResourcesGVK := []schema.GroupVersionKind{
-					{
-						Version: istioOperatorApi.GroupVersion.Version,
-						Group:   istioOperatorApi.GroupVersion.Group,
-						Kind:    reflect.TypeOf(istioOperatorApi.IstioMeshGateway{}).Name(),
-					},
-					{
-						Version: istioclientv1beta1.SchemeGroupVersion.Version,
-						Group:   istioclientv1beta1.SchemeGroupVersion.Group,
-						Kind:    reflect.TypeOf(istioclientv1beta1.Gateway{}).Name(),
-					},
-					{
-						Version: istioclientv1beta1.SchemeGroupVersion.Version,
-						Group:   istioclientv1beta1.SchemeGroupVersion.Group,
-						Kind:    reflect.TypeOf(istioclientv1beta1.VirtualService{}).Name(),
-					},
-				}
-				var istioResources unstructured.UnstructuredList
-				for _, gvk := range istioResourcesGVK {
-					istioResources.SetGroupVersionKind(gvk)
+		} else if r.KafkaCluster.Spec.RemoveUnusedIngressResources {
+			// Cleaning up unused istio resources when ingress controller is not istioingress or externalListener access method is not LoadBalancer
+			deletionCounter := 0
+			ctx := context.Background()
+			istioResourcesGVK := []schema.GroupVersionKind{
+				{
+					Version: istioOperatorApi.GroupVersion.Version,
+					Group:   istioOperatorApi.GroupVersion.Group,
+					Kind:    reflect.TypeOf(istioOperatorApi.IstioMeshGateway{}).Name(),
+				},
+				{
+					Version: istioclientv1beta1.SchemeGroupVersion.Version,
+					Group:   istioclientv1beta1.SchemeGroupVersion.Group,
+					Kind:    reflect.TypeOf(istioclientv1beta1.Gateway{}).Name(),
+				},
+				{
+					Version: istioclientv1beta1.SchemeGroupVersion.Version,
+					Group:   istioclientv1beta1.SchemeGroupVersion.Group,
+					Kind:    reflect.TypeOf(istioclientv1beta1.VirtualService{}).Name(),
+				},
+			}
+			var istioResources unstructured.UnstructuredList
+			for _, gvk := range istioResourcesGVK {
+				istioResources.SetGroupVersionKind(gvk)
 
-					if err := r.List(ctx, &istioResources, client.InNamespace(r.KafkaCluster.GetNamespace()),
-						client.MatchingLabels(labelsForIstioIngressWithoutEListenerName(r.KafkaCluster.Name, ""))); err != nil && !apimeta.IsNoMatchError(err) {
-						return errors.Wrap(err, "error when getting list of istio ingress resources for deletion")
-					}
+				if err := r.List(ctx, &istioResources, client.InNamespace(r.KafkaCluster.GetNamespace()),
+					client.MatchingLabels(labelsForIstioIngressWithoutEListenerName(r.KafkaCluster.Name, ""))); err != nil && !apimeta.IsNoMatchError(err) {
+					return errors.Wrap(err, "error when getting list of istio ingress resources for deletion")
+				}
 
-					for _, removeObject := range istioResources.Items {
-						if !strings.Contains(removeObject.GetLabels()[util.ExternalListenerLabelNameKey], eListener.Name) ||
-							util.ObjectManagedByClusterRegistry(&removeObject) ||
-							!removeObject.GetDeletionTimestamp().IsZero() {
-							continue
-						}
-						if err := r.Delete(ctx, &removeObject); client.IgnoreNotFound(err) != nil {
-							return errors.Wrap(err, "error when removing istio ingress resources")
-						}
-						log.V(1).Info(fmt.Sprintf("Deleted istio ingress '%s' resource '%s' for externalListener '%s'", gvk.Kind, removeObject.GetName(), eListener.Name))
-						deletionCounter++
+				for _, removeObject := range istioResources.Items {
+					if !strings.Contains(removeObject.GetLabels()[util.ExternalListenerLabelNameKey], eListener.Name) ||
+						util.ObjectManagedByClusterRegistry(&removeObject) ||
+						!removeObject.GetDeletionTimestamp().IsZero() {
+						continue
 					}
+					if err := r.Delete(ctx, &removeObject); client.IgnoreNotFound(err) != nil {
+						return errors.Wrap(err, "error when removing istio ingress resources")
+					}
+					log.V(1).Info(fmt.Sprintf("Deleted istio ingress '%s' resource '%s' for externalListener '%s'", gvk.Kind, removeObject.GetName(), eListener.Name))
+					deletionCounter++
 				}
-				if deletionCounter > 0 {
-					log.Info(fmt.Sprintf("Removed '%d' resources for istio ingress", deletionCounter))
-				}
+			}
+			if deletionCounter > 0 {
+				log.Info(fmt.Sprintf("Removed '%d' resources for istio ingress", deletionCounter))
 			}
 		}
 	}

--- a/pkg/resources/istioingress/istioingress.go
+++ b/pkg/resources/istioingress/istioingress.go
@@ -15,11 +15,16 @@
 package istioingress
 
 import (
+	"context"
+	"fmt"
+	"reflect"
 	"strings"
 
 	"emperror.dev/errors"
 
+	istioclientv1beta1 "github.com/banzaicloud/istio-client-go/pkg/networking/v1beta1"
 	istioOperatorApi "github.com/banzaicloud/istio-operator/api/v2/v1alpha1"
+	"github.com/banzaicloud/operator-tools/pkg/utils"
 
 	"github.com/banzaicloud/koperator/api/v1beta1"
 	"github.com/banzaicloud/koperator/pkg/k8sutil"
@@ -28,6 +33,9 @@ import (
 	"github.com/banzaicloud/koperator/pkg/util/istioingress"
 
 	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -39,12 +47,17 @@ const (
 	gatewayNameTemplateWithScope    = "%s-%s-%s-gateway"
 	virtualServiceTemplate          = "%s-%s-virtualservice"
 	virtualServiceTemplateWithScope = "%s-%s-%s-virtualservice"
+	eListenerLabelNameKey           = "eListenerName"
 )
 
 // labelsForIstioIngress returns the labels for selecting the resources
 // belonging to the given kafka CR name.
 func labelsForIstioIngress(crName, eLName, istioRevision string) map[string]string {
-	labels := map[string]string{v1beta1.AppLabelKey: "istioingress", "eListenerName": eLName, v1beta1.KafkaCRLabelKey: crName}
+	return utils.MergeLabels(labelsForIstioIngressWithoutEListenerName(crName, istioRevision), map[string]string{eListenerLabelNameKey: eLName})
+}
+
+func labelsForIstioIngressWithoutEListenerName(crName, istioRevision string) map[string]string {
+	labels := map[string]string{v1beta1.AppLabelKey: "istioingress", v1beta1.KafkaCRLabelKey: crName}
 	if istioRevision != "" {
 		labels["istio.io/rev"] = istioRevision
 	}
@@ -70,38 +83,81 @@ func New(client client.Client, cluster *v1beta1.KafkaCluster) *Reconciler {
 func (r *Reconciler) Reconcile(log logr.Logger) error {
 	log = log.WithValues("component", componentName)
 	log.V(1).Info("Reconciling")
-	if r.KafkaCluster.Spec.GetIngressController() == istioingress.IngressControllerName {
-		for _, eListener := range r.KafkaCluster.Spec.ListenersConfig.ExternalListeners {
-			if eListener.GetAccessMethod() == corev1.ServiceTypeLoadBalancer {
-				if r.KafkaCluster.Spec.IstioControlPlane == nil {
-					log.Error(errors.NewPlain("reference to Istio Control Plane is missing"), "skip external listener reconciliation", "external listener", eListener.Name)
+
+	for _, eListener := range r.KafkaCluster.Spec.ListenersConfig.ExternalListeners {
+		if r.KafkaCluster.Spec.GetIngressController() == istioingress.IngressControllerName && eListener.GetAccessMethod() == corev1.ServiceTypeLoadBalancer {
+			if r.KafkaCluster.Spec.IstioControlPlane == nil {
+				log.Error(errors.NewPlain("reference to Istio Control Plane is missing"), "skip external listener reconciliation", "external listener", eListener.Name)
+				continue
+			}
+
+			istioRevision := istioOperatorApi.NamespacedRevision(
+				strings.ReplaceAll(r.KafkaCluster.Spec.IstioControlPlane.Name, ".", "-"),
+				r.KafkaCluster.Spec.IstioControlPlane.Namespace)
+			ingressConfigs, defaultControllerName, err := util.GetIngressConfigs(r.KafkaCluster.Spec, eListener)
+			if err != nil {
+				return err
+			}
+			for name, ingressConfig := range ingressConfigs {
+				if !util.IsIngressConfigInUse(name, defaultControllerName, r.KafkaCluster, log) {
 					continue
 				}
-
-				istioRevision := istioOperatorApi.NamespacedRevision(
-					strings.ReplaceAll(r.KafkaCluster.Spec.IstioControlPlane.Name, ".", "-"),
-					r.KafkaCluster.Spec.IstioControlPlane.Namespace)
-
-				ingressConfigs, defaultControllerName, err := util.GetIngressConfigs(r.KafkaCluster.Spec, eListener)
-				if err != nil {
-					return err
+				for _, res := range []resources.ResourceWithLogAndExternalListenerSpecificInfosAndIstioRevision{
+					r.meshgateway,
+					r.gateway,
+					r.virtualService,
+				} {
+					o := res(log, eListener, ingressConfig, name, defaultControllerName, istioRevision)
+					err := k8sutil.Reconcile(log, r.Client, o, r.KafkaCluster)
+					if err != nil {
+						return err
+					}
 				}
-				for name, ingressConfig := range ingressConfigs {
-					if !util.IsIngressConfigInUse(name, defaultControllerName, r.KafkaCluster, log) {
+			}
+		} else {
+			// Cleaning up unused istio resources when ingress controller is not istioingress or eListener access method is not LoadBalancer
+			deletionCounter := 0
+			ctx := context.Background()
+			istioResourcesGVK := []schema.GroupVersionKind{
+				{
+					Version: istioOperatorApi.GroupVersion.Version,
+					Group:   istioOperatorApi.GroupVersion.Group,
+					Kind:    reflect.TypeOf(istioOperatorApi.IstioMeshGateway{}).Name(),
+				},
+				{
+					Version: istioclientv1beta1.SchemeGroupVersion.Version,
+					Group:   istioclientv1beta1.SchemeGroupVersion.Group,
+					Kind:    reflect.TypeOf(istioclientv1beta1.Gateway{}).Name(),
+				},
+				{
+					Version: istioclientv1beta1.SchemeGroupVersion.Version,
+					Group:   istioclientv1beta1.SchemeGroupVersion.Group,
+					Kind:    reflect.TypeOf(istioclientv1beta1.VirtualService{}).Name(),
+				},
+			}
+			var istioResources unstructured.UnstructuredList
+			for _, gvk := range istioResourcesGVK {
+				istioResources.SetGroupVersionKind(gvk)
+
+				if err := r.List(ctx, &istioResources, client.InNamespace(r.KafkaCluster.GetNamespace()),
+					client.MatchingLabels(labelsForIstioIngressWithoutEListenerName(r.KafkaCluster.Name, ""))); err != nil && !apimeta.IsNoMatchError(err) {
+					return errors.Wrap(err, "error happened when getting list of istio ingress resources for deletion")
+				}
+
+				for _, removeObject := range istioResources.Items {
+					if !strings.Contains(removeObject.GetLabels()[eListenerLabelNameKey], eListener.Name) ||
+						util.ObjectManagedByClusterRegistry(&removeObject) ||
+						!removeObject.GetDeletionTimestamp().IsZero() {
 						continue
 					}
-					for _, res := range []resources.ResourceWithLogAndExternalListenerSpecificInfosAndIstioRevision{
-						r.meshgateway,
-						r.gateway,
-						r.virtualService,
-					} {
-						o := res(log, eListener, ingressConfig, name, defaultControllerName, istioRevision)
-						err := k8sutil.Reconcile(log, r.Client, o, r.KafkaCluster)
-						if err != nil {
-							return err
-						}
+					if err := r.Delete(ctx, &removeObject); client.IgnoreNotFound(err) != nil {
+						return errors.Wrap(err, "error happened when removing istio ingress resources")
 					}
+					deletionCounter++
 				}
+			}
+			if deletionCounter > 0 {
+				log.Info(fmt.Sprintf("Removed '%d' resources for istio ingress", deletionCounter))
 			}
 		}
 	}

--- a/pkg/resources/nodeportexternalaccess/nodeportExternalAccess.go
+++ b/pkg/resources/nodeportexternalaccess/nodeportExternalAccess.go
@@ -16,6 +16,7 @@ package nodeportexternalaccess
 
 import (
 	"context"
+	"fmt"
 
 	"emperror.dev/errors"
 	"github.com/go-logr/logr"
@@ -68,9 +69,11 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 					}
 				} else {
 					// Cleaning up unused nodeport services
-					if err := r.Delete(context.Background(), service.(client.Object)); client.IgnoreNotFound(err) != nil {
+					removeService := service.(client.Object)
+					if err := r.Delete(context.Background(), removeService); client.IgnoreNotFound(err) != nil {
 						return errors.Wrap(err, "error when removing unused nodeport services")
 					}
+					log.V(1).Info(fmt.Sprintf("Deleted nodePort service '%s' for external listener '%s'", removeService.GetName(), eListener.Name))
 				}
 			}
 		}

--- a/pkg/resources/nodeportexternalaccess/nodeportExternalAccess.go
+++ b/pkg/resources/nodeportexternalaccess/nodeportExternalAccess.go
@@ -67,15 +67,13 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 					if err != nil {
 						return err
 					}
-				} else {
-					if r.KafkaCluster.Spec.RemoveUnusedIngressResources {
-						// Cleaning up unused nodeport services
-						removeService := service.(client.Object)
-						if err := r.Delete(context.Background(), removeService); client.IgnoreNotFound(err) != nil {
-							return errors.Wrap(err, "error when removing unused nodeport services")
-						}
-						log.V(1).Info(fmt.Sprintf("Deleted nodePort service '%s' for external listener '%s'", removeService.GetName(), eListener.Name))
+				} else if r.KafkaCluster.Spec.RemoveUnusedIngressResources {
+					// Cleaning up unused nodeport services
+					removeService := service.(client.Object)
+					if err := r.Delete(context.Background(), removeService); client.IgnoreNotFound(err) != nil {
+						return errors.Wrap(err, "error when removing unused nodeport services")
 					}
+					log.V(1).Info(fmt.Sprintf("Deleted nodePort service '%s' for external listener '%s'", removeService.GetName(), eListener.Name))
 				}
 			}
 		}

--- a/pkg/resources/nodeportexternalaccess/nodeportExternalAccess.go
+++ b/pkg/resources/nodeportexternalaccess/nodeportExternalAccess.go
@@ -69,7 +69,7 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 				} else {
 					// Cleaning up unused nodeport services
 					if err := r.Delete(context.Background(), service.(client.Object)); client.IgnoreNotFound(err) != nil {
-						return errors.Wrap(err, "error happened when removing unused nodeport services")
+						return errors.Wrap(err, "error when removing unused nodeport services")
 					}
 				}
 			}

--- a/pkg/resources/nodeportexternalaccess/nodeportExternalAccess.go
+++ b/pkg/resources/nodeportexternalaccess/nodeportExternalAccess.go
@@ -68,12 +68,14 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 						return err
 					}
 				} else {
-					// Cleaning up unused nodeport services
-					removeService := service.(client.Object)
-					if err := r.Delete(context.Background(), removeService); client.IgnoreNotFound(err) != nil {
-						return errors.Wrap(err, "error when removing unused nodeport services")
+					if r.KafkaCluster.Spec.RemoveUnusedIngressResources {
+						// Cleaning up unused nodeport services
+						removeService := service.(client.Object)
+						if err := r.Delete(context.Background(), removeService); client.IgnoreNotFound(err) != nil {
+							return errors.Wrap(err, "error when removing unused nodeport services")
+						}
+						log.V(1).Info(fmt.Sprintf("Deleted nodePort service '%s' for external listener '%s'", removeService.GetName(), eListener.Name))
 					}
-					log.V(1).Info(fmt.Sprintf("Deleted nodePort service '%s' for external listener '%s'", removeService.GetName(), eListener.Name))
 				}
 			}
 		}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -58,8 +58,9 @@ import (
 )
 
 const (
-	symbolSet               = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
-	IngressConfigGlobalName = "globalConfig"
+	symbolSet                  = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+	IngressConfigGlobalName    = "globalConfig"
+	EListenerLabelNameTemplate = "%s-%s"
 )
 
 // IntstrPointer generate IntOrString pointer from int
@@ -235,7 +236,7 @@ func ConstructEListenerLabelName(ingressConfigName, eListenerName string) string
 		return eListenerName
 	}
 
-	return fmt.Sprintf("%s-%s", eListenerName, ingressConfigName)
+	return fmt.Sprintf(EListenerLabelNameTemplate, eListenerName, ingressConfigName)
 }
 
 // ShouldIncludeBroker returns true if the broker should be included as a resource on external listener resources

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -58,9 +58,10 @@ import (
 )
 
 const (
-	symbolSet                  = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
-	IngressConfigGlobalName    = "globalConfig"
-	EListenerLabelNameTemplate = "%s-%s"
+	symbolSet                         = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+	IngressConfigGlobalName           = "globalConfig"
+	ExternalListenerLabelNameTemplate = "%s-%s"
+	ExternalListenerLabelNameKey      = "eListenerName"
 )
 
 // IntstrPointer generate IntOrString pointer from int
@@ -236,7 +237,7 @@ func ConstructEListenerLabelName(ingressConfigName, eListenerName string) string
 		return eListenerName
 	}
 
-	return fmt.Sprintf(EListenerLabelNameTemplate, eListenerName, ingressConfigName)
+	return fmt.Sprintf(ExternalListenerLabelNameTemplate, eListenerName, ingressConfigName)
 }
 
 // ShouldIncludeBroker returns true if the broker should be included as a resource on external listener resources


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why.  -->
Removing unused ingress resources (nodePort services, istio ingress, envoy ingress) for external listeners

### Why?
Koperator uses envoy as the ingress controller by default. When the users want to expose their Kafka brokers via LoadBalancer, the Koperator deploys these necessary resources: . But it doesn’t seem to remove these resources when they are not needed, for example, the users switch from LoadBalancer to NodePort. Moreover, the brokers are still reachable via the stale loadbalancer service. Same applies when changing from NodePort to LoadBalancer and from istioingress ingresscontroller to envoy ingress controller and vice-versa.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline

