### PR TITLE
Add nil pointer check before validating annotations in KafkaUser spec

### DIFF
--- a/api/v1alpha1/kafkauser_types.go
+++ b/api/v1alpha1/kafkauser_types.go
@@ -116,7 +116,7 @@ func (spec *KafkaUserSpec) GetAnnotations() map[string]string {
 // ValidateAnnotations checks if certificate signing request annotations are valid
 func (spec *KafkaUserSpec) ValidateAnnotations() error {
 	// Validate annotations for cert-manager pki backend signer
-	if strings.Split(spec.PKIBackendSpec.SignerName, "/")[0] == CertManagerSignerNamePrefix {
+	if spec.PKIBackendSpec != nil && strings.Split(spec.PKIBackendSpec.SignerName, "/")[0] == CertManagerSignerNamePrefix {
 		certManagerCSRAnnotations := newCertManagerSignerAnnotationsWithValidators()
 		err := certManagerCSRAnnotations.validate(spec.GetAnnotations())
 		if err != nil {


### PR DESCRIPTION
## Description

the `KafkaUser.spec.PKIBackendSpec` is an optional field, e.g. the `KafkaUser` that koperator creates here https://github.com/banzaicloud/koperator/blob/master/pkg/util/pki/common.go#L192-L203 doesn't not have `PKIBackendSpec`, and the nil pointer dereference causes Koperator to crash [with these SSL configurations](https://docs.calisti.app/sdm/koperator/ssl/#using-auto-generated-certificates-sslsecrets)

```
"level":"info","ts":"2023-07-29T15:02:07.107Z","msg":"Observed a panic in reconciler: runtime error: invalid memory address or nil pointer dereference","controller":"KafkaUser","controllerGroup":"kafka.banzaicloud.io","controllerKind":"KafkaUser","KafkaUser":{"name":"kafka-headless.default.svc.cluster.local","namespace":"default"},"namespace":"default","name":"kafka-headless.default.svc.cluster.local","reconcileID":"dcc75a1c-48b5-4489-831b-332c40260c40"} panic: runtime error: invalid memory address or nil pointer dereference [recovered] panic: runtime error: invalid memory address or nil pointer dereference [signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x15645d5] goroutine 469 [running]: sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1() /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:119 +0x1fa panic({0x1d0a920, 0x3467fd0}) /usr/local/go/src/runtime/panic.go:884 +0x212 github.com/banzaicloud/koperator/api/v1alpha1.(*KafkaUserSpec).ValidateAnnotations(0xc0008b6108) /workspace/api/v1alpha1/kafkauser_types.go:119 +0x35 github.com/banzaicloud/koperator/controllers.(*KafkaUserReconciler).Reconcile(0xc0009ac018, {0x2372aa8, 0xc000cef290}, {{{0xc0009e7c00?, 0x10?}, {0xc0009ff3b0?, 0x40da67?}}}) /workspace/controllers/kafkauser_controller.go:204 +0x53b sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x2372aa8?, {0x2372aa8?, 0xc000cef290?}, {{{0xc0009e7c00?, 0x1c59ee0?}, {0xc0009ff3b
```

## Type of Change
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Bug Fix

## Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
