### PR TITLE
Updated default zookeeper name to zookeeper-server

### DIFF
--- a/config/samples/kafkacluster-with-istio.yaml
+++ b/config/samples/kafkacluster-with-istio.yaml
@@ -14,7 +14,7 @@ spec:
     gatewayConfig:
       mode: ISTIO_MUTUAL
   zkAddresses:
-    - "zookeeper-client.zookeeper:2181"
+    - "zookeeper-server-client.zookeeper:2181"
   oneBrokerPerNode: false
   clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.0"
   readOnlyConfig: |

--- a/config/samples/kafkacluster_with_external_ssl.yaml
+++ b/config/samples/kafkacluster_with_external_ssl.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   headlessServiceEnabled: true
   zkAddresses:
-    - "zookeeper-client.zookeeper:2181"
+    - "zookeeper-server-client.zookeeper:2181"
   oneBrokerPerNode: false
   clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.0"
   readOnlyConfig: |

--- a/config/samples/kafkacluster_with_external_ssl_customcert.yaml
+++ b/config/samples/kafkacluster_with_external_ssl_customcert.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   headlessServiceEnabled: true
   zkAddresses:
-    - "zookeeper-client.zookeeper:2181"
+    - "zookeeper-server-client.zookeeper:2181"
   oneBrokerPerNode: false
   clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.0"
   readOnlyConfig: |

--- a/config/samples/kafkacluster_with_ssl_groups.yaml
+++ b/config/samples/kafkacluster_with_ssl_groups.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   headlessServiceEnabled: true
   zkAddresses:
-    - "zookeeper-client.zookeeper:2181"
+    - "zookeeper-server-client.zookeeper:2181"
   rackAwareness:
     # operator will use these labels from the nodes to create the rack for Kafka
     labels:

--- a/config/samples/kafkacluster_with_ssl_groups_customcert.yaml
+++ b/config/samples/kafkacluster_with_ssl_groups_customcert.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   headlessServiceEnabled: true
   zkAddresses:
-    - "zookeeper-client.zookeeper:2181"
+    - "zookeeper-server-client.zookeeper:2181"
   rackAwareness:
     # operator will use these labels from the nodes to create the rack for Kafka
     labels:

--- a/config/samples/kafkacluster_with_ssl_hybrid_customcert.yaml
+++ b/config/samples/kafkacluster_with_ssl_hybrid_customcert.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   headlessServiceEnabled: true
   zkAddresses:
-    - "zookeeper-client.zookeeper:2181"
+    - "zookeeper-server-client.zookeeper:2181"
   rackAwareness:
     # operator will use these labels from the nodes to create the rack for Kafka
     labels:

--- a/config/samples/kafkacluster_without_ssl.yaml
+++ b/config/samples/kafkacluster_without_ssl.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   headlessServiceEnabled: true
   zkAddresses:
-    - "zookeeper-client.zookeeper:2181"
+    - "zookeeper-server-client.zookeeper:2181"
   oneBrokerPerNode: false
   clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.0"
   readOnlyConfig: |

--- a/config/samples/kafkacluster_without_ssl_groups.yaml
+++ b/config/samples/kafkacluster_without_ssl_groups.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   headlessServiceEnabled: true
   zkAddresses:
-    - "zookeeper-client.zookeeper:2181"
+    - "zookeeper-server-client.zookeeper:2181"
   oneBrokerPerNode: false
   clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.0"
   readOnlyConfig: |

--- a/config/samples/simplekafkacluster-with-brokerbindings.yaml
+++ b/config/samples/simplekafkacluster-with-brokerbindings.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   headlessServiceEnabled: true
   zkAddresses:
-    - "zookeeper-client.zookeeper:2181"
+    - "zookeeper-server-client.zookeeper:2181"
   propagateLabels: false
   oneBrokerPerNode: false
   clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.0"

--- a/config/samples/simplekafkacluster-with-nodeport-external.yaml
+++ b/config/samples/simplekafkacluster-with-nodeport-external.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   headlessServiceEnabled: false
   zkAddresses:
