### PR TITLE
Fix CC operations issues with controller-only nodes in KRaft

### DIFF
--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -56,16 +56,19 @@ const (
 	// BrokerIdLabelKey is used to represent the reserved operator label, "brokerId"
 	BrokerIdLabelKey = "brokerId"
 
+	// ProcessRolesKey is used to identify which process roles the Kafka pod has
+	ProcessRolesKey = "processRoles"
+
 	// DefaultCruiseControlImage is the default CC image used when users don't specify it in CruiseControlConfig.Image
 	DefaultCruiseControlImage = "ghcr.io/banzaicloud/cruise-control:2.5.123"
 
 	// DefaultKafkaImage is the default Kafka image used when users don't specify it in KafkaClusterSpec.ClusterImage
 	DefaultKafkaImage = "ghcr.io/banzaicloud/kafka:2.13-3.4.1"
 
-	// controllerNodeProcessRole represents the node is a controller node
-	controllerNodeProcessRole = "controller"
-	// brokerNodeProcessRole represents the node is a broker node
-	brokerNodeProcessRole = "broker"
+	// ControllerNodeProcessRole represents the node is a controller node
+	ControllerNodeProcessRole = "controller"
+	// BrokerNodeProcessRole represents the node is a broker node
+	BrokerNodeProcessRole = "broker"
 )
 
 // KafkaClusterSpec defines the desired state of KafkaCluster
@@ -970,7 +973,10 @@ func (bConfig *BrokerConfig) GetBrokerLabels(kafkaClusterName string, brokerId i
 	return util.MergeLabels(
 		bConfig.BrokerLabels,
 		util.LabelsForKafka(kafkaClusterName),
-		map[string]string{BrokerIdLabelKey: fmt.Sprintf("%d", brokerId)},
+		map[string]string{
+			BrokerIdLabelKey: fmt.Sprintf("%d", brokerId),
+			ProcessRolesKey:  strings.Join(bConfig.Roles, "_"),
+		},
 	)
 }
 
@@ -1041,12 +1047,12 @@ func (cConfig *CruiseControlConfig) GetResources() *corev1.ResourceRequirements 
 
 // IsBrokerNode returns true when the broker is a broker node
 func (bConfig *BrokerConfig) IsBrokerNode() bool {
-	return util.StringSliceContains(bConfig.Roles, brokerNodeProcessRole)
+	return util.StringSliceContains(bConfig.Roles, BrokerNodeProcessRole)
 }
 
 // IsControllerNode returns true when the broker is a controller node
 func (bConfig *BrokerConfig) IsControllerNode() bool {
-	return util.StringSliceContains(bConfig.Roles, controllerNodeProcessRole)
+	return util.StringSliceContains(bConfig.Roles, ControllerNodeProcessRole)
 }
 
 // IsBrokerOnlyNode returns true when the broker is a broker-only node


### PR DESCRIPTION
## Description

CC doesn't have direct access to controller-only nodes, hence we need to exclude the controller-only nodes from all the CC actions. See this comment for details: https://github.com/banzaicloud/koperator/pull/1023#issuecomment-1656530989.

TODO:
- [ ] Hide the `graceActionState` from all the controller-only nodes' status , right now, the `graceActionState` is still shown for the controller-only nodes and this is a false information because there is no graceful actions can be done against the controller-only nodes
- [ ] Update controller tests correspondingly to cover the changes

## Type of Change
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Breaking Change

## Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
