### PR TITLE
Increase Kafka cluster create timeout limit to 10 mins in E2E test

### DIFF
--- a/tests/e2e/const.go
+++ b/tests/e2e/const.go
@@ -52,7 +52,7 @@ const (
 	defaultPodReadinessWaitTime            = 10 * time.Second
 	defaultTopicCreationWaitTime           = 10 * time.Second
 	defaultUserCreationWaitTime            = 10 * time.Second
-	kafkaClusterCreateTimeout              = 500 * time.Second
+	kafkaClusterCreateTimeout              = 600 * time.Second
 	kafkaClusterResourceCleanupTimeout     = 120 * time.Second
 	kcatDeleetionTimeout                   = 40 * time.Second
 	zookeeperClusterCreateTimeout          = 4 * time.Minute


### PR DESCRIPTION
## Description

CI passing rate too low due to timeout limit gets hit pretty often.

## Type of Change
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Other (please describe)

## Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
