### PR TITLE
Added KafkaCluster.spec.envoyConfig.PodSecurityContext to the API

### DIFF
--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -361,6 +361,10 @@ type EnvoyConfig struct {
 	// EnableHealthCheckHttp10 is a toggle for adding HTTP1.0 support to Envoy health-check, default false
 	// +optional
 	EnableHealthCheckHttp10 bool `json:"enableHealthCheckHttp10,omitempty"`
+
+	// PodSecurityContext holds pod-level security attributes and common container
+	// settings for the Envoy pods.
+	PodSecurityContext *corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
 }
 
 // EnvoyCommandLineArgs defines envoy command line arguments
@@ -848,6 +852,15 @@ func (eConfig *EnvoyConfig) GetAffinity() *corev1.Affinity {
 // GetTopologySpreadConstaints returns the Affinity config for envoy
 func (eConfig *EnvoyConfig) GetTopologySpreadConstaints() []corev1.TopologySpreadConstraint {
 	return eConfig.TopologySpreadConstraints
+}
+
+// GetPodSecurityContext returns the security context for the envoy deployment podspec.
+func (eConfig *EnvoyConfig) GetPodSecurityContext() *corev1.PodSecurityContext {
+	if eConfig == nil {
+		return nil
+	}
+
+	return eConfig.PodSecurityContext
 }
 
 // GetPriorityClassName returns the priority class name for envoy

--- a/charts/kafka-operator/templates/crds.yaml
+++ b/charts/kafka-operator/templates/crds.yaml
@@ -16850,6 +16850,177 @@ spec:
                     description: NodeSelector is the node selector expression for
                       envoy pods
                     type: object
+                  podSecurityContext:
+                    description: PodSecurityContext holds pod-level security attributes
+                      and common container settings for the Envoy pods.
+                    properties:
+                      fsGroup:
+                        description: "A special supplemental group that applies to
+                          all containers in a pod. Some volume types allow the Kubelet
+                          to change the ownership of that volume to be owned by the
+                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
+                          bit is set (new files created in the volume will be owned
+                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
+                          \n If unset, the Kubelet will not modify the ownership and
+                          permissions of any volume. Note that this field cannot be
+                          set when spec.os.name is windows."
+                        format: int64
+                        type: integer
+                      fsGroupChangePolicy:
+                        description: 'fsGroupChangePolicy defines behavior of changing
+                          ownership and permission of the volume before being exposed
+                          inside Pod. This field will only apply to volume types which
+                          support fsGroup based ownership(and permissions). It will
+                          have no effect on ephemeral volume types such as: secret,
+                          configmaps and emptydir. Valid values are "OnRootMismatch"
+                          and "Always". If not specified, "Always" is used. Note that
+                          this field cannot be set when spec.os.name is windows.'
+                        type: string
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container. Note that this field
+                          cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in SecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in SecurityContext.  If set
+                          in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence for that container.
+                          Note that this field cannot be set when spec.os.name is
+                          windows.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to all containers.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          SecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence
+                          for that container. Note that this field cannot be set when
+                          spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: The seccomp options to use by the containers
+                          in this pod. Note that this field cannot be set when spec.os.name
+                          is windows.
+                        properties:
+                          localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used. The profile must
+                              be preconfigured on the node to work. Must be a descending
+                              path, relative to the kubelet's configured seccomp profile
+                              location. Must only be set if type is "Localhost".
+                            type: string
+                          type:
+                            description: "type indicates which kind of seccomp profile
+                              will be applied. Valid options are: \n Localhost - a
+                              profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile
+                              should be used. Unconfined - no profile should be applied."
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      supplementalGroups:
+                        description: A list of groups applied to the first process
+                          run in each container, in addition to the container's primary
+                          GID.  If unspecified, no groups will be added to any container.
+                          Note that this field cannot be set when spec.os.name is
+                          windows.
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        description: Sysctls hold a list of namespaced sysctls used
+                          for the pod. Pods with unsupported sysctls (by the container
+                          runtime) might fail to launch. Note that this field cannot
+                          be set when spec.os.name is windows.
+                        items:
+                          description: Sysctl defines a kernel parameter to be set
+                          properties:
+                            name:
+                              description: Name of a property to set
+                              type: string
+                            value:
+                              description: Value of a property to set
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options within a container's
+                          SecurityContext will be used. If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence. Note that this field cannot be set when
+                          spec.os.name is linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: HostProcess determines if a container should
+                              be run as a 'Host Process' container. This field is
+                              alpha-level and will only be honored by components that
+                              enable the WindowsHostProcessContainers feature flag.
+                              Setting this field without the feature flag will result
+                              in errors when validating the Pod. All of a Pod's containers
+                              must have the same effective HostProcess value (it is
+                              not allowed to have a mix of HostProcess containers
+                              and non-HostProcess containers).  In addition, if HostProcess
+                              is true then HostNetwork must also be set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            type: string
+                        type: object
+                    type: object
                   priorityClassName:
                     description: PriorityClassName specifies the priority class name
                       for the Envoy pod(s) If specified, the PriorityClass resource
@@ -18902,6 +19073,224 @@ spec:
                                           type: string
                                         description: NodeSelector is the node selector
                                           expression for envoy pods
+                                        type: object
+                                      podSecurityContext:
+                                        description: PodSecurityContext holds pod-level
+                                          security attributes and common container
+                                          settings for the Envoy pods.
+                                        properties:
+                                          fsGroup:
+                                            description: "A special supplemental group
+                                              that applies to all containers in a
+                                              pod. Some volume types allow the Kubelet
+                                              to change the ownership of that volume
+                                              to be owned by the pod: \n 1. The owning
+                                              GID will be the FSGroup 2. The setgid
+                                              bit is set (new files created in the
+                                              volume will be owned by FSGroup) 3.
+                                              The permission bits are OR'd with rw-rw----
+                                              \n If unset, the Kubelet will not modify
+                                              the ownership and permissions of any
+                                              volume. Note that this field cannot
+                                              be set when spec.os.name is windows."
+                                            format: int64
+                                            type: integer
+                                          fsGroupChangePolicy:
+                                            description: 'fsGroupChangePolicy defines
+                                              behavior of changing ownership and permission
+                                              of the volume before being exposed inside
+                                              Pod. This field will only apply to volume
+                                              types which support fsGroup based ownership(and
+                                              permissions). It will have no effect
+                                              on ephemeral volume types such as: secret,
+                                              configmaps and emptydir. Valid values
+                                              are "OnRootMismatch" and "Always". If
+                                              not specified, "Always" is used. Note
+                                              that this field cannot be set when spec.os.name
+                                              is windows.'
+                                            type: string
+                                          runAsGroup:
+                                            description: The GID to run the entrypoint
+                                              of the container process. Uses runtime
+                                              default if unset. May also be set in
+                                              SecurityContext.  If set in both SecurityContext
+                                              and PodSecurityContext, the value specified
+                                              in SecurityContext takes precedence
+                                              for that container. Note that this field
+                                              cannot be set when spec.os.name is windows.
+                                            format: int64
+                                            type: integer
+                                          runAsNonRoot:
+                                            description: Indicates that the container
+                                              must run as a non-root user. If true,
+                                              the Kubelet will validate the image
+                                              at runtime to ensure that it does not
+                                              run as UID 0 (root) and fail to start
+                                              the container if it does. If unset or
+                                              false, no such validation will be performed.
+                                              May also be set in SecurityContext.  If
+                                              set in both SecurityContext and PodSecurityContext,
+                                              the value specified in SecurityContext
+                                              takes precedence.
+                                            type: boolean
+                                          runAsUser:
+                                            description: The UID to run the entrypoint
+                                              of the container process. Defaults to
+                                              user specified in image metadata if
+                                              unspecified. May also be set in SecurityContext.  If
+                                              set in both SecurityContext and PodSecurityContext,
+                                              the value specified in SecurityContext
+                                              takes precedence for that container.
+                                              Note that this field cannot be set when
+                                              spec.os.name is windows.
+                                            format: int64
+                                            type: integer
+                                          seLinuxOptions:
+                                            description: The SELinux context to be
+                                              applied to all containers. If unspecified,
+                                              the container runtime will allocate
+                                              a random SELinux context for each container.  May
+                                              also be set in SecurityContext.  If
+                                              set in both SecurityContext and PodSecurityContext,
+                                              the value specified in SecurityContext
+                                              takes precedence for that container.
+                                              Note that this field cannot be set when
+                                              spec.os.name is windows.
+                                            properties:
+                                              level:
+                                                description: Level is SELinux level
+                                                  label that applies to the container.
+                                                type: string
+                                              role:
+                                                description: Role is a SELinux role
+                                                  label that applies to the container.
+                                                type: string
+                                              type:
+                                                description: Type is a SELinux type
+                                                  label that applies to the container.
+                                                type: string
+                                              user:
+                                                description: User is a SELinux user
+                                                  label that applies to the container.
+                                                type: string
+                                            type: object
+                                          seccompProfile:
+                                            description: The seccomp options to use
+                                              by the containers in this pod. Note
+                                              that this field cannot be set when spec.os.name
+                                              is windows.
+                                            properties:
+                                              localhostProfile:
+                                                description: localhostProfile indicates
+                                                  a profile defined in a file on the
+                                                  node should be used. The profile
+                                                  must be preconfigured on the node
+                                                  to work. Must be a descending path,
+                                                  relative to the kubelet's configured
+                                                  seccomp profile location. Must only
+                                                  be set if type is "Localhost".
+                                                type: string
+                                              type:
+                                                description: "type indicates which
+                                                  kind of seccomp profile will be
+                                                  applied. Valid options are: \n Localhost
+                                                  - a profile defined in a file on
+                                                  the node should be used. RuntimeDefault
+                                                  - the container runtime default
+                                                  profile should be used. Unconfined
+                                                  - no profile should be applied."
+                                                type: string
+                                            required:
+                                            - type
+                                            type: object
+                                          supplementalGroups:
+                                            description: A list of groups applied
+                                              to the first process run in each container,
+                                              in addition to the container's primary
+                                              GID.  If unspecified, no groups will
+                                              be added to any container. Note that
+                                              this field cannot be set when spec.os.name
+                                              is windows.
+                                            items:
+                                              format: int64
+                                              type: integer
+                                            type: array
+                                          sysctls:
+                                            description: Sysctls hold a list of namespaced
+                                              sysctls used for the pod. Pods with
+                                              unsupported sysctls (by the container
+                                              runtime) might fail to launch. Note
+                                              that this field cannot be set when spec.os.name
+                                              is windows.
+                                            items:
+                                              description: Sysctl defines a kernel
+                                                parameter to be set
+                                              properties:
+                                                name:
+                                                  description: Name of a property
+                                                    to set
+                                                  type: string
+                                                value:
+                                                  description: Value of a property
+                                                    to set
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          windowsOptions:
+                                            description: The Windows specific settings
+                                              applied to all containers. If unspecified,
+                                              the options within a container's SecurityContext
+                                              will be used. If set in both SecurityContext
+                                              and PodSecurityContext, the value specified
+                                              in SecurityContext takes precedence.
+                                              Note that this field cannot be set when
+                                              spec.os.name is linux.
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                description: GMSACredentialSpec is
+                                                  where the GMSA admission webhook
+                                                  (https://github.com/kubernetes-sigs/windows-gmsa)
+                                                  inlines the contents of the GMSA
+                                                  credential spec named by the GMSACredentialSpecName
+                                                  field.
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                description: GMSACredentialSpecName
+                                                  is the name of the GMSA credential
+                                                  spec to use.
+                                                type: string
+                                              hostProcess:
+                                                description: HostProcess determines
+                                                  if a container should be run as
+                                                  a 'Host Process' container. This
+                                                  field is alpha-level and will only
+                                                  be honored by components that enable
+                                                  the WindowsHostProcessContainers
+                                                  feature flag. Setting this field
+                                                  without the feature flag will result
+                                                  in errors when validating the Pod.
+                                                  All of a Pod's containers must have
+                                                  the same effective HostProcess value
+                                                  (it is not allowed to have a mix
+                                                  of HostProcess containers and non-HostProcess
+                                                  containers).  In addition, if HostProcess
+                                                  is true then HostNetwork must also
+                                                  be set to true.
+                                                type: boolean
+                                              runAsUserName:
+                                                description: The UserName in Windows
+                                                  to run the entrypoint of the container
+                                                  process. Defaults to the user specified
+                                                  in image metadata if unspecified.
+                                                  May also be set in PodSecurityContext.
+                                                  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified
+                                                  in SecurityContext takes precedence.
+                                                type: string
+                                            type: object
                                         type: object
                                       priorityClassName:
                                         description: PriorityClassName specifies the

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -16687,6 +16687,177 @@ spec:
                     description: NodeSelector is the node selector expression for
                       envoy pods
                     type: object
+                  podSecurityContext:
+                    description: PodSecurityContext holds pod-level security attributes
+                      and common container settings for the Envoy pods.
+                    properties:
+                      fsGroup:
+                        description: "A special supplemental group that applies to
+                          all containers in a pod. Some volume types allow the Kubelet
+                          to change the ownership of that volume to be owned by the
+                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
+                          bit is set (new files created in the volume will be owned
+                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
+                          \n If unset, the Kubelet will not modify the ownership and
+                          permissions of any volume. Note that this field cannot be
+                          set when spec.os.name is windows."
+                        format: int64
+                        type: integer
+                      fsGroupChangePolicy:
+                        description: 'fsGroupChangePolicy defines behavior of changing
+                          ownership and permission of the volume before being exposed
+                          inside Pod. This field will only apply to volume types which
+                          support fsGroup based ownership(and permissions). It will
+                          have no effect on ephemeral volume types such as: secret,
+                          configmaps and emptydir. Valid values are "OnRootMismatch"
+                          and "Always". If not specified, "Always" is used. Note that
+                          this field cannot be set when spec.os.name is windows.'
+                        type: string
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container. Note that this field
+                          cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in SecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in SecurityContext.  If set
+                          in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence for that container.
+                          Note that this field cannot be set when spec.os.name is
+                          windows.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to all containers.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          SecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence
+                          for that container. Note that this field cannot be set when
+                          spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: The seccomp options to use by the containers
+                          in this pod. Note that this field cannot be set when spec.os.name
+                          is windows.
+                        properties:
+                          localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used. The profile must
+                              be preconfigured on the node to work. Must be a descending
+                              path, relative to the kubelet's configured seccomp profile
+                              location. Must only be set if type is "Localhost".
+                            type: string
+                          type:
+                            description: "type indicates which kind of seccomp profile
+                              will be applied. Valid options are: \n Localhost - a
+                              profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile
+                              should be used. Unconfined - no profile should be applied."
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      supplementalGroups:
+                        description: A list of groups applied to the first process
+                          run in each container, in addition to the container's primary
+                          GID.  If unspecified, no groups will be added to any container.
+                          Note that this field cannot be set when spec.os.name is
+                          windows.
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        description: Sysctls hold a list of namespaced sysctls used
+                          for the pod. Pods with unsupported sysctls (by the container
+                          runtime) might fail to launch. Note that this field cannot
+                          be set when spec.os.name is windows.
+                        items:
+                          description: Sysctl defines a kernel parameter to be set
+                          properties:
+                            name:
+                              description: Name of a property to set
+                              type: string
+                            value:
+                              description: Value of a property to set
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options within a container's
+                          SecurityContext will be used. If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence. Note that this field cannot be set when
+                          spec.os.name is linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: HostProcess determines if a container should
+                              be run as a 'Host Process' container. This field is
+                              alpha-level and will only be honored by components that
+                              enable the WindowsHostProcessContainers feature flag.
+                              Setting this field without the feature flag will result
+                              in errors when validating the Pod. All of a Pod's containers
+                              must have the same effective HostProcess value (it is
+                              not allowed to have a mix of HostProcess containers
+                              and non-HostProcess containers).  In addition, if HostProcess
+                              is true then HostNetwork must also be set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            type: string
+                        type: object
+                    type: object
                   priorityClassName:
                     description: PriorityClassName specifies the priority class name
                       for the Envoy pod(s) If specified, the PriorityClass resource
@@ -18739,6 +18910,224 @@ spec:
                                           type: string
                                         description: NodeSelector is the node selector
                                           expression for envoy pods
+                                        type: object
+                                      podSecurityContext:
+                                        description: PodSecurityContext holds pod-level
+                                          security attributes and common container
+                                          settings for the Envoy pods.
+                                        properties:
+                                          fsGroup:
+                                            description: "A special supplemental group
+                                              that applies to all containers in a
+                                              pod. Some volume types allow the Kubelet
+                                              to change the ownership of that volume
+                                              to be owned by the pod: \n 1. The owning
+                                              GID will be the FSGroup 2. The setgid
+                                              bit is set (new files created in the
+                                              volume will be owned by FSGroup) 3.
+                                              The permission bits are OR'd with rw-rw----
+                                              \n If unset, the Kubelet will not modify
+                                              the ownership and permissions of any
+                                              volume. Note that this field cannot
+                                              be set when spec.os.name is windows."
+                                            format: int64
+                                            type: integer
+                                          fsGroupChangePolicy:
+                                            description: 'fsGroupChangePolicy defines
+                                              behavior of changing ownership and permission
+                                              of the volume before being exposed inside
+                                              Pod. This field will only apply to volume
+                                              types which support fsGroup based ownership(and
+                                              permissions). It will have no effect
+                                              on ephemeral volume types such as: secret,
+                                              configmaps and emptydir. Valid values
+                                              are "OnRootMismatch" and "Always". If
+                                              not specified, "Always" is used. Note
+                                              that this field cannot be set when spec.os.name
+                                              is windows.'
+                                            type: string
+                                          runAsGroup:
+                                            description: The GID to run the entrypoint
+                                              of the container process. Uses runtime
+                                              default if unset. May also be set in
+                                              SecurityContext.  If set in both SecurityContext
+                                              and PodSecurityContext, the value specified
+                                              in SecurityContext takes precedence
+                                              for that container. Note that this field
+                                              cannot be set when spec.os.name is windows.
+                                            format: int64
+                                            type: integer
+                                          runAsNonRoot:
+                                            description: Indicates that the container
+                                              must run as a non-root user. If true,
+                                              the Kubelet will validate the image
+                                              at runtime to ensure that it does not
+                                              run as UID 0 (root) and fail to start
+                                              the container if it does. If unset or
+                                              false, no such validation will be performed.
+                                              May also be set in SecurityContext.  If
+                                              set in both SecurityContext and PodSecurityContext,
+                                              the value specified in SecurityContext
+                                              takes precedence.
+                                            type: boolean
+                                          runAsUser:
+                                            description: The UID to run the entrypoint
+                                              of the container process. Defaults to
+                                              user specified in image metadata if
+                                              unspecified. May also be set in SecurityContext.  If
+                                              set in both SecurityContext and PodSecurityContext,
+                                              the value specified in SecurityContext
+                                              takes precedence for that container.
+                                              Note that this field cannot be set when
+                                              spec.os.name is windows.
+                                            format: int64
+                                            type: integer
+                                          seLinuxOptions:
+                                            description: The SELinux context to be
+                                              applied to all containers. If unspecified,
+                                              the container runtime will allocate
+                                              a random SELinux context for each container.  May
+                                              also be set in SecurityContext.  If
+                                              set in both SecurityContext and PodSecurityContext,
+                                              the value specified in SecurityContext
+                                              takes precedence for that container.
+                                              Note that this field cannot be set when
+                                              spec.os.name is windows.
+                                            properties:
+                                              level:
+                                                description: Level is SELinux level
+                                                  label that applies to the container.
+                                                type: string
+                                              role:
+                                                description: Role is a SELinux role
+                                                  label that applies to the container.
+                                                type: string
+                                              type:
+                                                description: Type is a SELinux type
+                                                  label that applies to the container.
+                                                type: string
+                                              user:
+                                                description: User is a SELinux user
+                                                  label that applies to the container.
+                                                type: string
+                                            type: object
+                                          seccompProfile:
+                                            description: The seccomp options to use
+                                              by the containers in this pod. Note
+                                              that this field cannot be set when spec.os.name
+                                              is windows.
+                                            properties:
+                                              localhostProfile:
+                                                description: localhostProfile indicates
+                                                  a profile defined in a file on the
+                                                  node should be used. The profile
+                                                  must be preconfigured on the node
+                                                  to work. Must be a descending path,
+                                                  relative to the kubelet's configured
+                                                  seccomp profile location. Must only
+                                                  be set if type is "Localhost".
+                                                type: string
+                                              type:
+                                                description: "type indicates which
+                                                  kind of seccomp profile will be
+                                                  applied. Valid options are: \n Localhost
+                                                  - a profile defined in a file on
+                                                  the node should be used. RuntimeDefault
+                                                  - the container runtime default
+                                                  profile should be used. Unconfined
+                                                  - no profile should be applied."
+                                                type: string
+                                            required:
+                                            - type
+                                            type: object
+                                          supplementalGroups:
+                                            description: A list of groups applied
+                                              to the first process run in each container,
+                                              in addition to the container's primary
+                                              GID.  If unspecified, no groups will
+                                              be added to any container. Note that
+                                              this field cannot be set when spec.os.name
+                                              is windows.
+                                            items:
+                                              format: int64
+                                              type: integer
+                                            type: array
+                                          sysctls:
+                                            description: Sysctls hold a list of namespaced
+                                              sysctls used for the pod. Pods with
+                                              unsupported sysctls (by the container
+                                              runtime) might fail to launch. Note
+                                              that this field cannot be set when spec.os.name
+                                              is windows.
+                                            items:
+                                              description: Sysctl defines a kernel
+                                                parameter to be set
+                                              properties:
+                                                name:
+                                                  description: Name of a property
+                                                    to set
+                                                  type: string
+                                                value:
+                                                  description: Value of a property
+                                                    to set
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          windowsOptions:
+                                            description: The Windows specific settings
+                                              applied to all containers. If unspecified,
+                                              the options within a container's SecurityContext
+                                              will be used. If set in both SecurityContext
+                                              and PodSecurityContext, the value specified
+                                              in SecurityContext takes precedence.
+                                              Note that this field cannot be set when
+                                              spec.os.name is linux.
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                description: GMSACredentialSpec is
+                                                  where the GMSA admission webhook
+                                                  (https://github.com/kubernetes-sigs/windows-gmsa)
+                                                  inlines the contents of the GMSA
+                                                  credential spec named by the GMSACredentialSpecName
+                                                  field.
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                description: GMSACredentialSpecName
+                                                  is the name of the GMSA credential
+                                                  spec to use.
+                                                type: string
+                                              hostProcess:
+                                                description: HostProcess determines
+                                                  if a container should be run as
+                                                  a 'Host Process' container. This
+                                                  field is alpha-level and will only
+                                                  be honored by components that enable
+                                                  the WindowsHostProcessContainers
+                                                  feature flag. Setting this field
+                                                  without the feature flag will result
+                                                  in errors when validating the Pod.
+                                                  All of a Pod's containers must have
+                                                  the same effective HostProcess value
+                                                  (it is not allowed to have a mix
+                                                  of HostProcess containers and non-HostProcess
+                                                  containers).  In addition, if HostProcess
+                                                  is true then HostNetwork must also
+                                                  be set to true.
+                                                type: boolean
+                                              runAsUserName:
+                                                description: The UserName in Windows
+                                                  to run the entrypoint of the container
+                                                  process. Defaults to the user specified
+                                                  in image metadata if unspecified.
+                                                  May also be set in PodSecurityContext.
+                                                  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified
+                                                  in SecurityContext takes precedence.
+                                                type: string
+                                            type: object
                                         type: object
                                       priorityClassName:
                                         description: PriorityClassName specifies the


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no |
| New feature?    | yes |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | - |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Added KafkaCluster.spec.envoyConfig.PodSecurityContext to the API

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

RHOS requires setting some fields which needed propagation.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested
- ~Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)~
- ~Logging code meets the guideline~
- [X] User guide and development docs updated (if needed)
