### PR TITLE
add function to delete namespaces during uninstall e2e test

### DIFF
--- a/tests/e2e/helm.go
+++ b/tests/e2e/helm.go
@@ -245,7 +245,7 @@ func (helmDescriptor *helmDescriptor) uninstallHelmChart(kubectlOptions k8s.Kube
 		&helm.Options{
 			KubectlOptions: &kubectlOptions,
 			ExtraArgs: map[string][]string{
-				"delete": append(fixedArguments, helmDescriptor.HelmExtraArguments["install"]...),
+				"delete": append(fixedArguments, helmDescriptor.HelmExtraArguments["delete"]...),
 			},
 		},
 		helmDescriptor.ReleaseName,

--- a/tests/e2e/uninstall.go
+++ b/tests/e2e/uninstall.go
@@ -214,9 +214,5 @@ func requireRemoveNamespace(kubectlOptions k8s.KubectlOptions, namespace string)
 	It(fmt.Sprintf("Removing namespace %s", namespace), func() {
 		err := deleteK8sResourceNoErrNotFound(kubectlOptions, defaultDeletionTimeout, "namespace", namespace, "--wait")
 		Expect(err).ShouldNot(HaveOccurred())
-
-		remainingResources, err := getK8sResources(kubectlOptions, []string{"namespaces"}, "", "", kubectlArgGoTemplateName)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(remainingResources).ShouldNot(ContainElement(namespace))
 	})
 }


### PR DESCRIPTION
## Description

The `uninstall` e2e test does not currently remove the namespaces created by the install test/steps (via the Namespace field of helmDescriptors and the "--create-namespace" `helm` command flag).  

This PR brings a function that will do that.  
This action should be idempotent due to the call to `deleteK8sResourceNoErrNotFound()`.

This will be useful in the context of reusing test clusters and being able to check that an uninstall didn't leave unwanted objects behind (like we did with these namespaces).

I also moved the `requireRemoveKoperatorCRDs()` function definition a bit lower in the file to maintain some consistency in the order we define functions in the `tests/e2e/uninstall.go` file.

The small change in the `tests/e2e/helm.go` file ("delete" word) is just correcting a typo that has been harmless so far.

## Type of Change
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Other (please describe) : complete a test feature

## Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [x] I have verified this change is not present in other open pull requests
- [x] All code style checks pass

