### PR TITLE
Adding certificate validity duration in Kafka user

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -28,10 +28,8 @@ require (
 	golang.org/x/text v0.7.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	k8s.io/apiextensions-apiserver v0.26.4 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448 // indirect
-	sigs.k8s.io/gateway-api v0.6.0 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )

--- a/api/go.sum
+++ b/api/go.sum
@@ -104,8 +104,6 @@ gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 k8s.io/api v0.26.4 h1:qSG2PmtcD23BkYiWfoYAcak870eF/hE7NNYBYavTT94=
 k8s.io/api v0.26.4/go.mod h1:WwKEXU3R1rgCZ77AYa7DFksd9/BAIKyOmRlbVxgvjCk=
-k8s.io/apiextensions-apiserver v0.26.4 h1:9D2RTxYGxrG5uYg6D7QZRcykXvavBvcA59j5kTaedQI=
-k8s.io/apiextensions-apiserver v0.26.4/go.mod h1:cd4uGFGIgzEqUghWpRsr9KE8j2KNTjY8Ji8pnMMazyw=
 k8s.io/apimachinery v0.0.0-20190704094733-8f6ac2502e51/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
 k8s.io/apimachinery v0.26.4 h1:rZccKdBLg9vP6J09JD+z8Yr99Ce8gk3Lbi9TCx05Jzs=
 k8s.io/apimachinery v0.26.4/go.mod h1:ats7nN1LExKHvJ9TmwootT00Yz05MuYqPXEXaVeOy5I=
@@ -116,8 +114,6 @@ k8s.io/utils v0.0.0-20221128185143-99ec85e7a448 h1:KTgPnR10d5zhztWptI952TNtt/4u5
 k8s.io/utils v0.0.0-20221128185143-99ec85e7a448/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/controller-runtime v0.14.6 h1:oxstGVvXGNnMvY7TAESYk+lzr6S3V5VFxQ6d92KcwQA=
 sigs.k8s.io/controller-runtime v0.14.6/go.mod h1:WqIdsAY6JBsjfc/CqO0CORmNtoCtE4S6qbPc9s68h+0=
-sigs.k8s.io/gateway-api v0.6.0 h1:v2FqrN2ROWZLrSnI2o91taHR8Sj3s+Eh3QU7gLNWIqA=
-sigs.k8s.io/gateway-api v0.6.0/go.mod h1:EYJT+jlPWTeNskjV0JTki/03WX1cyAnBhwBJfYHpV/0=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 h1:iXTIw73aPyC+oRdyqqvVJuloN1p0AC/kzH07hu3NE+k=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3 h1:PRbqxJClWWYMNV1dhaG4NsibJbArud9kFxnAMREiWFE=

--- a/config/samples/example-user-with-pkibackend.yaml
+++ b/config/samples/example-user-with-pkibackend.yaml
@@ -18,4 +18,4 @@ spec:
       name: "ca-issuer"
       kind: "ClusterIssuer"
       group: "cert-manager.io"
-  duration: "1h"
+  expirationSeconds: 7200

--- a/config/samples/example-user-with-pkibackend.yaml
+++ b/config/samples/example-user-with-pkibackend.yaml
@@ -17,3 +17,5 @@ spec:
     issuerRef:
       name: "ca-issuer"
       kind: "ClusterIssuer"
+      group: "cert-manager.io"
+  duration: "1h"

--- a/controllers/cruisecontroloperation_controller.go
+++ b/controllers/cruisecontroloperation_controller.go
@@ -267,6 +267,8 @@ func (r *CruiseControlOperationReconciler) executeOperation(ctx context.Context,
 		cruseControlTaskResult, err = r.scaler.RebalanceWithParams(ctx, ccOperationExecution.CurrentTaskParameters())
 	case banzaiv1alpha1.OperationStopExecution:
 		cruseControlTaskResult, err = r.scaler.StopExecution(ctx)
+	case banzaiv1alpha1.OperationStatus:
+		err = errors.NewWithDetails("Cruise Control operation not supported", "name", ccOperationExecution.GetName(), "namespace", ccOperationExecution.GetNamespace(), "operation", ccOperationExecution.CurrentTaskOperation(), "parameters", ccOperationExecution.CurrentTaskParameters())
 	default:
 		err = errors.NewWithDetails("Cruise Control operation not supported", "name", ccOperationExecution.GetName(), "namespace", ccOperationExecution.GetNamespace(), "operation", ccOperationExecution.CurrentTaskOperation(), "parameters", ccOperationExecution.CurrentTaskParameters())
 	}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/banzaicloud/istio-client-go v0.0.17
 	github.com/banzaicloud/istio-operator/api/v2 v2.15.1
 	github.com/banzaicloud/k8s-objectmatcher v1.8.0
