### PR TITLE
Support Kafka up to 3.4.1

### DIFF
--- a/config/samples/banzaicloud_v1beta1_kafkacluster.yaml
+++ b/config/samples/banzaicloud_v1beta1_kafkacluster.yaml
@@ -35,7 +35,7 @@ spec:
 
   # Specify the Kafka Broker related settings
   # clusterImage can specify the whole kafkacluster image in one place
-  #clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.2
+  #clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.4.1
 
   #clusterWideConfig specifies the cluster-wide kafka config cluster wide, all these can be overridden per-broker
   #clusterWideConfig: |
@@ -169,7 +169,7 @@ spec:
         cruise.control.metrics.topic.replication.factor=2
       brokerConfig:
         # Docker image used by the operator to create the Broker with id 0
-        #image: "ghcr.io/banzaicloud/kafka:2.13-3.1.2
+        #image: "ghcr.io/banzaicloud/kafka:2.13-3.4.1
         # resourceRequirements works exactly like Container resources, the user can specify the limit and the requests
         # through this property
         #resourceRequirements:
@@ -240,7 +240,7 @@ spec:
         #volumeMounts:
         #  - mountPath: "/opt/kafka/libs/extra-jars"
         #    name: "jars"
-    - image: "ghcr.io/banzaicloud/kafka:2.13-3.1.2"
+    - image: "ghcr.io/banzaicloud/kafka:2.13-3.4.1"
       id: 1
       config: |
         auto.create.topics.enable=false
@@ -262,7 +262,7 @@ spec:
       readOnlyConfig: |
         auto.create.topics.enable=false
       brokerConfig:
-        image: "ghcr.io/banzaicloud/kafka:2.13-3.1.2"
+        image: "ghcr.io/banzaicloud/kafka:2.13-3.4.1"
         storageConfigs:
           - mountPath: "/kafka-logs"
             pvcSpec:

--- a/config/samples/kafkacluster-prometheus.yaml
+++ b/config/samples/kafkacluster-prometheus.yaml
@@ -85,7 +85,7 @@ spec:
         storageClass: 'gp2'
         mountPath: '/kafkalog'
         diskSize: '10G'
-        image: 'ghcr.io/banzaicloud/kafka:2.13-3.1.2'
+        image: 'ghcr.io/banzaicloud/kafka:2.13-3.4.1'
         # annotations to be applied onto the broker pod
         # brokerAnnotations: '{ "sidecar.istio.io/logLevel": "trace", "sidecar.istio.io/proxyCPULimit": "50m" }'
         command: 'upScale'
@@ -101,7 +101,7 @@ spec:
         storageClass: 'gp2'
         mountPath: '/kafkalog'
         diskSize: '10G'
-        image: 'ghcr.io/banzaicloud/kafka:2.13-3.1.2'
+        image: 'ghcr.io/banzaicloud/kafka:2.13-3.4.1'
         # annotations to be applied onto the broker pod
         # brokerAnnotations: '{ "sidecar.istio.io/logLevel": "trace", "sidecar.istio.io/proxyCPULimit": "50m" }'
         command: 'upScale'
@@ -117,7 +117,7 @@ spec:
         storageClass: 'gp2'
         mountPath: '/kafkalog'
         diskSize: '10G'
-        image: 'ghcr.io/banzaicloud/kafka:2.13-3.1.2'
+        image: 'ghcr.io/banzaicloud/kafka:2.13-3.4.1'
         # annotations to be applied onto the broker pod
         # brokerAnnotations: '{ "sidecar.istio.io/logLevel": "trace", "sidecar.istio.io/proxyCPULimit": "50m" }'
         command: 'upScale'

