### PR TITLE
don't own ConfigMap

### DIFF
--- a/controllers/kafkacluster_controller.go
+++ b/controllers/kafkacluster_controller.go
@@ -401,7 +401,6 @@ func SetupKafkaClusterWithManager(mgr ctrl.Manager) *ctrl.Builder {
 func kafkaWatches(builder *ctrl.Builder) *ctrl.Builder {
 	return builder.
 		Owns(&corev1.Service{}).
-		Owns(&corev1.ConfigMap{}).
 		Owns(&policyv1.PodDisruptionBudget{}).
 		Owns(&corev1.PersistentVolumeClaim{}).
 		Owns(&corev1.Pod{})
@@ -410,13 +409,11 @@ func kafkaWatches(builder *ctrl.Builder) *ctrl.Builder {
 func envoyWatches(builder *ctrl.Builder) *ctrl.Builder {
 	return builder.
 		Owns(&corev1.Service{}).
-		Owns(&appsv1.Deployment{}).
-		Owns(&corev1.ConfigMap{})
+		Owns(&appsv1.Deployment{})
 }
 
 func cruiseControlWatches(builder *ctrl.Builder) *ctrl.Builder {
 	return builder.
 		Owns(&corev1.Service{}).
-		Owns(&appsv1.Deployment{}).
-		Owns(&corev1.ConfigMap{})
+		Owns(&appsv1.Deployment{})
 }


### PR DESCRIPTION
## Description

for issue #995

AIUI, operators should own ALL Secrets or ConfigMaps and probably some other resources.
https://sdk.operatorframework.io/docs/best-practices/designing-lean-operators/

The default client cache will handle watching changes to the ConfigMaps in this namespace as they are used.


## Type of Change
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [X] Bug Fix

## Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