-	github.com/banzaicloud/koperator/api v0.26.0
+	github.com/banzaicloud/koperator/api v0.28.2
 	github.com/banzaicloud/koperator/properties v0.4.1
 	github.com/cert-manager/cert-manager v1.11.2
 	github.com/cisco-open/cluster-registry-controller/api v0.2.5

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/banzaicloud/istio-operator/api/v2 v2.15.1 h1:BZg8COvoOJtfx/dgN7KpoOnc
 github.com/banzaicloud/istio-operator/api/v2 v2.15.1/go.mod h1:5qCpwWlIfxiLvBfTvT2mD2wp5RlFCDEt8Xql4sYPNBc=
 github.com/banzaicloud/k8s-objectmatcher v1.8.0 h1:Nugn25elKtPMTA2br+JgHNeSQ04sc05MDPmpJnd1N2A=
 github.com/banzaicloud/k8s-objectmatcher v1.8.0/go.mod h1:p2LSNAjlECf07fbhDyebTkPUIYnU05G+WfGgkTmgeMg=
-github.com/banzaicloud/koperator/api v0.26.0 h1:fQhByPO3IWY+EGhlh5ZSyBMeLhOYTz3lsXkbKHWRmvo=
-github.com/banzaicloud/koperator/api v0.26.0/go.mod h1:qvpewvjdELAnfO70vg9397CXZ4K4uHxpiWtf5fhKSrQ=
+github.com/banzaicloud/koperator/api v0.28.2 h1:x3n9dl+zhePgfwXFZlbzqeoI8veF4gL7JJAdKvfc61M=
+github.com/banzaicloud/koperator/api v0.28.2/go.mod h1:MpHo+CO1TmVyHooJ3n3+o6ibL/AKlBp7L9bdyKy5Ec0=
 github.com/banzaicloud/koperator/properties v0.4.1 h1:SB2QgXlcK1Dc7Z1rg65PJifErDa8OQnoWCCJgmC7SGc=
 github.com/banzaicloud/koperator/properties v0.4.1/go.mod h1:TcL+llxuhW3UeQtVEDYEXGouFLF2P+LuZZVudSb6jyA=
 github.com/banzaicloud/operator-tools v0.28.0 h1:GSfc0qZr6zo7WrNxdgWZE1LcTChPU8QFYOTDirYVtIM=

--- a/pkg/pki/certmanagerpki/certmanager_user.go
+++ b/pkg/pki/certmanagerpki/certmanager_user.go
@@ -17,6 +17,7 @@ package certmanagerpki
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"emperror.dev/errors"
 
@@ -161,6 +162,7 @@ func (c *certManager) clusterCertificateForUser(
 				Kind:  caKind,
 				Group: caGroup,
 			},
+			Duration: &metav1.Duration{Duration: time.Duration(user.Spec.GetExpirationSeconds()) * time.Second},
 		},
 	}
 	if user.Spec.IncludeJKS {
@@ -178,9 +180,6 @@ func (c *certManager) clusterCertificateForUser(
 	}
 	if user.Spec.DNSNames != nil && len(user.Spec.DNSNames) > 0 {
 		cert.Spec.DNSNames = user.Spec.DNSNames
-	}
-	if user.Spec.Duration != nil {
-		cert.Spec.Duration = user.Spec.Duration
 	}
 	return cert
 }

--- a/pkg/pki/certmanagerpki/certmanager_user.go
+++ b/pkg/pki/certmanagerpki/certmanager_user.go
@@ -179,6 +179,9 @@ func (c *certManager) clusterCertificateForUser(
 	if user.Spec.DNSNames != nil && len(user.Spec.DNSNames) > 0 {
 		cert.Spec.DNSNames = user.Spec.DNSNames
 	}
+	if user.Spec.Duration != nil {
+		cert.Spec.Duration = user.Spec.Duration
+	}
 	return cert
 }
 

--- a/pkg/pki/certmanagerpki/certmanager_user_test.go
+++ b/pkg/pki/certmanagerpki/certmanager_user_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/banzaicloud/koperator/api/v1alpha1"
 	"github.com/banzaicloud/koperator/pkg/errorfactory"
+	"github.com/banzaicloud/koperator/pkg/util"
 	certutil "github.com/banzaicloud/koperator/pkg/util/cert"
 )
 
@@ -98,6 +99,14 @@ func TestReconcileUserCertificate(t *testing.T) {
 			Group: "testGroup",
 		},
 	}
