### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The version of Kafka that is installed by the operator requires Apache ZooKeeper
 1. Install ZooKeeper using [Pravega’s Zookeeper Operator](https://github.com/pravega/zookeeper-operator).
 
 ```
-helm install zookeeper-operator --repo https://charts.pravega.io --namespace=zookeeper --create-namespace pravega/zookeeper-operator
+helm install zookeeper-operator --repo https://charts.pravega.io --namespace=zookeeper --create-namespace zookeeper-operator
 ```
 
 2. Create a ZooKeeper cluster.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ kubectl create --validate=false -f https://github.com/banzaicloud/koperator/rele
 2. Install Koperator into the `kafka` namespace:
 
 ```
-helm install kafka-operator --repo https://kubernetes-charts.banzaicloud.com/ --namespace=kafka --create-namespace banzaicloud-stable/kafka-operator
+helm install kafka-operator --repo https://kubernetes-charts.banzaicloud.com/ --namespace=kafka --create-namespace kafka-operator
 ```
 
 3. Create the Kafka cluster using the `KafkaCluster` custom resource. The quick start uses a minimal custom resource, but there are other examples in the same directory.


### PR DESCRIPTION
## Description

Remove local references of helm repos from the all-in-1 helm commands for installing zookeeper-operator and koperator. 

Current helm repo references, `pravega` and `banzaicloud-stable`, wouldn't be present at user's machine unless they added those before and users might run into errors like this when they follow the README steps:

```
helm install kafka-operator --repo https://kubernetes-charts.banzaicloud.com/ --namespace=kafka --create-namespace banzaicloud-stable/kafka-operator
Error: chart "banzaicloud-stable/kafka-operator" not found in https://kubernetes-charts.banzaicloud.com/ repository
```

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md)