### PR TITLE
validate kafkauser annotations before creating csr

### DIFF
--- a/controllers/kafkauser_controller.go
+++ b/controllers/kafkauser_controller.go
@@ -201,7 +201,7 @@ func (r *KafkaUserReconciler) Reconcile(ctx context.Context, request reconcile.R
 		// Validate the KafkaUser instance annotations before creating a certificate request
 		err := instance.Spec.ValidateAnnotations()
 		if err != nil {
-			return requeueWithError(reqLogger, "failed to reconcile kafkauser", err)
+			return requeueWithError(reqLogger, "failed to reconcile kafkauser while validating annotations", err)
 		}
 
 		// Avoid panic if the user wants to create a kafka user but the cluster is in plaintext mode

--- a/controllers/kafkauser_controller.go
+++ b/controllers/kafkauser_controller.go
@@ -198,6 +198,12 @@ func (r *KafkaUserReconciler) Reconcile(ctx context.Context, request reconcile.R
 	var kafkaUser string
 
 	if instance.Spec.GetIfCertShouldBeCreated() {
+		// Validate the KafkaUser instance annotations before creating a certificate request
+		err := instance.Spec.ValidateAnnotations()
+		if err != nil {
+			return requeueWithError(reqLogger, "failed to reconcile kafkauser", err)
+		}
+
 		// Avoid panic if the user wants to create a kafka user but the cluster is in plaintext mode
 		// TODO: refactor this and use webhook to validate if the cluster is eligible to create a kafka user
 		if cluster.Spec.ListenersConfig.SSLSecrets == nil && instance.Spec.PKIBackendSpec == nil {

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/banzaicloud/istio-client-go v0.0.17
 	github.com/banzaicloud/istio-operator/api/v2 v2.15.1
 	github.com/banzaicloud/k8s-objectmatcher v1.8.0
-	github.com/banzaicloud/koperator/api v0.28.5
+	github.com/banzaicloud/koperator/api v0.28.6
 	github.com/banzaicloud/koperator/properties v0.4.1
 	github.com/cert-manager/cert-manager v1.11.2
 	github.com/cisco-open/cluster-registry-controller/api v0.2.5
@@ -24,7 +24,7 @@ require (
 	github.com/prometheus/common v0.37.0
 	github.com/stretchr/testify v1.8.1
 	go.uber.org/zap v1.24.0
-	golang.org/x/exp v0.0.0-20220827204233-334a2380cb91
+	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
 	google.golang.org/protobuf v1.28.1
 	gopkg.in/inf.v0 v0.9.1
 	gotest.tools v2.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/banzaicloud/istio-operator/api/v2 v2.15.1 h1:BZg8COvoOJtfx/dgN7KpoOnc
 github.com/banzaicloud/istio-operator/api/v2 v2.15.1/go.mod h1:5qCpwWlIfxiLvBfTvT2mD2wp5RlFCDEt8Xql4sYPNBc=
 github.com/banzaicloud/k8s-objectmatcher v1.8.0 h1:Nugn25elKtPMTA2br+JgHNeSQ04sc05MDPmpJnd1N2A=
 github.com/banzaicloud/k8s-objectmatcher v1.8.0/go.mod h1:p2LSNAjlECf07fbhDyebTkPUIYnU05G+WfGgkTmgeMg=
-github.com/banzaicloud/koperator/api v0.28.5 h1:MJ1s5QtW8zRN4aozyfBxXJ1nca8VcXL4TTZUc2Y9T6U=
-github.com/banzaicloud/koperator/api v0.28.5/go.mod h1:fo0y8UdiH9YPE+sIK5LcJWG6hd0pIA13F4li6DOIal4=
+github.com/banzaicloud/koperator/api v0.28.6 h1:ZsOAXAsg34O78qVCEHx84cdp57HlCje6zjzXHhvtXf4=
+github.com/banzaicloud/koperator/api v0.28.6/go.mod h1:AGGQ+aTBklaaG8ErotNPlP/nS47MYLc/jFVW7AsDiEE=
 github.com/banzaicloud/koperator/properties v0.4.1 h1:SB2QgXlcK1Dc7Z1rg65PJifErDa8OQnoWCCJgmC7SGc=
 github.com/banzaicloud/koperator/properties v0.4.1/go.mod h1:TcL+llxuhW3UeQtVEDYEXGouFLF2P+LuZZVudSb6jyA=
 github.com/banzaicloud/operator-tools v0.28.0 h1:GSfc0qZr6zo7WrNxdgWZE1LcTChPU8QFYOTDirYVtIM=
@@ -506,8 +506,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20220827204233-334a2380cb91 h1:tnebWN09GYg9OLPss1KXj8txwZc6X6uMr6VFdcGNbHw=
-golang.org/x/exp v0.0.0-20220827204233-334a2380cb91/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
+golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1 h1:MGwJjxBy0HJshjDNfLsYO8xppfqWlA5ZT9OhtUUhTNw=
+golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/pkg/pki/k8scsrpki/k8scsr.go
+++ b/pkg/pki/k8scsrpki/k8scsr.go
@@ -22,9 +22,8 @@ import (
 )
 
 const (
-	DependingCsrAnnotation      string = "banzaicloud.io/csr"
-	IncludeFullChainAnnotation  string = "csr.banzaicloud.io/fullchain"
-	CertManagerSignerNamePrefix string = "clusterissuers.cert-manager.io"
+	DependingCsrAnnotation     string = "banzaicloud.io/csr"
+	IncludeFullChainAnnotation string = "csr.banzaicloud.io/fullchain"
 )
 
 type K8sCSR interface {

--- a/pkg/pki/k8scsrpki/k8scsr_user.go
+++ b/pkg/pki/k8scsrpki/k8scsr_user.go
@@ -162,7 +162,7 @@ func (c *k8sCSR) ReconcileUserCertificate(
 	}
 
 	if !foundApproved {
-		if strings.Split(signingReq.Spec.SignerName, "/")[0] == CertManagerSignerNamePrefix {
+		if strings.Split(signingReq.Spec.SignerName, "/")[0] == v1alpha1.CertManagerSignerNamePrefix {
 			err = c.Approve(ctx, signingReq)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
## Description

* Validate KafkaUser annotations before creating CSRs in kafkauser controller
* Update koperator API to v0.28.6
* Use the `CertManagerSignerNamePrefix` constant from the API package everywhere

## Type of Change
- [x] New Feature

## Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
