### PR TITLE
fix(cc): re-creation of CC metrics topic

### DIFF
--- a/controllers/kafkacluster_controller.go
+++ b/controllers/kafkacluster_controller.go
@@ -119,7 +119,7 @@ func (r *KafkaClusterReconciler) Reconcile(ctx context.Context, request ctrl.Req
 		kafkamonitoring.New(r.Client, instance),
 		cruisecontrolmonitoring.New(r.Client, instance),
 		kafka.New(r.Client, r.DirectClient, instance, r.KafkaClientProvider),
-		cruisecontrol.New(r.Client, instance),
+		cruisecontrol.New(r.Client, instance, r.KafkaClientProvider),
 	}
 
 	for _, rec := range reconcilers {

--- a/pkg/resources/cruisecontrol/cruisecontrol.go
+++ b/pkg/resources/cruisecontrol/cruisecontrol.go
@@ -66,13 +66,13 @@ func ccLabelSelector(kafkaCluster string) map[string]string {
 }
 
 // New creates a new reconciler for CC
-func New(client client.Client, cluster *v1beta1.KafkaCluster, KafkaClientProvider kafkaclient.Provider) *Reconciler {
+func New(client client.Client, cluster *v1beta1.KafkaCluster, kafkaClientProvider kafkaclient.Provider) *Reconciler {
 	return &Reconciler{
 		Reconciler: resources.Reconciler{
 			Client:       client,
 			KafkaCluster: cluster,
 		},
-		KafkaClientProvider: KafkaClientProvider,
+		KafkaClientProvider: kafkaClientProvider,
 	}
 }
 

--- a/pkg/resources/cruisecontrol/topicManager.go
+++ b/pkg/resources/cruisecontrol/topicManager.go
@@ -73,7 +73,7 @@ func newCruiseControlTopic(cluster *v1beta1.KafkaCluster) *v1alpha1.KafkaTopic {
 	}
 }
 
-func generateCCTopic(cluster *v1beta1.KafkaCluster, client client.Client, log logr.Logger) error {
+func generateCCTopic(cluster *v1beta1.KafkaCluster, client client.Client, kafkaClientProvider kafkaclient.Provider, log logr.Logger) error {
 	readOnlyConfigProperties, err := properties.NewFromString(cluster.Spec.ReadOnlyConfig)
 	if err != nil {
 		return errors.WrapIf(err, "could not parse broker config")
@@ -91,7 +91,7 @@ func generateCCTopic(cluster *v1beta1.KafkaCluster, client client.Client, log lo
 	}
 	// Handle that case when the topic is created by CC but later cruise.control.metrics.topic.auto.create config removed from readOnlyConfig,
 	// or its value changed to false. In that case we dont need to create CC Metrics topic
-	broker, close, err := kafkaclient.NewFromCluster(client, cluster)
+	broker, close, err := kafkaClientProvider.NewFromCluster(client, cluster)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

CC reconciler run into error when  the CC metrics topic is already created but because of the insufficient check (cruise.control.metrics.topic.auto.create). It tries to re-create it through kafkaTopic CR.

This PR fix this by checking the CC metrics topic existence in the Kafka cluster.

## Type of Change
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Bug Fix

## Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [x] All new and existing tests pass