--- a/config/samples/kafkacluster-with-istio.yaml
+++ b/config/samples/kafkacluster-with-istio.yaml
@@ -16,7 +16,7 @@ spec:
   zkAddresses:
     - "zookeeper-server-client.zookeeper:2181"
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.2"
+  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.4.1"
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/kafkacluster_with_external_ssl.yaml
+++ b/config/samples/kafkacluster_with_external_ssl.yaml
@@ -9,7 +9,7 @@ spec:
   zkAddresses:
     - "zookeeper-server-client.zookeeper:2181"
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.2"
+  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.4.1"
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/kafkacluster_with_external_ssl_customcert.yaml
+++ b/config/samples/kafkacluster_with_external_ssl_customcert.yaml
@@ -9,7 +9,7 @@ spec:
   zkAddresses:
     - "zookeeper-server-client.zookeeper:2181"
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.2"
+  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.4.1"
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/kafkacluster_with_ssl_groups.yaml
+++ b/config/samples/kafkacluster_with_ssl_groups.yaml
@@ -14,7 +14,7 @@ spec:
       - "failure-domain.beta.kubernetes.io/region"
       - "failure-domain.beta.kubernetes.io/zone"
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.2"
+  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.4.1"
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/kafkacluster_with_ssl_groups_customcert.yaml
+++ b/config/samples/kafkacluster_with_ssl_groups_customcert.yaml
@@ -14,7 +14,7 @@ spec:
       - "failure-domain.beta.kubernetes.io/region"
       - "failure-domain.beta.kubernetes.io/zone"
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.2"
+  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.4.1"
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/kafkacluster_with_ssl_hybrid_customcert.yaml
+++ b/config/samples/kafkacluster_with_ssl_hybrid_customcert.yaml
@@ -14,7 +14,7 @@ spec:
       - "failure-domain.beta.kubernetes.io/region"
       - "failure-domain.beta.kubernetes.io/zone"
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.2"
+  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.4.1"
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/kafkacluster_without_ssl.yaml
+++ b/config/samples/kafkacluster_without_ssl.yaml
@@ -9,7 +9,7 @@ spec:
   zkAddresses:
     - "zookeeper-server-client.zookeeper:2181"
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.2"
+  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.4.1"
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/kafkacluster_without_ssl_groups.yaml
+++ b/config/samples/kafkacluster_without_ssl_groups.yaml
@@ -9,7 +9,7 @@ spec:
   zkAddresses:
     - "zookeeper-server-client.zookeeper:2181"
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.2"
+  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.4.1"
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/simplekafkacluster-with-brokerbindings.yaml
+++ b/config/samples/simplekafkacluster-with-brokerbindings.yaml
@@ -10,7 +10,7 @@ spec:
     - "zookeeper-server-client.zookeeper:2181"
   propagateLabels: false
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.2"
+  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.4.1"
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/simplekafkacluster-with-nodeport-external.yaml
+++ b/config/samples/simplekafkacluster-with-nodeport-external.yaml
@@ -10,7 +10,7 @@ spec:
     - "zookeeper-server-client.zookeeper:2181"
   propagateLabels: false
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.2"
+  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.4.1"
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/simplekafkacluster.yaml
+++ b/config/samples/simplekafkacluster.yaml
@@ -12,7 +12,7 @@ spec:
     - "zookeeper-server-client.zookeeper:2181"
   propagateLabels: false
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.2"
+  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.4.1"
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/simplekafkacluster_affinity.yaml
+++ b/config/samples/simplekafkacluster_affinity.yaml
@@ -12,7 +12,7 @@ spec:
   # If true OneBrokerPerNode ensures that each kafka broker will be placed on a different node unless a custom
   # Affinity definition overrides this behavior either set in brokerConfigGroups or in one specific brokerConfig
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.2"
+  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.4.1"
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/simplekafkacluster_ebs_csi.yaml
+++ b/config/samples/simplekafkacluster_ebs_csi.yaml
@@ -15,7 +15,7 @@ spec:
   zkPath: "/kafka"
   propagateLabels: true
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.2"
+  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.4.1"
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/simplekafkacluster_ssl.yaml
+++ b/config/samples/simplekafkacluster_ssl.yaml
@@ -10,7 +10,7 @@ spec:
     - "zookeeper-server-client.zookeeper:2181"
   propagateLabels: false
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.2"
+  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.4.1"
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/simplekafkacluster_with_k8s_provided_nodeport.yaml
+++ b/config/samples/simplekafkacluster_with_k8s_provided_nodeport.yaml
@@ -10,7 +10,7 @@ spec:
     - "zookeeper-server-client.zookeeper:2181"
   propagateLabels: false
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.2"
+  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.4.1"
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/simplekafkacluster_with_sasl.yaml
+++ b/config/samples/simplekafkacluster_with_sasl.yaml
@@ -10,7 +10,7 @@ spec:
     - "zookeeper-server-client.zookeeper:2181"
   propagateLabels: false
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.2"
+  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.4.1"
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/controllers/tests/clusterregistry/common_test.go
+++ b/controllers/tests/clusterregistry/common_test.go
@@ -104,7 +104,7 @@ func createMinimalKafkaClusterCR(name, namespace string) *v1beta1.KafkaCluster {
 					BrokerConfigGroup: defaultBrokerConfigGroup,
 				},
 			},
