### PR TITLE
Fix out of range panic in resizePVC fn

### DIFF
--- a/charts/kafka-operator/Chart.yaml
+++ b/charts/kafka-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kafka-operator
-version: 0.24.0
+version: 0.24.1
 description: kafka-operator manages Kafka deployments on Kubernetes
 sources:
   - https://github.com/banzaicloud/koperator
-appVersion: v0.24.0
+appVersion: v0.24.1

--- a/charts/kafka-operator/README.md
+++ b/charts/kafka-operator/README.md
@@ -12,7 +12,7 @@ Before installing the chart, you must first install the Koperator CustomResource
 This is performed in a separate step to allow you to easily uninstall and reinstall Koperator without deleting your installed custom resources.
 
 ```
-kubectl create --validate=false -f https://github.com/banzaicloud/koperator/releases/download/v0.24.0/kafka-operator.crds.yaml
+kubectl create --validate=false -f https://github.com/banzaicloud/koperator/releases/download/v0.24.1/kafka-operator.crds.yaml
 ```
 
 To install the chart:
@@ -53,7 +53,7 @@ The following table lists the configurable parameters of the Banzaicloud Kafka O
 Parameter | Description | Default
 --------- | ----------- | -------
 `operator.image.repository` | Operator container image repository | `ghcr.io/banzaicloud/kafka-operator`
-`operator.image.tag` | Operator container image tag | `v0.24.0`
+`operator.image.tag` | Operator container image tag | `v0.24.1`
 `operator.image.pullPolicy` | Operator container image pull policy | `IfNotPresent`
 `operator.serviceAccount.name` | ServiceAccount used by the operator pod | `kafka-operator`
 `operator.serviceAccount.create` | If true, create the `operator.serviceAccount.name` service account | `true`

--- a/internal/alertmanager/currentalert/process.go
+++ b/internal/alertmanager/currentalert/process.go
@@ -283,7 +283,6 @@ func resizePvc(log logr.Logger, labels model.LabelSet, annotiations model.LabelS
 					} else {
 						broker.BrokerConfig.StorageConfigs[idx] = *modifiableConfig
 					}
-
 				}
 			}
 			cr.Spec.Brokers[i].BrokerConfig = broker.BrokerConfig

--- a/internal/alertmanager/currentalert/process.go
+++ b/internal/alertmanager/currentalert/process.go
@@ -271,19 +271,19 @@ func resizePvc(log logr.Logger, labels model.LabelSet, annotiations model.LabelS
 
 					modifiableConfig.PvcSpec.Resources.Requests["storage"] = size
 
-					// When the storage is in brokerConfigGroup we don't resize the storage there because in that case
-					// all of those brokers that are using this brokerConfigGroup its storage would be resized.
-					// We add the storage into the broker.BrokerConfig.StorageConfigs in this way only that broker pvc will be resized.
+					// When the storage is in a brokerConfigGroup we don't resize the storage there because in that case
+					// all of the brokers that are using this brokerConfigGroup would have their storages resized.
+					// We add the storage into the broker.BrokerConfig.StorageConfigs in this way only the PVC belonging to that specific broker will be resized.
 					if broker.BrokerConfig == nil {
 						broker.BrokerConfig = &v1beta1.BrokerConfig{}
-					} else {
-						idx := slices.IndexFunc(broker.BrokerConfig.StorageConfigs, func(c v1beta1.StorageConfig) bool { return c.MountPath == pvc.Annotations["mountPath"] })
-						if idx == -1 {
-							broker.BrokerConfig.StorageConfigs = append(broker.BrokerConfig.StorageConfigs, *modifiableConfig)
-						} else {
-							broker.BrokerConfig.StorageConfigs[idx] = *modifiableConfig
-						}
 					}
+					idx := slices.IndexFunc(broker.BrokerConfig.StorageConfigs, func(c v1beta1.StorageConfig) bool { return c.MountPath == pvc.Annotations["mountPath"] })
+					if idx == -1 {
+						broker.BrokerConfig.StorageConfigs = append(broker.BrokerConfig.StorageConfigs, *modifiableConfig)
+					} else {
+						broker.BrokerConfig.StorageConfigs[idx] = *modifiableConfig
+					}
+
 				}
 			}
 			cr.Spec.Brokers[i].BrokerConfig = broker.BrokerConfig

--- a/internal/alertmanager/currentalert/process.go
+++ b/internal/alertmanager/currentalert/process.go
@@ -23,6 +23,7 @@ import (
 	"emperror.dev/errors"
 	"github.com/go-logr/logr"
 	"github.com/prometheus/common/model"
+	"golang.org/x/exp/slices"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
@@ -262,7 +263,7 @@ func resizePvc(log logr.Logger, labels model.LabelSet, annotiations model.LabelS
 
 			storageConfigs := brokerConfig.StorageConfigs
 
-			for n, c := range storageConfigs {
+			for _, c := range storageConfigs {
 				modifiableConfig := c.DeepCopy()
 				if modifiableConfig.MountPath == pvc.Annotations["mountPath"] {
 					size := *modifiableConfig.PvcSpec.Resources.Requests.Storage()
@@ -270,12 +271,18 @@ func resizePvc(log logr.Logger, labels model.LabelSet, annotiations model.LabelS
 
 					modifiableConfig.PvcSpec.Resources.Requests["storage"] = size
 
+					// When the storage is in brokerConfigGroup we don't resize the storage there because in that case
+					// all of those brokers that are using this brokerConfigGroup its storage would be resized.
+					// We add the storage into the broker.BrokerConfig.StorageConfigs in this way only that broker pvc will be resized.
 					if broker.BrokerConfig == nil {
-						broker.BrokerConfig = &v1beta1.BrokerConfig{
-							StorageConfigs: []v1beta1.StorageConfig{*modifiableConfig},
-						}
+						broker.BrokerConfig = &v1beta1.BrokerConfig{}
 					} else {
-						broker.BrokerConfig.StorageConfigs[n] = *modifiableConfig
+						idx := slices.IndexFunc(broker.BrokerConfig.StorageConfigs, func(c v1beta1.StorageConfig) bool { return c.MountPath == pvc.Annotations["mountPath"] })
+						if idx == -1 {
+							broker.BrokerConfig.StorageConfigs = append(broker.BrokerConfig.StorageConfigs, *modifiableConfig)
+						} else {
+							broker.BrokerConfig.StorageConfigs[idx] = *modifiableConfig
+						}
 					}
 				}
 			}


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Fixes resizePVC  function because the storageConfigs could go out of range in some cases

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
https://github.com/banzaicloud/koperator/blob/12af3cd3140cb02d224752c332b9a0072c41e72c/internal/alertmanager/currentalert/process.go#L278 this will be out of range panic when the storageConfig is in the brokerConfigGroup

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
