### PR TITLE
add kafkauser annotation validations

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/banzaicloud/istio-client-go v0.0.17
 	github.com/cert-manager/cert-manager v1.11.2
 	github.com/imdario/mergo v0.3.13
+	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.26.4
 	k8s.io/apimachinery v0.26.4

--- a/api/go.sum
+++ b/api/go.sum
@@ -59,6 +59,8 @@ go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9i
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1 h1:MGwJjxBy0HJshjDNfLsYO8xppfqWlA5ZT9OhtUUhTNw=
+golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=

--- a/api/v1alpha1/kafkauser_types.go
+++ b/api/v1alpha1/kafkauser_types.go
@@ -15,6 +15,7 @@
 package v1alpha1
 
 import (
+	"strings"
 	"time"
 
 	"github.com/banzaicloud/koperator/api/util"
@@ -26,6 +27,8 @@ import (
 const (
 	// default certificate duration if kafkauser.spec.expirationSeconds is not set
 	defaultCertificateDuration = time.Hour * 24 * 90
+	// CertManagerSignerNamePrefix is acceptable pki backend signerName prefix for cert-manager
+	CertManagerSignerNamePrefix string = "clusterissuers.cert-manager.io"
 )
 
 // KafkaUserSpec defines the desired state of KafkaUser
@@ -108,6 +111,19 @@ func (spec *KafkaUserSpec) GetIfCertShouldBeCreated() bool {
 // GetAnnotations returns Annotations to use for certificate or certificate signing request object
 func (spec *KafkaUserSpec) GetAnnotations() map[string]string {
 	return util.CloneMap(spec.Annotations)
+}
+
+// ValidateAnnotations checks if certificate signing request annotations are valid
+func (spec *KafkaUserSpec) ValidateAnnotations() error {
+	// Validate annotations for cert-manager pki backend signer
+	if strings.Split(spec.PKIBackendSpec.SignerName, "/")[0] == CertManagerSignerNamePrefix {
+		certManagerCSRAnnotations := newCertManagerSignerAnnotations()
+		err := certManagerCSRAnnotations.validate(spec.GetAnnotations())
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (spec *KafkaUserSpec) GetExpirationSeconds() int32 {

--- a/api/v1alpha1/kafkauser_types.go
+++ b/api/v1alpha1/kafkauser_types.go
@@ -117,7 +117,7 @@ func (spec *KafkaUserSpec) GetAnnotations() map[string]string {
 func (spec *KafkaUserSpec) ValidateAnnotations() error {
 	// Validate annotations for cert-manager pki backend signer
 	if strings.Split(spec.PKIBackendSpec.SignerName, "/")[0] == CertManagerSignerNamePrefix {
-		certManagerCSRAnnotations := newCertManagerSignerAnnotations()
+		certManagerCSRAnnotations := newCertManagerSignerAnnotationsWithValidators()
 		err := certManagerCSRAnnotations.validate(spec.GetAnnotations())
 		if err != nil {
 			return err

--- a/api/v1alpha1/kafkauser_types_test.go
+++ b/api/v1alpha1/kafkauser_types_test.go
@@ -1,0 +1,89 @@
+// Copyright © 2023 Cisco Systems, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/banzaicloud/koperator/api/v1beta1"
+)
+
+const (
+	testNamespace             = "test-namespace"
+	testCertManagerSignerName = CertManagerSignerNamePrefix + "/test-issuer"
+)
+
+var (
+	testKafkaUser = &KafkaUser{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "KafkaUser",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-user",
+			Namespace: testNamespace,
+		},
+		Spec: KafkaUserSpec{
+			SecretName: "test-secret",
+			PKIBackendSpec: &PKIBackendSpec{
+				PKIBackend: string(v1beta1.PKIBackendK8sCSR),
+				SignerName: testCertManagerSignerName,
+			},
+		},
+	}
+)
+
+func TestKafkaUserSpecValidateAnnotationsCorrectAnnotationsList(t *testing.T) {
+	testAnnotations := map[string]string{
+		"experimental.cert-manager.io/request-duration": "2880h",
+	}
+	kafkaUser := testKafkaUser
+	kafkaUser.Spec.Annotations = testAnnotations
+
+	err := kafkaUser.Spec.ValidateAnnotations()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestKafkaUserSpecValidateAnnotationsCorrectAnnotationIncorrectValue(t *testing.T) {
+	testAnnotations := map[string]string{
+		"experimental.cert-manager.io/request-duration": "2880",
+	}
+	expectedErrorMessage := "could not parse certificate request duration: time: missing unit in duration \"2880\""
+	kafkaUser := testKafkaUser
+	kafkaUser.Spec.Annotations = testAnnotations
+
+	err := kafkaUser.Spec.ValidateAnnotations()
+	if !reflect.DeepEqual(err.Error(), expectedErrorMessage) {
+		t.Error("Expected:", expectedErrorMessage, "Got:", err.Error())
+	}
+}
+
+func TestKafkaUserSpecValidateAnnotationsIncorrectAnnotationsList(t *testing.T) {
+	testAnnotations := map[string]string{
+		"test-annotation": "test",
+	}
+	expected := newCertManagerSignerAnnotations().getNotSupportedAnnotationError()
+	kafkaUser := testKafkaUser
+	kafkaUser.Spec.Annotations = testAnnotations
+
+	err := kafkaUser.Spec.ValidateAnnotations()
+	if !reflect.DeepEqual(err.Error(), expected.Error()) {
+		t.Error("Expected:", expected.Error(), "Got:", err.Error())
+	}
+}

--- a/api/v1alpha1/kafkauser_types_test.go
+++ b/api/v1alpha1/kafkauser_types_test.go
@@ -89,8 +89,9 @@ func TestKafkaUserSpecValidateAnnotations(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			kafkaUser.Spec.Annotations = tt.args.annotations
-			found := kafkaUser.Spec.ValidateAnnotations()
+			k := kafkaUser.DeepCopy()
+			k.Spec.Annotations = tt.args.annotations
+			found := k.Spec.ValidateAnnotations()
 
 			if tt.wanted != nil && found != nil {
 				assert.Equal(t, tt.wanted.Error(), found.Error())

--- a/api/v1alpha1/kafkauserspec_annotations.go
+++ b/api/v1alpha1/kafkauserspec_annotations.go
@@ -1,0 +1,68 @@
+// Copyright © 2023 Cisco Systems, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"fmt"
+	"time"
+
+	"emperror.dev/errors"
+	"golang.org/x/exp/maps"
+)
+
+// annotationsWhithValidations is a map whose keys are KafkaUserSpec annotation keys, and values are validators
+type annotationsWhithValidations map[string]annotationValidator
+
+func (a annotationsWhithValidations) validate(as map[string]string) error {
+	for key, value := range as {
+		validator, ok := a[key]
+		if !ok {
+			return a.getNotSupportedAnnotationError()
+		}
+		err := validator.validate(value)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (a annotationsWhithValidations) getNotSupportedAnnotationError() error {
+	return fmt.Errorf("kafkauser annotations contain a not supported annotation for the signer, supported annotations: %v", maps.Keys(a))
+}
+
+// annotationValidator is used to implement a single annotation validator
+type annotationValidator interface {
+	validate(string) error
+}
+
+// newCertManagerSignerAnnotations returns annotationsWhithValidations for cert-manager pki backend signer
+func newCertManagerSignerAnnotations() annotationsWhithValidations {
+	var c certManagerRequestDurationValidator
+	return annotationsWhithValidations{
+		"experimental.cert-manager.io/request-duration": &c,
+	}
+}
+
+// certManagerRequestDurationValidator implements annotationValidator interface
+type certManagerRequestDurationValidator struct{}
+
+func (c certManagerRequestDurationValidator) validate(a string) error {
+	_, err := time.ParseDuration(a)
+	if err != nil {
+		return errors.WrapIf(err, "could not parse certificate request duration")
+	}
+	return nil
+}

--- a/api/v1alpha1/kafkauserspec_annotations.go
+++ b/api/v1alpha1/kafkauserspec_annotations.go
@@ -22,10 +22,10 @@ import (
 	"golang.org/x/exp/maps"
 )
 
-// annotationsWhithValidations is a map whose keys are KafkaUserSpec annotation keys, and values are validators
-type annotationsWhithValidations map[string]annotationValidator
+// annotationsWithValidations is a map whose keys are KafkaUserSpec annotation keys, and values are validators
+type annotationsWithValidations map[string]annotationValidator
 
-func (a annotationsWhithValidations) validate(as map[string]string) error {
+func (a annotationsWithValidations) validate(as map[string]string) error {
 	for key, value := range as {
 		validator, ok := a[key]
 		if !ok {
@@ -39,7 +39,7 @@ func (a annotationsWhithValidations) validate(as map[string]string) error {
 	return nil
 }
 
-func (a annotationsWhithValidations) getNotSupportedAnnotationError() error {
+func (a annotationsWithValidations) getNotSupportedAnnotationError() error {
 	return fmt.Errorf("kafkauser annotations contain a not supported annotation for the signer, supported annotations: %v", maps.Keys(a))
 }
 
@@ -48,10 +48,10 @@ type annotationValidator interface {
 	validate(string) error
 }
 
-// newCertManagerSignerAnnotationsWithValidators returns annotationsWhithValidations for cert-manager pki backend signer
-func newCertManagerSignerAnnotationsWithValidators() annotationsWhithValidations {
+// newCertManagerSignerAnnotationsWithValidators returns annotationsWithValidations for cert-manager pki backend signer
+func newCertManagerSignerAnnotationsWithValidators() annotationsWithValidations {
 	var c certManagerRequestDurationValidator
-	return annotationsWhithValidations{
+	return annotationsWithValidations{
 		"experimental.cert-manager.io/request-duration": &c,
 	}
 }

--- a/api/v1alpha1/kafkauserspec_annotations.go
+++ b/api/v1alpha1/kafkauserspec_annotations.go
@@ -48,8 +48,8 @@ type annotationValidator interface {
 	validate(string) error
 }
 
-// newCertManagerSignerAnnotations returns annotationsWhithValidations for cert-manager pki backend signer
-func newCertManagerSignerAnnotations() annotationsWhithValidations {
+// newCertManagerSignerAnnotationsWithValidators returns annotationsWhithValidations for cert-manager pki backend signer
+func newCertManagerSignerAnnotationsWithValidators() annotationsWhithValidations {
 	var c certManagerRequestDurationValidator
 	return annotationsWhithValidations{
 		"experimental.cert-manager.io/request-duration": &c,
@@ -57,7 +57,7 @@ func newCertManagerSignerAnnotations() annotationsWhithValidations {
 }
 
 // certManagerRequestDurationValidator implements annotationValidator interface
-type certManagerRequestDurationValidator struct{}
+type certManagerRequestDurationValidator func(string) error
 
 func (c certManagerRequestDurationValidator) validate(a string) error {
 	_, err := time.ParseDuration(a)


### PR DESCRIPTION
## Description

Add validators and whitelist for `KafkaUser` spec annotations.

Only cert-manager pki backend signer annotations are validated. The whitelist contains only one annotation - `experimental.cert-manager.io/request-duration`.

The kafkauser controller's side implementation and the `CertManagerSignerNamePrefix` references update will be pushed after bumping the API version.

Annotations' structs, methods, and interfaces are currently private and may be turned public in the future if needed.

## Type of Change
- [x] New Feature

## Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [x] I have verified this change is not present in other open pull requests
- [x] All code style checks pass
- [x] All new and existing tests pass