-			ClusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.2",
+			ClusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.4.1",
 			ZKAddresses:  []string{},
 			MonitoringConfig: v1beta1.MonitoringConfig{
 				CCJMXExporterConfig: "custom_property: custom_value",

--- a/controllers/tests/common_test.go
+++ b/controllers/tests/common_test.go
@@ -118,7 +118,7 @@ func createMinimalKafkaClusterCR(name, namespace string) *v1beta1.KafkaCluster {
 					BrokerConfigGroup: defaultBrokerConfigGroup,
 				},
 			},
-			ClusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.2",
+			ClusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.4.1",
 			ZKAddresses:  []string{},
 			MonitoringConfig: v1beta1.MonitoringConfig{
 				CCJMXExporterConfig: "custom_property: custom_value",

--- a/controllers/tests/kafkacluster_controller_cruisecontrol_test.go
+++ b/controllers/tests/kafkacluster_controller_cruisecontrol_test.go
@@ -281,7 +281,7 @@ func expectCruiseControlDeployment(ctx context.Context, kafkaCluster *v1beta1.Ka
 	Expect(container.Lifecycle).NotTo(BeNil())
 	Expect(container.Lifecycle.PreStop).NotTo(BeNil())
 	Expect(container.Lifecycle.PreStop.Exec).NotTo(BeNil())
-	Expect(container.Image).To(Equal("ghcr.io/banzaicloud/cruise-control:2.5.101"))
+	Expect(container.Image).To(Equal("ghcr.io/banzaicloud/cruise-control:2.5.123"))
 	Expect(container.Ports).To(ConsistOf(
 		corev1.ContainerPort{
 			ContainerPort: 8090,

--- a/controllers/tests/kafkacluster_controller_kafka_test.go
+++ b/controllers/tests/kafkacluster_controller_kafka_test.go
@@ -251,7 +251,7 @@ func expectKafkaBrokerPod(ctx context.Context, kafkaCluster *v1beta1.KafkaCluste
 	Expect(pod.Spec.Containers[1]).To(WithTransform(getContainerName, Equal("test-container")))
 	container := pod.Spec.Containers[0]
 	Expect(container.Name).To(Equal("kafka"))
-	Expect(container.Image).To(Equal("ghcr.io/banzaicloud/kafka:2.13-3.1.2"))
+	Expect(container.Image).To(Equal("ghcr.io/banzaicloud/kafka:2.13-3.4.1"))
 	Expect(container.Lifecycle).NotTo(BeNil())
 	Expect(container.Lifecycle.PreStop).NotTo(BeNil())
 	getEnvName := func(c corev1.EnvVar) string { return c.Name }

--- a/docs/benchmarks/infrastructure/kafka.yaml
+++ b/docs/benchmarks/infrastructure/kafka.yaml
@@ -9,7 +9,7 @@ spec:
   zkAddresses:
     - "zookeeper-server-client.zookeeper:2181"
   oneBrokerPerNode: true
-  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.2"
+  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.4.1"
   readOnlyConfig: |
     auto.create.topics.enable=false
   rackAwareness:

--- a/docs/benchmarks/infrastructure/kafka_202001_3brokers.yaml
+++ b/docs/benchmarks/infrastructure/kafka_202001_3brokers.yaml
@@ -65,7 +65,7 @@ spec:
   zkAddresses:
     - "zookeeper-server-client.zookeeper:2181"
   oneBrokerPerNode: true
-  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.1.2"
+  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-3.4.1"
   readOnlyConfig: |
     auto.create.topics.enable=false
     min.insync.replicas=3

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/banzaicloud/istio-client-go v0.0.17
 	github.com/banzaicloud/istio-operator/api/v2 v2.15.1
 	github.com/banzaicloud/k8s-objectmatcher v1.8.0
-	github.com/banzaicloud/koperator/api v0.28.4
+	github.com/banzaicloud/koperator/api v0.28.5
 	github.com/banzaicloud/koperator/properties v0.4.1
 	github.com/cert-manager/cert-manager v1.11.2
 	github.com/cisco-open/cluster-registry-controller/api v0.2.5

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/banzaicloud/istio-operator/api/v2 v2.15.1 h1:BZg8COvoOJtfx/dgN7KpoOnc
 github.com/banzaicloud/istio-operator/api/v2 v2.15.1/go.mod h1:5qCpwWlIfxiLvBfTvT2mD2wp5RlFCDEt8Xql4sYPNBc=
 github.com/banzaicloud/k8s-objectmatcher v1.8.0 h1:Nugn25elKtPMTA2br+JgHNeSQ04sc05MDPmpJnd1N2A=
 github.com/banzaicloud/k8s-objectmatcher v1.8.0/go.mod h1:p2LSNAjlECf07fbhDyebTkPUIYnU05G+WfGgkTmgeMg=
-github.com/banzaicloud/koperator/api v0.28.4 h1:ZVLGvWbxuJI4+3123141mcRVK+x6p7IWxO3BtBVc0LQ=
-github.com/banzaicloud/koperator/api v0.28.4/go.mod h1:fo0y8UdiH9YPE+sIK5LcJWG6hd0pIA13F4li6DOIal4=
+github.com/banzaicloud/koperator/api v0.28.5 h1:MJ1s5QtW8zRN4aozyfBxXJ1nca8VcXL4TTZUc2Y9T6U=
+github.com/banzaicloud/koperator/api v0.28.5/go.mod h1:fo0y8UdiH9YPE+sIK5LcJWG6hd0pIA13F4li6DOIal4=
 github.com/banzaicloud/koperator/properties v0.4.1 h1:SB2QgXlcK1Dc7Z1rg65PJifErDa8OQnoWCCJgmC7SGc=
 github.com/banzaicloud/koperator/properties v0.4.1/go.mod h1:TcL+llxuhW3UeQtVEDYEXGouFLF2P+LuZZVudSb6jyA=
 github.com/banzaicloud/operator-tools v0.28.0 h1:GSfc0qZr6zo7WrNxdgWZE1LcTChPU8QFYOTDirYVtIM=


### PR DESCRIPTION
## Description

Add support for Kafka up to v3.4.1

### Smoke test
- [x] Kafka cluster with PLAINTEXT listeners
- [x] Kafka cluster with SSL internal and external listeners
- [x] Kafka cluster with ACL enabled while using SSL for both internal and external listeners
- [x] Brokers scaling

Note: the image built with the change in this PR https://github.com/banzaicloud/docker-kafka/pull/32 was used for the above smoke tests

## Type of Change
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] New Feature

## Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