+
+	if _, err := manager.ReconcileUserCertificate(ctx, user, scheme.Scheme, clusterDomain); err != nil {
+		t.Error("Expected no error, got:", err)
+	}
+
+	// Test cert duration
+	user = newMockUser()
+	user.Spec.ExpirationSeconds = util.Int32Pointer(7200)
 
 	if _, err := manager.ReconcileUserCertificate(ctx, user, scheme.Scheme, clusterDomain); err != nil {
 		t.Error("Expected no error, got:", err)

--- a/pkg/pki/certmanagerpki/certmanager_user_test.go
+++ b/pkg/pki/certmanagerpki/certmanager_user_test.go
@@ -18,10 +18,8 @@ import (
 	"context"
 	"reflect"
 	"testing"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
@@ -30,8 +28,6 @@ import (
 	"github.com/banzaicloud/koperator/pkg/errorfactory"
 	certutil "github.com/banzaicloud/koperator/pkg/util/cert"
 )
-
-const testDuration = time.Hour * 1
 
 func newMockUser() *v1alpha1.KafkaUser {
 	user := &v1alpha1.KafkaUser{}
@@ -102,14 +98,6 @@ func TestReconcileUserCertificate(t *testing.T) {
 			Group: "testGroup",
 		},
 	}
-
-	if _, err := manager.ReconcileUserCertificate(ctx, user, scheme.Scheme, clusterDomain); err != nil {
-		t.Error("Expected no error, got:", err)
-	}
-
-	// Test cert duration case
-	user = newMockUser()
-	user.Spec.Duration = &v1.Duration{Duration: testDuration}
 
 	if _, err := manager.ReconcileUserCertificate(ctx, user, scheme.Scheme, clusterDomain); err != nil {
 		t.Error("Expected no error, got:", err)

--- a/pkg/pki/certmanagerpki/certmanager_user_test.go
+++ b/pkg/pki/certmanagerpki/certmanager_user_test.go
@@ -18,8 +18,10 @@ import (
 	"context"
 	"reflect"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
@@ -28,6 +30,8 @@ import (
 	"github.com/banzaicloud/koperator/pkg/errorfactory"
 	certutil "github.com/banzaicloud/koperator/pkg/util/cert"
 )
+
+const testDuration = time.Hour * 1
 
 func newMockUser() *v1alpha1.KafkaUser {
 	user := &v1alpha1.KafkaUser{}
@@ -98,6 +102,14 @@ func TestReconcileUserCertificate(t *testing.T) {
 			Group: "testGroup",
 		},
 	}
+
+	if _, err := manager.ReconcileUserCertificate(ctx, user, scheme.Scheme, clusterDomain); err != nil {
+		t.Error("Expected no error, got:", err)
+	}
+
+	// Test cert duration case
+	user = newMockUser()
+	user.Spec.Duration = &v1.Duration{Duration: testDuration}
 
 	if _, err := manager.ReconcileUserCertificate(ctx, user, scheme.Scheme, clusterDomain); err != nil {
 		t.Error("Expected no error, got:", err)

--- a/pkg/pki/k8scsrpki/k8scsr_user_test.go
+++ b/pkg/pki/k8scsrpki/k8scsr_user_test.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/banzaicloud/koperator/api/v1alpha1"
 	"github.com/banzaicloud/koperator/api/v1beta1"
+	"github.com/banzaicloud/koperator/pkg/util"
 	"github.com/banzaicloud/koperator/pkg/util/cert"
 )
 
@@ -58,7 +59,8 @@ func createKafkaUser() *v1alpha1.KafkaUser {
 				PKIBackend: string(v1beta1.PKIBackendK8sCSR),
 				SignerName: "foo.bar/foobar",
 			},
-			DNSNames: []string{testDns},
+			DNSNames:          []string{testDns},
+			ExpirationSeconds: util.Int32Pointer(7200),
 		},
 	}
 }

--- a/properties/go.mod
+++ b/properties/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	emperror.dev/errors v0.8.1
-	github.com/onsi/gomega v1.27.7
+	github.com/onsi/gomega v1.27.8
 )
 
 require (

--- a/properties/go.sum
+++ b/properties/go.sum
@@ -8,9 +8,9 @@ github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEe
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 h1:yAJXTCF9TqKcTiHJAE8dj7HMvPfh66eeA2JYW7eFpSE=
-github.com/onsi/ginkgo/v2 v2.9.5 h1:+6Hr4uxzP4XIUyAkg61dWBw8lb/gc4/X5luuxN/EC+Q=
-github.com/onsi/gomega v1.27.7 h1:fVih9JD6ogIiHUN6ePK7HJidyEDpWGVB5mzM7cWNXoU=
-github.com/onsi/gomega v1.27.7/go.mod h1:1p8OOlwo2iUUDsHnOrjE5UKYJ+e3W8eQ3qSlRahPmr4=
+github.com/onsi/ginkgo/v2 v2.9.7 h1:06xGQy5www2oN160RtEZoTvnP2sPhEfePYmCDc2szss=
+github.com/onsi/gomega v1.27.8 h1:gegWiwZjBsf2DgiSbf5hpokZ98JVDMcWkUiigk6/KXc=
+github.com/onsi/gomega v1.27.8/go.mod h1:2J8vzI/s+2shY9XHRApDkdgPo1TKT7P2u6fXeJKFnNQ=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
## Description

This MR is to add duration in Kafka user spec. It allows user to specify validity time for certificate created by cert manager.  
It helps the user to create user certificate for longer duration than the default value of cert manager. #964 

## Type of Change
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] New Feature

## Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
