### PR TITLE
don't cache secrets

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,12 +36,14 @@ import (
 	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	istioclientv1beta1 "github.com/banzaicloud/istio-client-go/pkg/networking/v1beta1"
 
 	banzaiistiov1alpha1 "github.com/banzaicloud/istio-operator/api/v2/v1alpha1"
 
 	certv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -125,13 +127,14 @@ func main() {
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:             scheme,
-		MetricsBindAddress: metricsAddr,
-		LeaderElection:     enableLeaderElection,
-		LeaderElectionID:   "controller-leader-election-helper",
-		NewCache:           managerWatchCacheBuilder,
-		Port:               webhookServerPort,
-		CertDir:            webhookCertDir,
+		Scheme:                scheme,
+		MetricsBindAddress:    metricsAddr,
+		LeaderElection:        enableLeaderElection,
+		LeaderElectionID:      "controller-leader-election-helper",
+		NewCache:              managerWatchCacheBuilder,
+		Port:                  webhookServerPort,
+		CertDir:               webhookCertDir,
+		ClientDisableCacheFor: []client.Object{&corev1.Secret{}},
 	})
 
 	if err != nil {


### PR DESCRIPTION
## Description

Don't cache secrets. controller-runtime uses watches to update its cache, effectively caching every object, not just namespaced objects. See: https://stackoverflow.com/questions/75412402/golang-client-pkg-how-to-execute-a-list-secret-under-a-resourcenames-restric

On clusters with a large number of large secrets, the memory usage of the cache is too large. This isn't needed so don't do it.

## Type of Change
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [X] Bug Fix

## Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
