### PR TITLE
modify uninstall global settings initialization to accept empty list

### DIFF
--- a/tests/e2e/k8s.go
+++ b/tests/e2e/k8s.go
@@ -501,6 +501,12 @@ func listK8sResourceKinds(kubectlOptions k8s.KubectlOptions, apiGroupSelector st
 		return nil, err
 	}
 
+	output = strings.Trim(output, "'")
+	// Empty output
+	if output == "" {
+		return nil, nil
+	}
+
 	return kubectlRemoveWarnings(strings.Split(output, "\n")), nil
 }
 

--- a/tests/e2e/types.go
+++ b/tests/e2e/types.go
@@ -25,25 +25,16 @@ func (c *dependencyCRDsType) CertManager() []string {
 func (c *dependencyCRDsType) Initialize(kubectlOptions k8s.KubectlOptions) error {
 	var err error
 	c.certManager, err = listK8sResourceKinds(kubectlOptions, apiGroupKoperatorDependencies()["cert-manager"])
-	if len(c.certManager) == 0 {
-		if err != nil {
-			return fmt.Errorf("initialize Cert-manager CRDs error: %w", err)
-		}
-		return fmt.Errorf("Cert-manager CRDs %w", ErrorNotFound)
+	if err != nil {
+		return fmt.Errorf("initialize Cert-manager CRDs error: %w", err)
 	}
 	c.prometheus, err = listK8sResourceKinds(kubectlOptions, apiGroupKoperatorDependencies()["prometheus"])
-	if len(c.prometheus) == 0 {
-		if err != nil {
-			return fmt.Errorf("initialize Prometheus CRDs error: %w", err)
-		}
-		return fmt.Errorf("Prometheus CRDs %w", ErrorNotFound)
+	if err != nil {
+		return fmt.Errorf("initialize Prometheus CRDs error: %w", err)
 	}
 	c.zookeeper, err = listK8sResourceKinds(kubectlOptions, apiGroupKoperatorDependencies()["zookeeper"])
-	if len(c.zookeeper) == 0 {
-		if err != nil {
-			return fmt.Errorf("initialize Zookeeper CRDs error: %w", err)
-		}
-		return fmt.Errorf("Zookeeper CRDs %w", ErrorNotFound)
+	if err != nil {
+		return fmt.Errorf("initialize Zookeeper CRDs error: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

The code in the koperator e2e tests uninstall part (the part with CRDs and "prerequisites" of koperator like cert-manager, prometheus and zookeeper) does not appear to be idempotent in either execution or initialisation of variables.

This PR aims to fix 2 things : 

1. Because `listK8sResourceKinds()` doesn't have a check for `""` as kubectl output (like `getK8sResources()` does) when there are no CRs or CRDs under a specific APIGroup the returned `[]string` contains a `""` as the only element making the check for `len == 0` always false and the returned value itself quite misleading (it's devoid of meaning yet not empty -> the `tests/e2e/k8s.go` part of this PR aims to cover that)
    * this is a bug rooted in some inconsistent output from the CLI command
    * accepting a `[""]` as a valid result for c.certmanager (and the others) has another consequence: 
        * when we call `deleteK8sResourceNoErrNotFound()` during the Uninstall test we end up asking terratest to issue the command "kubectl delete <resource>" without a name for the instance of the resource to be deleted which yields this error from kubectl `error: resource(s) were provided, but no name was specified` even on the CLI (here is an [example of such a place](https://github.com/banzaicloud/koperator/blob/2a3e8ce8d5aa2d4f09e20111c508b898997448e7/tests/e2e/uninstall.go#L203))

3. The check for `if len(c.certManager) == 0` (and the equivalent ones for other components) combined with **always** returning an error (which eventually means test failure) **if** that condition evaluates to `true`
    * this combination effectively ensure that the uninstall operation is not idempotent which is not what we aimed for
    * The condition being true approximately means: "no CRDs or CRs from a certain 3rd party APIGroup were found"
    * The fact that no relevant resources were found means there is nothing to delete. This should not mean test failure but simply that "there is nothing to do here so move on".
    * This has the unintended consequence of: 
        * If a test run successfully deletes ZookeeperOperator resources but later fails on deleting cert-manager, then subsequent runs of the Uninstall test on the same cluster will fail during `Setting Globals` (the initial part of the uninstall test) for Zookeeper since the `listK8sResourceKinds()` output will be empty and we would return an error with the current code instead of accepting the "NOOP" 

The current behaviour of the uninstall test becomes a problem when trying to develop more for or around that test and that can require multiple runs on the same cluster and it ends up tying it too strongly to an install step being run every single time before uninstall. 

The uninstall step "not finding a resource" in order to delete it should be ok. It's the install step's duty to check all things get installed correctly in the beginning.

## Type of Change
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Bug Fix

## Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [x] I have verified this change is not present in other open pull requests
- [x] All code style checks pass