-    - "zookeeper-client.zookeeper:2181"
+    - "zookeeper-server-client.zookeeper:2181"
   propagateLabels: false
   oneBrokerPerNode: false
   clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.0"

--- a/config/samples/simplekafkacluster.yaml
+++ b/config/samples/simplekafkacluster.yaml
@@ -9,7 +9,7 @@ spec:
     jmxImage: "ghcr.io/banzaicloud/jmx-javaagent:0.16.1"
   headlessServiceEnabled: true
   zkAddresses:
-    - "zookeeper-client.zookeeper:2181"
+    - "zookeeper-server-client.zookeeper:2181"
   propagateLabels: false
   oneBrokerPerNode: false
   clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.0"

--- a/config/samples/simplekafkacluster_affinity.yaml
+++ b/config/samples/simplekafkacluster_affinity.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   headlessServiceEnabled: true
   zkAddresses:
-    - "zookeeper-client.zookeeper:2181"
+    - "zookeeper-server-client.zookeeper:2181"
   propagateLabels: false
   # If true OneBrokerPerNode ensures that each kafka broker will be placed on a different node unless a custom
   # Affinity definition overrides this behavior either set in brokerConfigGroups or in one specific brokerConfig

--- a/config/samples/simplekafkacluster_ebs_csi.yaml
+++ b/config/samples/simplekafkacluster_ebs_csi.yaml
@@ -11,7 +11,7 @@ spec:
       - "failure-domain.beta.kubernetes.io/region"
       - "failure-domain.beta.kubernetes.io/zone"
   zkAddresses:
-    - "zookeeper-client.zookeeper:2181"
+    - "zookeeper-server-client.zookeeper:2181"
   zkPath: "/kafka"
   propagateLabels: true
   oneBrokerPerNode: false

--- a/config/samples/simplekafkacluster_ssl.yaml
+++ b/config/samples/simplekafkacluster_ssl.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   headlessServiceEnabled: true
   zkAddresses:
-    - "zookeeper-client.zookeeper:2181"
+    - "zookeeper-server-client.zookeeper:2181"
   propagateLabels: false
   oneBrokerPerNode: false
   clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.0"

--- a/config/samples/simplekafkacluster_with_k8s_provided_nodeport.yaml
+++ b/config/samples/simplekafkacluster_with_k8s_provided_nodeport.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   headlessServiceEnabled: true
   zkAddresses:
-    - "zookeeper-client.zookeeper:2181"
+    - "zookeeper-server-client.zookeeper:2181"
   propagateLabels: false
   oneBrokerPerNode: false
   clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.0"

--- a/config/samples/simplekafkacluster_with_sasl.yaml
+++ b/config/samples/simplekafkacluster_with_sasl.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   headlessServiceEnabled: true
   zkAddresses:
-    - "zookeeper-client.zookeeper:2181"
+    - "zookeeper-server-client.zookeeper:2181"
   propagateLabels: false
   oneBrokerPerNode: false
   clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.0"

--- a/docs/benchmarks/infrastructure/kafka.yaml
+++ b/docs/benchmarks/infrastructure/kafka.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   headlessServiceEnabled: false
   zkAddresses:
-    - "zookeeper-client.zookeeper:2181"
+    - "zookeeper-server-client.zookeeper:2181"
   oneBrokerPerNode: true
   clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.0"
   readOnlyConfig: |

--- a/docs/benchmarks/infrastructure/kafka_202001_3brokers.yaml
+++ b/docs/benchmarks/infrastructure/kafka_202001_3brokers.yaml
@@ -63,7 +63,7 @@ spec:
           partition: $4
   headlessServiceEnabled: false
   zkAddresses:
-    - "zookeeper-client.zookeeper:2181"
+    - "zookeeper-server-client.zookeeper:2181"
   oneBrokerPerNode: true
   clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.0"
   readOnlyConfig: |


### PR DESCRIPTION
## Description

Updated zookeeper cluster default name to zookeeper-server. Not sure if it's a breaking change really but I'll still mark it as one to be sure.

## Type of Change
- [x] Breaking Change
- [x] Refactor

## Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] All new and existing tests pass
